### PR TITLE
chore: bump version to 0.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@o3co/ts.hocon",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary
- Bump version to 0.1.4 for npm publish via CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)