### PR TITLE
feat(zod): HOCON-aware type coercion in validate()

### DIFF
--- a/docs/superpowers/plans/2026-03-30-hocon-aware-zod-coercion.md
+++ b/docs/superpowers/plans/2026-03-30-hocon-aware-zod-coercion.md
@@ -1,0 +1,565 @@
+# HOCON-Aware Zod Coercion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `validate()` and `getValidated()` apply HOCON-aware type coercion (boolean, number) by introspecting the Zod v4 schema before passing values to `schema.parse()`, and extend `Config.getBoolean()` to support `"yes"/"no"/"on"/"off"`.
+
+**Architecture:** Add a recursive `coerceValue(value, schema)` function to `src/zod.ts` that walks the Zod schema tree via `_zod.def.type` and applies HOCON coercion rules to matching values. Extract shared boolean coercion logic into `src/coerce.ts` so both `Config.getBoolean()` and `coerceValue()` use the same rules.
+
+**Tech Stack:** TypeScript, Zod v4 (`_zod.def.type` introspection), vitest
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/coerce.ts` | Create | Shared HOCON coercion functions: `coerceBoolean(v)`, `coerceNumber(v)` |
+| `src/config.ts` | Modify | Use `coerceBoolean()` from coerce.ts in `getBoolean()` |
+| `src/zod.ts` | Modify | Add `coerceValue()` schema walker, update `validate()`/`getValidated()` |
+| `src/index.ts` | No change | — |
+| `package.json` | Modify | Narrow peer dep `zod >=3.0.0` → `zod >=4.0.0` |
+| `tests/config.test.ts` | Modify | Update boolean coercion tests (add "yes"/"no"/"on"/"off", fix "yes" throw test) |
+| `tests/zod.test.ts` | Modify | Add coercion tests for validate()/getValidated() |
+
+---
+
+### Task 1: Shared Boolean/Number Coercion Functions
+
+**Files:**
+- Create: `src/coerce.ts`
+- Create: `tests/coerce.test.ts`
+
+- [ ] **Step 1: Write failing tests for coerceBoolean**
+
+```ts
+// tests/coerce.test.ts
+import { describe, it, expect } from 'vitest'
+import { coerceBoolean, coerceNumber } from '../src/coerce.js'
+
+describe('coerceBoolean', () => {
+  it.each([
+    ['true', true],
+    ['false', false],
+    ['yes', true],
+    ['no', false],
+    ['on', true],
+    ['off', false],
+    ['True', true],
+    ['FALSE', false],
+    ['Yes', true],
+    ['NO', false],
+    ['ON', true],
+    ['Off', false],
+  ])('coerces %s to %s', (input, expected) => {
+    expect(coerceBoolean(input)).toBe(expected)
+  })
+
+  it('returns undefined for non-boolean string', () => {
+    expect(coerceBoolean('maybe')).toBeUndefined()
+    expect(coerceBoolean('1')).toBeUndefined()
+    expect(coerceBoolean('')).toBeUndefined()
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd repos/ts.hocon && pnpm test -- tests/coerce.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement coerceBoolean**
+
+```ts
+// src/coerce.ts
+const TRUTHY = new Set(['true', 'yes', 'on'])
+const FALSY = new Set(['false', 'no', 'off'])
+
+export function coerceBoolean(value: string): boolean | undefined {
+  const lower = value.toLowerCase()
+  if (TRUTHY.has(lower)) return true
+  if (FALSY.has(lower)) return false
+  return undefined
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd repos/ts.hocon && pnpm test -- tests/coerce.test.ts`
+Expected: PASS
+
+- [ ] **Step 5: Write failing tests for coerceNumber**
+
+Add to `tests/coerce.test.ts`:
+
+```ts
+describe('coerceNumber', () => {
+  it.each([
+    ['8080', 8080],
+    ['3.14', 3.14],
+    ['0', 0],
+    ['-1', -1],
+    ['1e3', 1000],
+  ])('coerces %s to %s', (input, expected) => {
+    expect(coerceNumber(input)).toBe(expected)
+  })
+
+  it('returns undefined for non-numeric string', () => {
+    expect(coerceNumber('abc')).toBeUndefined()
+    expect(coerceNumber('')).toBeUndefined()
+    expect(coerceNumber('NaN')).toBeUndefined()
+  })
+})
+```
+
+- [ ] **Step 6: Run test to verify it fails**
+
+Run: `cd repos/ts.hocon && pnpm test -- tests/coerce.test.ts`
+Expected: FAIL — coerceNumber not exported
+
+- [ ] **Step 7: Implement coerceNumber**
+
+Add to `src/coerce.ts`:
+
+```ts
+export function coerceNumber(value: string): number | undefined {
+  if (value === '') return undefined
+  const n = Number(value)
+  if (Number.isNaN(n)) return undefined
+  return n
+}
+```
+
+- [ ] **Step 8: Run test to verify it passes**
+
+Run: `cd repos/ts.hocon && pnpm test -- tests/coerce.test.ts`
+Expected: PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd repos/ts.hocon && git add src/coerce.ts tests/coerce.test.ts
+git commit -m "feat: add shared HOCON coercion functions (coerceBoolean, coerceNumber)"
+```
+
+---
+
+### Task 2: Extend Config.getBoolean() to Use Shared Coercion
+
+**Files:**
+- Modify: `src/config.ts:29-37`
+- Modify: `tests/config.test.ts:73-76`
+
+- [ ] **Step 1: Update existing test and add new boolean coercion tests**
+
+In `tests/config.test.ts`, replace the test at line 73-76:
+
+```ts
+// REPLACE this test:
+//   it('getBoolean() throws ConfigError for non-boolean string', () => {
+//     const c = makeConfig({ val: { kind: 'scalar', value: 'yes' } })
+//     expect(() => c.getBoolean('val')).toThrow(ConfigError)
+//   })
+//
+// WITH these tests:
+
+it('getBoolean() coerces string "yes" to true', () => {
+  const c = makeConfig({ val: { kind: 'scalar', value: 'yes' } })
+  expect(c.getBoolean('val')).toBe(true)
+})
+
+it('getBoolean() coerces string "no" to false', () => {
+  const c = makeConfig({ val: { kind: 'scalar', value: 'no' } })
+  expect(c.getBoolean('val')).toBe(false)
+})
+
+it('getBoolean() coerces string "on" to true', () => {
+  const c = makeConfig({ val: { kind: 'scalar', value: 'on' } })
+  expect(c.getBoolean('val')).toBe(true)
+})
+
+it('getBoolean() coerces string "off" to false', () => {
+  const c = makeConfig({ val: { kind: 'scalar', value: 'off' } })
+  expect(c.getBoolean('val')).toBe(false)
+})
+
+it('getBoolean() is case-insensitive', () => {
+  const c1 = makeConfig({ val: { kind: 'scalar', value: 'TRUE' } })
+  expect(c1.getBoolean('val')).toBe(true)
+  const c2 = makeConfig({ val: { kind: 'scalar', value: 'Yes' } })
+  expect(c2.getBoolean('val')).toBe(true)
+  const c3 = makeConfig({ val: { kind: 'scalar', value: 'OFF' } })
+  expect(c3.getBoolean('val')).toBe(false)
+})
+
+it('getBoolean() throws ConfigError for non-boolean string', () => {
+  const c = makeConfig({ val: { kind: 'scalar', value: 'maybe' } })
+  expect(() => c.getBoolean('val')).toThrow(ConfigError)
+})
+```
+
+- [ ] **Step 2: Run tests to verify new ones fail**
+
+Run: `cd repos/ts.hocon && pnpm test -- tests/config.test.ts`
+Expected: FAIL — "yes"/"no"/"on"/"off" and case-insensitive tests fail
+
+- [ ] **Step 3: Update getBoolean() to use coerceBoolean**
+
+In `src/config.ts`, add import and replace the string handling in `getBoolean()`:
+
+Add at top of file:
+```ts
+import { coerceBoolean } from './coerce.js'
+```
+
+Replace lines 29-37 of `getBoolean()`:
+```ts
+getBoolean(path: string): boolean {
+  const v = this.requireScalar(path)
+  if (typeof v === 'boolean') return v
+  if (typeof v === 'string') {
+    const coerced = coerceBoolean(v)
+    if (coerced !== undefined) return coerced
+  }
+  throw new ConfigError(`expected boolean at ${path}, got ${typeof v}`, path)
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd repos/ts.hocon && pnpm test -- tests/config.test.ts`
+Expected: ALL PASS
+
+- [ ] **Step 5: Run full test suite to check for regressions**
+
+Run: `cd repos/ts.hocon && pnpm test`
+Expected: ALL PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd repos/ts.hocon && git add src/config.ts tests/config.test.ts
+git commit -m "feat: extend getBoolean() to support yes/no/on/off (case-insensitive)"
+```
+
+---
+
+### Task 3: HOCON-Aware Coercion in validate() and getValidated()
+
+**Files:**
+- Modify: `src/zod.ts`
+- Modify: `tests/zod.test.ts`
+
+- [ ] **Step 1: Write failing tests for boolean coercion in validate()**
+
+Add to `tests/zod.test.ts`:
+
+```ts
+describe('validate() HOCON-aware coercion', () => {
+  it('coerces string "true" to boolean for z.boolean()', () => {
+    const c = parse('debug = "true"')
+    const schema = z.object({ debug: z.boolean() })
+    const result = validate(c, schema)
+    expect(result.debug).toBe(true)
+  })
+
+  it('coerces string "false" to boolean for z.boolean()', () => {
+    const c = parse('debug = "false"')
+    const schema = z.object({ debug: z.boolean() })
+    const result = validate(c, schema)
+    expect(result.debug).toBe(false)
+  })
+
+  it('coerces "yes"/"no"/"on"/"off" to boolean', () => {
+    const c = parse(`
+      a = "yes"
+      b = "no"
+      c = "on"
+      d = "off"
+    `)
+    const schema = z.object({
+      a: z.boolean(),
+      b: z.boolean(),
+      c: z.boolean(),
+      d: z.boolean(),
+    })
+    const result = validate(c, schema)
+    expect(result.a).toBe(true)
+    expect(result.b).toBe(false)
+    expect(result.c).toBe(true)
+    expect(result.d).toBe(false)
+  })
+
+  it('coerces case-insensitively', () => {
+    const c = parse('flag = "TRUE"')
+    const schema = z.object({ flag: z.boolean() })
+    expect(validate(c, schema).flag).toBe(true)
+  })
+
+  it('passes through boolean literals without coercion', () => {
+    const c = parse('debug = false')
+    const schema = z.object({ debug: z.boolean() })
+    expect(validate(c, schema).debug).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd repos/ts.hocon && pnpm test -- tests/zod.test.ts`
+Expected: FAIL — ZodError for string values with z.boolean()
+
+- [ ] **Step 3: Write failing tests for number coercion**
+
+Add to `tests/zod.test.ts`:
+
+```ts
+describe('validate() number coercion', () => {
+  it('coerces numeric string to number for z.number()', () => {
+    const c = parse('port = "8080"')
+    const schema = z.object({ port: z.number() })
+    expect(validate(c, schema).port).toBe(8080)
+  })
+
+  it('coerces float string to number', () => {
+    const c = parse('rate = "3.14"')
+    const schema = z.object({ rate: z.number() })
+    expect(validate(c, schema).rate).toBe(3.14)
+  })
+
+  it('passes through number literals without coercion', () => {
+    const c = parse('port = 8080')
+    const schema = z.object({ port: z.number() })
+    expect(validate(c, schema).port).toBe(8080)
+  })
+
+  it('lets Zod reject non-numeric strings', () => {
+    const c = parse('port = "abc"')
+    const schema = z.object({ port: z.number() })
+    expect(() => validate(c, schema)).toThrow()
+  })
+})
+```
+
+- [ ] **Step 4: Write failing tests for schema wrapper unwrapping**
+
+Add to `tests/zod.test.ts`:
+
+```ts
+describe('validate() wrapper unwrapping', () => {
+  it('coerces through z.optional()', () => {
+    const c = parse('debug = "true"')
+    const schema = z.object({ debug: z.boolean().optional() })
+    expect(validate(c, schema).debug).toBe(true)
+  })
+
+  it('coerces through z.nullable()', () => {
+    const c = parse('debug = "false"')
+    const schema = z.object({ debug: z.boolean().nullable() })
+    expect(validate(c, schema).debug).toBe(false)
+  })
+
+  it('coerces through z.default()', () => {
+    const c = parse('debug = "on"')
+    const schema = z.object({ debug: z.boolean().default(false) })
+    expect(validate(c, schema).debug).toBe(true)
+  })
+
+  it('coerces inside z.array()', () => {
+    const c = parse('flags = ["true", "false", "yes"]')
+    const schema = z.object({ flags: z.array(z.boolean()) })
+    const result = validate(c, schema)
+    expect(result.flags).toEqual([true, false, true])
+  })
+
+  it('coerces in nested objects', () => {
+    const c = parse(`
+      server {
+        debug = "true"
+        port = "3000"
+      }
+    `)
+    const schema = z.object({
+      server: z.object({
+        debug: z.boolean(),
+        port: z.number(),
+      }),
+    })
+    const result = validate(c, schema)
+    expect(result.server.debug).toBe(true)
+    expect(result.server.port).toBe(3000)
+  })
+})
+```
+
+- [ ] **Step 5: Write failing test for getValidated() coercion**
+
+Add to `tests/zod.test.ts`:
+
+```ts
+describe('getValidated() coercion', () => {
+  it('coerces boolean string at path', () => {
+    const c = parse('debug = "false"')
+    expect(getValidated(c, 'debug', z.boolean())).toBe(false)
+  })
+
+  it('coerces numeric string at path', () => {
+    const c = parse('port = "8080"')
+    expect(getValidated(c, 'port', z.number())).toBe(8080)
+  })
+})
+```
+
+- [ ] **Step 6: Run all new tests to verify they fail**
+
+Run: `cd repos/ts.hocon && pnpm test -- tests/zod.test.ts`
+Expected: FAIL — new coercion tests fail, existing tests still pass
+
+- [ ] **Step 7: Implement coerceValue() and update validate()/getValidated()**
+
+Replace `src/zod.ts` entirely:
+
+```ts
+import type { ZodType } from 'zod'
+import type { Config } from './config.js'
+import { coerceBoolean, coerceNumber } from './coerce.js'
+
+export function validate<T>(config: Config, schema: ZodType<T>): T {
+  const plain = config.toObject()
+  const coerced = coerceValue(plain, schema)
+  return schema.parse(coerced)
+}
+
+export function getValidated<T>(config: Config, path: string, schema: ZodType<T>): T {
+  const val = config.get(path)
+  const coerced = coerceValue(val, schema)
+  return schema.parse(coerced)
+}
+
+function getDefType(schema: ZodType): string | undefined {
+  const zod = (schema as any)._zod
+  return zod?.def?.type
+}
+
+function getInnerSchema(schema: ZodType): ZodType | undefined {
+  return (schema as any)._zod?.def?.schema
+}
+
+function coerceValue(value: unknown, schema: ZodType): unknown {
+  if (value === null || value === undefined) return value
+
+  const defType = getDefType(schema)
+  if (!defType) return value
+
+  switch (defType) {
+    case 'boolean':
+      if (typeof value === 'string') {
+        const coerced = coerceBoolean(value)
+        return coerced !== undefined ? coerced : value
+      }
+      return value
+
+    case 'number':
+    case 'int':
+      if (typeof value === 'string') {
+        const coerced = coerceNumber(value)
+        return coerced !== undefined ? coerced : value
+      }
+      return value
+
+    case 'object': {
+      if (typeof value !== 'object' || Array.isArray(value)) return value
+      const shape = (schema as any)._zod?.def?.shape
+      if (!shape || typeof shape !== 'object') return value
+      const result: Record<string, unknown> = {}
+      const obj = value as Record<string, unknown>
+      for (const key of Object.keys(obj)) {
+        const fieldSchema = shape[key]
+        result[key] = fieldSchema ? coerceValue(obj[key], fieldSchema) : obj[key]
+      }
+      return result
+    }
+
+    case 'array': {
+      if (!Array.isArray(value)) return value
+      const elementSchema = (schema as any)._zod?.def?.element
+      if (!elementSchema) return value
+      return value.map((item) => coerceValue(item, elementSchema))
+    }
+
+    case 'optional':
+    case 'nullable':
+    case 'default':
+    case 'catch': {
+      const inner = getInnerSchema(schema)
+      return inner ? coerceValue(value, inner) : value
+    }
+
+    default:
+      return value
+  }
+}
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `cd repos/ts.hocon && pnpm test -- tests/zod.test.ts`
+Expected: ALL PASS
+
+- [ ] **Step 9: Run full test suite**
+
+Run: `cd repos/ts.hocon && pnpm test`
+Expected: ALL PASS
+
+- [ ] **Step 10: Run typecheck**
+
+Run: `cd repos/ts.hocon && pnpm typecheck`
+Expected: No errors
+
+- [ ] **Step 11: Commit**
+
+```bash
+cd repos/ts.hocon && git add src/zod.ts tests/zod.test.ts
+git commit -m "feat(zod): add HOCON-aware coercion in validate()/getValidated()
+
+Introspects Zod v4 schema via _zod.def.type and applies HOCON coercion
+rules (boolean: true/false/yes/no/on/off, number: numeric strings)
+before passing values to schema.parse().
+
+Closes #8"
+```
+
+---
+
+### Task 4: Update Peer Dependency and Final Verification
+
+**Files:**
+- Modify: `package.json:29`
+
+- [ ] **Step 1: Update peer dep**
+
+In `package.json`, change:
+```json
+"zod": ">=3.0.0"
+```
+to:
+```json
+"zod": ">=4.0.0"
+```
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `cd repos/ts.hocon && pnpm test`
+Expected: ALL PASS
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `cd repos/ts.hocon && pnpm typecheck`
+Expected: No errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd repos/ts.hocon && git add package.json
+git commit -m "chore: narrow zod peer dep to >=4.0.0 (required for schema introspection)"
+```

--- a/docs/superpowers/specs/2026-03-30-hocon-aware-zod-coercion-design.md
+++ b/docs/superpowers/specs/2026-03-30-hocon-aware-zod-coercion-design.md
@@ -1,0 +1,121 @@
+# HOCON-Aware Zod Coercion in validate()
+
+**Date**: 2026-03-30
+**Issue**: o3co/ts.hocon#8
+**Status**: Design
+
+## Problem
+
+`@o3co/ts.hocon/zod`'s `validate()` passes `config.toObject()` directly to `schema.parse()` without any HOCON-aware type coercion. This causes failures when HOCON config values arrive as strings (e.g., via environment variable overrides) but the Zod schema expects typed values.
+
+- `z.boolean()` rejects string `"false"`
+- `z.coerce.boolean()` treats `"false"` as `true` (JavaScript `Boolean("false") === true`)
+- `z.stringbool()` (Zod v4) rejects boolean literals, which HOCON returns for non-env-var values
+
+The root cause: HOCON has well-defined type coercion rules (implemented in `Config.getBoolean()`, `Config.getNumber()`), but the Zod integration layer doesn't apply them.
+
+## Decision
+
+`validate()` and `getValidated()` will introspect the Zod schema via `_zod.def.type` and apply HOCON-aware coercion to the plain object before passing it to Zod's `schema.parse()`. This makes standard Zod schemas (`z.boolean()`, `z.number()`) work correctly with HOCON configs without requiring special helper schemas or user-side workarounds.
+
+### Why not helper schemas (Option A)?
+
+Exporting `hoconBoolean()` etc. would require users to import and use special schemas everywhere, which doesn't solve the boilerplate problem the issue describes. The Zod schema's type declaration already expresses the user's intent — `z.boolean()` means "I want a boolean." In the HOCON context, coercing string `"false"` to `false` is always the correct behavior. There is no realistic opt-out case.
+
+### Why introspection is acceptable
+
+- Peer dep will be narrowed to `zod >=4.0.0` (from `>=3.0.0`)
+- Zod v4's `_zod.def.type` is documented for library authors
+- The set of types to introspect is small and bounded
+- `validate()` exists to be HOCON-aware; without coercion it's just `schema.parse(config.toObject())`
+
+## Coercion Rules
+
+### Boolean (case-insensitive)
+
+| String value | Coerced to |
+|---|---|
+| `"true"`, `"yes"`, `"on"` | `true` |
+| `"false"`, `"no"`, `"off"` | `false` |
+| Other strings | No coercion (let Zod reject) |
+
+Already-boolean values pass through unchanged.
+
+These rules align with go.hocon's boolean coercion and Zod v4's `z.stringbool()` defaults.
+
+### Number
+
+| String value | Coerced to |
+|---|---|
+| Parseable by `Number()` and not `NaN` | The numeric value |
+| Other strings | No coercion (let Zod reject) |
+
+Already-numeric values pass through unchanged.
+
+## Schema Introspection Walk
+
+The coercion function walks the Zod schema tree and the corresponding plain value simultaneously:
+
+```
+_zod.def.type     Action
+─────────────     ──────
+"object"          Recurse into each field (def.shape)
+"array"           Recurse into element schema (def.element)
+"optional"        Unwrap def.schema, recurse
+"nullable"        Unwrap def.schema, recurse
+"default"         Unwrap def.schema, recurse
+"catch"           Unwrap def.schema, recurse
+"boolean"         Coerce string → boolean if matches rules
+"number" / "int"  Coerce string → number if parseable
+"pipe"            Skip (z.transform, z.stringbool etc. handle their own coercion)
+"union"           Skip (ambiguous target type)
+"lazy"            Skip (deferred evaluation)
+Other             No coercion (pass through)
+```
+
+`pipe`, `union`, `lazy` are intentionally skipped — they either handle coercion themselves or have ambiguous target types. Letting Zod handle these directly is safer than guessing.
+
+## Changes
+
+### `src/zod.ts` — HOCON-aware coercion in validate/getValidated
+
+- `validate(config, schema)`: walk schema + `config.toObject()`, coerce, then `schema.parse()`
+- `getValidated(config, path, schema)`: coerce `config.get(path)` based on top-level schema type, then `schema.parse()`
+- Internal `coerceValue(value, schema)` function: recursive schema walker + coercion
+
+### `src/config.ts` — Extend getBoolean() coercion rules
+
+Current `getBoolean()` only handles `"true"` / `"false"`. Extend to:
+- Truthy: `"true"`, `"yes"`, `"on"` (case-insensitive)
+- Falsy: `"false"`, `"no"`, `"off"` (case-insensitive)
+
+This aligns with go.hocon behavior and ensures consistency between `Config.getBoolean()` and the Zod coercion layer.
+
+### `package.json` — Narrow peer dep
+
+```
+"zod": ">=3.0.0" → ">=4.0.0"
+```
+
+## Test Plan
+
+### validate() / getValidated() coercion
+
+- Boolean coercion: `"true"/"yes"/"on"` → `true`, `"false"/"no"/"off"` → `false`
+- Boolean case-insensitive: `"True"/"TRUE"/"Yes"/"ON"` etc.
+- Number coercion: `"8080"` → `8080`, `"3.14"` → `3.14`
+- Pass-through: boolean `true`/`false` → `z.boolean()` works as-is
+- Pass-through: number `8080` → `z.number()` works as-is
+- Pass-through: string `"hello"` → `z.string()` works as-is
+- Nested objects: coercion inside `z.object({ inner: z.object({ ... }) })`
+- Wrapper unwrap: `z.optional(z.boolean())`, `z.nullable(z.boolean())`, `z.default(z.boolean(), false)`
+- Array coercion: `z.array(z.boolean())` with string elements
+- Invalid values: `"maybe"` with `z.boolean()` → ZodError
+- Invalid numbers: `"abc"` with `z.number()` → ZodError
+
+### Config.getBoolean() extension
+
+- `"yes"/"on"` → `true`
+- `"no"/"off"` → `false`
+- Case-insensitive: `"Yes"/"TRUE"/"On"/"NO"` etc.
+- Existing tests unchanged: `"true"/"false"`, boolean literals, wrong types throw

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "bench": "vitest bench"
   },
   "peerDependencies": {
-    "zod": ">=3.0.0"
+    "zod": ">=4.0.0"
   },
   "peerDependenciesMeta": {
     "zod": {

--- a/src/coerce.ts
+++ b/src/coerce.ts
@@ -9,9 +9,6 @@ export function coerceBoolean(value: string): boolean | undefined {
 }
 
 export function coerceNumber(value: string): number | undefined {
-  const trimmed = value.trim()
-  if (trimmed === '') return undefined
-  // Only allow JSON-like numeric literals (no hex, octal, Infinity etc.)
-  if (!/^-?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/.test(trimmed)) return undefined
-  return Number(trimmed)
+  if (!/^-?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/.test(value)) return undefined
+  return Number(value)
 }

--- a/src/coerce.ts
+++ b/src/coerce.ts
@@ -9,8 +9,9 @@ export function coerceBoolean(value: string): boolean | undefined {
 }
 
 export function coerceNumber(value: string): number | undefined {
-  if (value === '') return undefined
-  const n = Number(value)
-  if (Number.isNaN(n)) return undefined
-  return n
+  const trimmed = value.trim()
+  if (trimmed === '') return undefined
+  // Only allow JSON-like numeric literals (no hex, octal, Infinity etc.)
+  if (!/^-?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/.test(trimmed)) return undefined
+  return Number(trimmed)
 }

--- a/src/coerce.ts
+++ b/src/coerce.ts
@@ -1,0 +1,16 @@
+const TRUTHY = new Set(['true', 'yes', 'on'])
+const FALSY = new Set(['false', 'no', 'off'])
+
+export function coerceBoolean(value: string): boolean | undefined {
+  const lower = value.toLowerCase()
+  if (TRUTHY.has(lower)) return true
+  if (FALSY.has(lower)) return false
+  return undefined
+}
+
+export function coerceNumber(value: string): number | undefined {
+  if (value === '') return undefined
+  const n = Number(value)
+  if (Number.isNaN(n)) return undefined
+  return n
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,4 @@
+import { coerceBoolean } from './coerce.js'
 import { ConfigError } from './errors.js'
 import type { HoconValue } from './value.js'
 
@@ -30,8 +31,8 @@ export class Config {
     const v = this.requireScalar(path)
     if (typeof v === 'boolean') return v
     if (typeof v === 'string') {
-      if (v === 'true') return true
-      if (v === 'false') return false
+      const coerced = coerceBoolean(v)
+      if (coerced !== undefined) return coerced
     }
     throw new ConfigError(`expected boolean at ${path}, got ${typeof v}`, path)
   }

--- a/src/zod.ts
+++ b/src/zod.ts
@@ -25,6 +25,15 @@ function getInnerSchema(schema: ZodType): ZodType | undefined {
   return def?.innerType ?? def?.schema
 }
 
+function getObjectShape(schema: ZodType): Record<string, ZodType> | undefined {
+  const shape = (schema as any)._zod?.def?.shape
+  return typeof shape === 'object' && shape !== null ? shape : undefined
+}
+
+function getArrayElement(schema: ZodType): ZodType | undefined {
+  return (schema as any)._zod?.def?.element
+}
+
 function coerceValue(value: unknown, schema: ZodType): unknown {
   if (value === null || value === undefined) return value
 
@@ -40,7 +49,6 @@ function coerceValue(value: unknown, schema: ZodType): unknown {
       return value
 
     case 'number':
-    case 'int':
       if (typeof value === 'string') {
         const coerced = coerceNumber(value)
         return coerced !== undefined ? coerced : value
@@ -49,20 +57,21 @@ function coerceValue(value: unknown, schema: ZodType): unknown {
 
     case 'object': {
       if (typeof value !== 'object' || Array.isArray(value)) return value
-      const shape = (schema as any)._zod?.def?.shape
-      if (!shape || typeof shape !== 'object') return value
-      const result: Record<string, unknown> = {}
+      const shape = getObjectShape(schema)
+      if (!shape) return value
       const obj = value as Record<string, unknown>
-      for (const key of Object.keys(obj)) {
-        const fieldSchema = shape[key]
-        result[key] = fieldSchema ? coerceValue(obj[key], fieldSchema) : obj[key]
+      const result: Record<string, unknown> = { ...obj }
+      for (const key of Object.keys(shape)) {
+        if (key in obj) {
+          result[key] = coerceValue(obj[key], shape[key])
+        }
       }
       return result
     }
 
     case 'array': {
       if (!Array.isArray(value)) return value
-      const elementSchema = (schema as any)._zod?.def?.element
+      const elementSchema = getArrayElement(schema)
       if (!elementSchema) return value
       return value.map((item) => coerceValue(item, elementSchema))
     }
@@ -70,7 +79,8 @@ function coerceValue(value: unknown, schema: ZodType): unknown {
     case 'optional':
     case 'nullable':
     case 'default':
-    case 'catch': {
+    case 'catch':
+    case 'readonly': {
       const inner = getInnerSchema(schema)
       return inner ? coerceValue(value, inner) : value
     }

--- a/src/zod.ts
+++ b/src/zod.ts
@@ -22,6 +22,9 @@ function getDefType(schema: ZodType): string | undefined {
 
 function getInnerSchema(schema: ZodType): ZodType | undefined {
   const def = (schema as any)._zod?.def
+  // Zod v4 wrapper types (optional, nullable, default, catch, readonly) store
+  // the wrapped schema in `def.innerType`. The `def.schema` fallback is for
+  // forward-compatibility in case future Zod versions change the property name.
   return def?.innerType ?? def?.schema
 }
 

--- a/src/zod.ts
+++ b/src/zod.ts
@@ -1,12 +1,81 @@
 import type { ZodType } from 'zod'
+
+import { coerceBoolean, coerceNumber } from './coerce.js'
 import type { Config } from './config.js'
 
 export function validate<T>(config: Config, schema: ZodType<T>): T {
   const plain = config.toObject()
-  return schema.parse(plain)
+  const coerced = coerceValue(plain, schema)
+  return schema.parse(coerced)
 }
 
 export function getValidated<T>(config: Config, path: string, schema: ZodType<T>): T {
   const val = config.get(path)
-  return schema.parse(val)
+  const coerced = coerceValue(val, schema)
+  return schema.parse(coerced)
+}
+
+function getDefType(schema: ZodType): string | undefined {
+  const zod = (schema as any)._zod
+  return zod?.def?.type
+}
+
+function getInnerSchema(schema: ZodType): ZodType | undefined {
+  const def = (schema as any)._zod?.def
+  return def?.innerType ?? def?.schema
+}
+
+function coerceValue(value: unknown, schema: ZodType): unknown {
+  if (value === null || value === undefined) return value
+
+  const defType = getDefType(schema)
+  if (!defType) return value
+
+  switch (defType) {
+    case 'boolean':
+      if (typeof value === 'string') {
+        const coerced = coerceBoolean(value)
+        return coerced !== undefined ? coerced : value
+      }
+      return value
+
+    case 'number':
+    case 'int':
+      if (typeof value === 'string') {
+        const coerced = coerceNumber(value)
+        return coerced !== undefined ? coerced : value
+      }
+      return value
+
+    case 'object': {
+      if (typeof value !== 'object' || Array.isArray(value)) return value
+      const shape = (schema as any)._zod?.def?.shape
+      if (!shape || typeof shape !== 'object') return value
+      const result: Record<string, unknown> = {}
+      const obj = value as Record<string, unknown>
+      for (const key of Object.keys(obj)) {
+        const fieldSchema = shape[key]
+        result[key] = fieldSchema ? coerceValue(obj[key], fieldSchema) : obj[key]
+      }
+      return result
+    }
+
+    case 'array': {
+      if (!Array.isArray(value)) return value
+      const elementSchema = (schema as any)._zod?.def?.element
+      if (!elementSchema) return value
+      return value.map((item) => coerceValue(item, elementSchema))
+    }
+
+    case 'optional':
+    case 'nullable':
+    case 'default':
+    case 'catch': {
+      const inner = getInnerSchema(schema)
+      return inner ? coerceValue(value, inner) : value
+    }
+
+    default:
+      return value
+  }
 }

--- a/tests/coerce.test.ts
+++ b/tests/coerce.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest'
+import { coerceBoolean, coerceNumber } from '../src/coerce.js'
+
+describe('coerceBoolean', () => {
+  it.each([
+    ['true', true],
+    ['false', false],
+    ['yes', true],
+    ['no', false],
+    ['on', true],
+    ['off', false],
+    ['True', true],
+    ['FALSE', false],
+    ['Yes', true],
+    ['NO', false],
+    ['ON', true],
+    ['Off', false],
+  ])('coerces %s to %s', (input, expected) => {
+    expect(coerceBoolean(input)).toBe(expected)
+  })
+
+  it('returns undefined for non-boolean string', () => {
+    expect(coerceBoolean('maybe')).toBeUndefined()
+    expect(coerceBoolean('1')).toBeUndefined()
+    expect(coerceBoolean('')).toBeUndefined()
+  })
+})
+
+describe('coerceNumber', () => {
+  it.each([
+    ['8080', 8080],
+    ['3.14', 3.14],
+    ['0', 0],
+    ['-1', -1],
+    ['1e3', 1000],
+  ])('coerces %s to %s', (input, expected) => {
+    expect(coerceNumber(input)).toBe(expected)
+  })
+
+  it('returns undefined for non-numeric string', () => {
+    expect(coerceNumber('abc')).toBeUndefined()
+    expect(coerceNumber('')).toBeUndefined()
+    expect(coerceNumber('NaN')).toBeUndefined()
+  })
+})

--- a/tests/coerce.test.ts
+++ b/tests/coerce.test.ts
@@ -42,4 +42,18 @@ describe('coerceNumber', () => {
     expect(coerceNumber('')).toBeUndefined()
     expect(coerceNumber('NaN')).toBeUndefined()
   })
+
+  it('returns undefined for whitespace-only string', () => {
+    expect(coerceNumber('   ')).toBeUndefined()
+  })
+
+  it('returns undefined for Infinity', () => {
+    expect(coerceNumber('Infinity')).toBeUndefined()
+    expect(coerceNumber('-Infinity')).toBeUndefined()
+  })
+
+  it('returns undefined for hex literals', () => {
+    expect(coerceNumber('0xff')).toBeUndefined()
+    expect(coerceNumber('0xFF')).toBeUndefined()
+  })
 })

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -70,8 +70,37 @@ describe('Config', () => {
     expect(c.getBoolean('debug')).toBe(false)
   })
 
-  it('getBoolean() throws ConfigError for non-boolean string', () => {
+  it('getBoolean() coerces string "yes" to true', () => {
     const c = makeConfig({ val: { kind: 'scalar', value: 'yes' } })
+    expect(c.getBoolean('val')).toBe(true)
+  })
+
+  it('getBoolean() coerces string "no" to false', () => {
+    const c = makeConfig({ val: { kind: 'scalar', value: 'no' } })
+    expect(c.getBoolean('val')).toBe(false)
+  })
+
+  it('getBoolean() coerces string "on" to true', () => {
+    const c = makeConfig({ val: { kind: 'scalar', value: 'on' } })
+    expect(c.getBoolean('val')).toBe(true)
+  })
+
+  it('getBoolean() coerces string "off" to false', () => {
+    const c = makeConfig({ val: { kind: 'scalar', value: 'off' } })
+    expect(c.getBoolean('val')).toBe(false)
+  })
+
+  it('getBoolean() is case-insensitive', () => {
+    const c1 = makeConfig({ val: { kind: 'scalar', value: 'TRUE' } })
+    expect(c1.getBoolean('val')).toBe(true)
+    const c2 = makeConfig({ val: { kind: 'scalar', value: 'Yes' } })
+    expect(c2.getBoolean('val')).toBe(true)
+    const c3 = makeConfig({ val: { kind: 'scalar', value: 'OFF' } })
+    expect(c3.getBoolean('val')).toBe(false)
+  })
+
+  it('getBoolean() throws ConfigError for non-boolean string', () => {
+    const c = makeConfig({ val: { kind: 'scalar', value: 'maybe' } })
     expect(() => c.getBoolean('val')).toThrow(ConfigError)
   })
 

--- a/tests/zod.test.ts
+++ b/tests/zod.test.ts
@@ -138,6 +138,12 @@ describe('validate() wrapper unwrapping', () => {
     expect(validate(c, schema).debug).toBe(true)
   })
 
+  it('coerces through z.catch()', () => {
+    const c = parse('debug = "yes"')
+    const schema = z.object({ debug: z.boolean().catch(false) })
+    expect(validate(c, schema).debug).toBe(true)
+  })
+
   it('coerces inside z.array()', () => {
     const c = parse('flags = ["true", "false", "yes"]')
     const schema = z.object({ flags: z.array(z.boolean()) })
@@ -161,6 +167,20 @@ describe('validate() wrapper unwrapping', () => {
     const result = validate(c, schema)
     expect(result.server.debug).toBe(true)
     expect(result.server.port).toBe(3000)
+  })
+})
+
+describe('validate() passthrough behavior', () => {
+  it('passes through string values for z.string()', () => {
+    const c = parse('name = "hello"')
+    const schema = z.object({ name: z.string() })
+    expect(validate(c, schema).name).toBe('hello')
+  })
+
+  it('lets Zod reject non-boolean strings for z.boolean()', () => {
+    const c = parse('debug = "maybe"')
+    const schema = z.object({ debug: z.boolean() })
+    expect(() => validate(c, schema)).toThrow()
   })
 })
 

--- a/tests/zod.test.ts
+++ b/tests/zod.test.ts
@@ -39,6 +39,137 @@ describe('validate()', () => {
   })
 })
 
+describe('validate() HOCON-aware coercion', () => {
+  it('coerces string "true" to boolean for z.boolean()', () => {
+    const c = parse('debug = "true"')
+    const schema = z.object({ debug: z.boolean() })
+    const result = validate(c, schema)
+    expect(result.debug).toBe(true)
+  })
+
+  it('coerces string "false" to boolean for z.boolean()', () => {
+    const c = parse('debug = "false"')
+    const schema = z.object({ debug: z.boolean() })
+    const result = validate(c, schema)
+    expect(result.debug).toBe(false)
+  })
+
+  it('coerces "yes"/"no"/"on"/"off" to boolean', () => {
+    const c = parse(`
+      a = "yes"
+      b = "no"
+      c = "on"
+      d = "off"
+    `)
+    const schema = z.object({
+      a: z.boolean(),
+      b: z.boolean(),
+      c: z.boolean(),
+      d: z.boolean(),
+    })
+    const result = validate(c, schema)
+    expect(result.a).toBe(true)
+    expect(result.b).toBe(false)
+    expect(result.c).toBe(true)
+    expect(result.d).toBe(false)
+  })
+
+  it('coerces case-insensitively', () => {
+    const c = parse('flag = "TRUE"')
+    const schema = z.object({ flag: z.boolean() })
+    expect(validate(c, schema).flag).toBe(true)
+  })
+
+  it('passes through boolean literals without coercion', () => {
+    const c = parse('debug = false')
+    const schema = z.object({ debug: z.boolean() })
+    expect(validate(c, schema).debug).toBe(false)
+  })
+})
+
+describe('validate() number coercion', () => {
+  it('coerces numeric string to number for z.number()', () => {
+    const c = parse('port = "8080"')
+    const schema = z.object({ port: z.number() })
+    expect(validate(c, schema).port).toBe(8080)
+  })
+
+  it('coerces float string to number', () => {
+    const c = parse('rate = "3.14"')
+    const schema = z.object({ rate: z.number() })
+    expect(validate(c, schema).rate).toBe(3.14)
+  })
+
+  it('passes through number literals without coercion', () => {
+    const c = parse('port = 8080')
+    const schema = z.object({ port: z.number() })
+    expect(validate(c, schema).port).toBe(8080)
+  })
+
+  it('lets Zod reject non-numeric strings', () => {
+    const c = parse('port = "abc"')
+    const schema = z.object({ port: z.number() })
+    expect(() => validate(c, schema)).toThrow()
+  })
+})
+
+describe('validate() wrapper unwrapping', () => {
+  it('coerces through z.optional()', () => {
+    const c = parse('debug = "true"')
+    const schema = z.object({ debug: z.boolean().optional() })
+    expect(validate(c, schema).debug).toBe(true)
+  })
+
+  it('coerces through z.nullable()', () => {
+    const c = parse('debug = "false"')
+    const schema = z.object({ debug: z.boolean().nullable() })
+    expect(validate(c, schema).debug).toBe(false)
+  })
+
+  it('coerces through z.default()', () => {
+    const c = parse('debug = "on"')
+    const schema = z.object({ debug: z.boolean().default(false) })
+    expect(validate(c, schema).debug).toBe(true)
+  })
+
+  it('coerces inside z.array()', () => {
+    const c = parse('flags = ["true", "false", "yes"]')
+    const schema = z.object({ flags: z.array(z.boolean()) })
+    const result = validate(c, schema)
+    expect(result.flags).toEqual([true, false, true])
+  })
+
+  it('coerces in nested objects', () => {
+    const c = parse(`
+      server {
+        debug = "true"
+        port = "3000"
+      }
+    `)
+    const schema = z.object({
+      server: z.object({
+        debug: z.boolean(),
+        port: z.number(),
+      }),
+    })
+    const result = validate(c, schema)
+    expect(result.server.debug).toBe(true)
+    expect(result.server.port).toBe(3000)
+  })
+})
+
+describe('getValidated() coercion', () => {
+  it('coerces boolean string at path', () => {
+    const c = parse('debug = "false"')
+    expect(getValidated(c, 'debug', z.boolean())).toBe(false)
+  })
+
+  it('coerces numeric string at path', () => {
+    const c = parse('port = "8080"')
+    expect(getValidated(c, 'port', z.number())).toBe(8080)
+  })
+})
+
 describe('getValidated()', () => {
   it('returns typed value at path', () => {
     const port = getValidated(cfg, 'server.port', z.number().int())

--- a/tests/zod.test.ts
+++ b/tests/zod.test.ts
@@ -132,6 +132,12 @@ describe('validate() wrapper unwrapping', () => {
     expect(validate(c, schema).debug).toBe(true)
   })
 
+  it('coerces through z.readonly()', () => {
+    const c = parse('debug = "true"')
+    const schema = z.object({ debug: z.boolean().readonly() })
+    expect(validate(c, schema).debug).toBe(true)
+  })
+
   it('coerces inside z.array()', () => {
     const c = parse('flags = ["true", "false", "yes"]')
     const schema = z.object({ flags: z.array(z.boolean()) })


### PR DESCRIPTION
## Summary

- `validate()` and `getValidated()` now introspect the Zod v4 schema via `_zod.def.type` and apply HOCON-aware coercion before `schema.parse()`
- Boolean coercion: `"true"/"false"/"yes"/"no"/"on"/"off"` (case-insensitive) → `boolean` when schema expects `z.boolean()`
- Number coercion: numeric strings → `number` when schema expects `z.number()`
- `Config.getBoolean()` extended to support `"yes"/"no"/"on"/"off"` (case-insensitive), aligned with go.hocon
- Peer dep narrowed from `zod >=3.0.0` to `zod >=4.0.0` (required for schema introspection)

## Known Follow-up

- `Config.getNumber()` still uses inline `Number()` coercion instead of the shared `coerceNumber()` — this is a behavioral difference (accepts hex, Infinity, whitespace-padded strings). Tracked separately to avoid semver concerns in this PR.

## Test plan

- [x] 164 tests pass (47 new across coerce, config, zod test files)
- [x] Boolean coercion: all truthy/falsy variants + case-insensitive
- [x] Number coercion: integers, floats, scientific notation + rejection of invalid
- [x] Schema wrapper unwrapping: optional, nullable, default, catch, readonly
- [x] Nested objects and arrays coercion
- [x] Passthrough: non-coerced types work as-is
- [x] Existing tests unaffected (no regressions)
- [x] Typecheck passes

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)