### PR TITLE
Fix getNumber/getBoolean string coercion for env vars

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -18,14 +18,22 @@ export class Config {
 
   getNumber(path: string): number {
     const v = this.requireScalar(path)
-    if (typeof v !== 'number') throw new ConfigError(`expected number at ${path}, got ${typeof v}`, path)
-    return v
+    if (typeof v === 'number') return v
+    if (typeof v === 'string') {
+      const n = Number(v)
+      if (!Number.isNaN(n)) return n
+    }
+    throw new ConfigError(`expected number at ${path}, got ${typeof v}`, path)
   }
 
   getBoolean(path: string): boolean {
     const v = this.requireScalar(path)
-    if (typeof v !== 'boolean') throw new ConfigError(`expected boolean at ${path}, got ${typeof v}`, path)
-    return v
+    if (typeof v === 'boolean') return v
+    if (typeof v === 'string') {
+      if (v === 'true') return true
+      if (v === 'false') return false
+    }
+    throw new ConfigError(`expected boolean at ${path}, got ${typeof v}`, path)
   }
 
   getConfig(path: string): Config {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -40,14 +40,39 @@ describe('Config', () => {
     expect(c.getNumber('port')).toBe(8080)
   })
 
-  it('getNumber() throws ConfigError for non-number', () => {
+  it('getNumber() coerces numeric string to number', () => {
+    const c = makeConfig({ port: { kind: 'scalar', value: '9999' } })
+    expect(c.getNumber('port')).toBe(9999)
+  })
+
+  it('getNumber() throws ConfigError for non-numeric string', () => {
     const c = makeConfig({ host: { kind: 'scalar', value: 'localhost' } })
     expect(() => c.getNumber('host')).toThrow(ConfigError)
+  })
+
+  it('getNumber() throws ConfigError for non-number/non-string', () => {
+    const c = makeConfig({ flag: { kind: 'scalar', value: true } })
+    expect(() => c.getNumber('flag')).toThrow(ConfigError)
   })
 
   it('getBoolean() returns boolean value', () => {
     const c = makeConfig({ debug: { kind: 'scalar', value: true } })
     expect(c.getBoolean('debug')).toBe(true)
+  })
+
+  it('getBoolean() coerces string "true" to true', () => {
+    const c = makeConfig({ debug: { kind: 'scalar', value: 'true' } })
+    expect(c.getBoolean('debug')).toBe(true)
+  })
+
+  it('getBoolean() coerces string "false" to false', () => {
+    const c = makeConfig({ debug: { kind: 'scalar', value: 'false' } })
+    expect(c.getBoolean('debug')).toBe(false)
+  })
+
+  it('getBoolean() throws ConfigError for non-boolean string', () => {
+    const c = makeConfig({ val: { kind: 'scalar', value: 'yes' } })
+    expect(() => c.getBoolean('val')).toThrow(ConfigError)
   })
 
   it('getConfig() returns sub-config', () => {


### PR DESCRIPTION
## Summary

Fix `getNumber()` and `getBoolean()` to coerce string values from env var substitutions.

## Problem

```typescript
const config = await parseAsync("port = 50051\nport = ${?GRPC_PORT}", {
  env: { GRPC_PORT: "9999" },
});
config.getNumber("port"); // throws: ConfigError: expected number at port, got string
```

Env vars are always strings per the HOCON spec. Typed getters need to coerce them.

## Fix

- `getNumber()`: coerces numeric strings (e.g., `"9999"` → `9999`), throws on non-numeric strings
- `getBoolean()`: coerces `"true"`/`"false"`, throws on other strings

Matches Lightbend's reference implementation behavior.

## Test plan

- [x] `getNumber()` coerces numeric string to number
- [x] `getNumber()` throws for non-numeric string
- [x] `getNumber()` throws for non-number/non-string
- [x] `getBoolean()` coerces `"true"` to `true`
- [x] `getBoolean()` coerces `"false"` to `false`
- [x] `getBoolean()` throws for non-boolean string
- [x] All 117 tests pass (112 existing + 5 new)

Fixes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)