### PR TITLE
Fix npm package to include only dist/

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "files": ["dist"],
   "scripts": {
     "build": "tsup",
     "test": "vitest run",


### PR DESCRIPTION
## Summary

- Add `"files": ["dist"]` to package.json to control npm publish contents
- Previously, `src/`, `tests/`, `docs/`, `.github/` etc. were all included in the published package

## Before

```
src/, tests/, docs/, .github/, tsconfig.json, vitest.config.ts, ...
(90+ files)
```

## After

```
dist/ (10 files: js, cjs, d.ts, d.cts)
LICENSE, package.json, README.md, README.ja.md
(14 files)
```

## Test plan

- [x] `pnpm pack --dry-run` confirms only dist/ and metadata files are included
- [x] `pnpm build` succeeds
- [x] All exports (`.` and `./zod`) resolve to files in dist/

🤖 Generated with [Claude Code](https://claude.com/claude-code)