### PR TITLE
fix: use shared coerceNumber() in Config.getNumber()

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,4 @@
-import { coerceBoolean } from './coerce.js'
+import { coerceBoolean, coerceNumber } from './coerce.js'
 import { ConfigError } from './errors.js'
 import type { HoconValue } from './value.js'
 
@@ -21,8 +21,8 @@ export class Config {
     const v = this.requireScalar(path)
     if (typeof v === 'number') return v
     if (typeof v === 'string') {
-      const n = Number(v)
-      if (!Number.isNaN(n)) return n
+      const coerced = coerceNumber(v)
+      if (coerced !== undefined) return coerced
     }
     throw new ConfigError(`expected number at ${path}, got ${typeof v}`, path)
   }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -55,6 +55,21 @@ describe('Config', () => {
     expect(() => c.getNumber('flag')).toThrow(ConfigError)
   })
 
+  it('getNumber() rejects hex strings', () => {
+    const c = makeConfig({ val: { kind: 'scalar', value: '0xff' } })
+    expect(() => c.getNumber('val')).toThrow(ConfigError)
+  })
+
+  it('getNumber() rejects Infinity', () => {
+    const c = makeConfig({ val: { kind: 'scalar', value: 'Infinity' } })
+    expect(() => c.getNumber('val')).toThrow(ConfigError)
+  })
+
+  it('getNumber() rejects whitespace-only string', () => {
+    const c = makeConfig({ val: { kind: 'scalar', value: '   ' } })
+    expect(() => c.getNumber('val')).toThrow(ConfigError)
+  })
+
   it('getBoolean() returns boolean value', () => {
     const c = makeConfig({ debug: { kind: 'scalar', value: true } })
     expect(c.getBoolean('debug')).toBe(true)


### PR DESCRIPTION
## Summary

- `Config.getNumber()` now uses the shared `coerceNumber()` from `src/coerce.ts` instead of inline `Number()` coercion
- This tightens validation: hex literals (`0xff`), `Infinity`, and whitespace-only strings are now rejected
- Aligns `getNumber()` behavior with the Zod coercion layer and `getBoolean()` (which already uses shared coercion)

## Breaking Change

Values that were previously accepted by `getNumber()` will now throw `ConfigError`:
- `"0xff"` (hex) — was coerced to `255`
- `"Infinity"` — was coerced to `Infinity`
- `"   "` (whitespace) — was coerced to `0`

These are not valid HOCON numeric literals, so rejection is the correct behavior.

## Test plan

- [x] 167 tests pass (3 new rejection tests for hex, Infinity, whitespace)
- [x] Existing numeric string coercion (`"9999"` → `9999`) still works
- [x] Non-numeric strings still throw ConfigError

🤖 Generated with [Claude Code](https://claude.com/claude-code)