### PR TITLE
Fix optional substitution fallback to prior value

### DIFF
--- a/src/internal/resolver/resolver.ts
+++ b/src/internal/resolver/resolver.ts
@@ -174,7 +174,16 @@ function resolveResObj(
   const result = new Map<string, HoconValue>()
   for (const [key, val] of obj.fields) {
     const resolved = resolveVal(val, obj, root, resolving, resolvedCache, opts)
-    if (resolved !== undefined) result.set(key, resolved)
+    if (resolved !== undefined) {
+      result.set(key, resolved)
+    } else {
+      // Unresolved optional substitution: fall back to prior value per HOCON spec
+      const prior = obj.priorValues.get(key)
+      if (prior !== undefined) {
+        const priorResolved = resolveVal(prior, obj, root, resolving, resolvedCache, opts)
+        if (priorResolved !== undefined) result.set(key, priorResolved)
+      }
+    }
   }
   return { kind: 'object', fields: result }
 }

--- a/tests/resolver.test.ts
+++ b/tests/resolver.test.ts
@@ -94,6 +94,24 @@ describe('Resolver - Pass 2 (substitutions)', () => {
     expect(obj(v).get('b')).toBeUndefined()
   })
 
+  it('falls back to prior value when ${?path} is unresolved', () => {
+    const v = resolveStr('port = 50051\nport = ${?GRPC_PORT}')
+    expect(obj(v).get('port')).toEqual({ kind: 'scalar', value: 50051 })
+  })
+
+  it('uses env var when ${?path} resolves', () => {
+    const v = resolveStr('port = 50051\nport = ${?GRPC_PORT}', { GRPC_PORT: '9090' })
+    expect(obj(v).get('port')).toEqual({ kind: 'scalar', value: '9090' })
+  })
+
+  it('falls back to prior value for nested ${?path}', () => {
+    const v = resolveStr('server { port = 8080 }\nserver { port = ${?SERVER_PORT} }')
+    const server = obj(v).get('server')
+    if (server?.kind === 'object') {
+      expect(server.fields.get('port')).toEqual({ kind: 'scalar', value: 8080 })
+    }
+  })
+
   it('throws ResolveError for unresolved mandatory substitution', () => {
     expect(() => resolveStr('b = ${missing}')).toThrow(ResolveError)
   })


### PR DESCRIPTION
## Summary

Fix `${?VAR}` dropping the key when the variable is unset, instead of falling back to the prior assignment.

## Problem

```hocon
port = 50051
port = ${?GRPC_PORT}
```

When `GRPC_PORT` is unset, `config.getNumber("port")` threw "path not found" instead of returning `50051`.

## Root Cause

In `resolveResObj`, when `resolveVal` returned `undefined` (unresolved optional substitution), the key was simply skipped. The prior value stored in `priorValues` was never consulted.

## Fix

When `resolveVal` returns `undefined`, check `obj.priorValues` for a fallback and resolve that instead. This matches the HOCON spec: "If the last definition is an unresolved optional substitution, it should be omitted and the prior assignment used."

## Test plan

- [x] New test: `falls back to prior value when ${?path} is unresolved`
- [x] New test: `uses env var when ${?path} resolves`
- [x] New test: `falls back to prior value for nested ${?path}`
- [x] All 112 tests pass (109 existing + 3 new)

Fixes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)