### PR TITLE
ci: add provenance support for npm trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   publish:
     name: Publish to npm
@@ -45,6 +49,6 @@ jobs:
         run: pnpm build
 
       - name: Publish
-        run: pnpm publish --access public --no-git-checks
+        run: pnpm publish --access public --no-git-checks --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `id-token: write` permission for OIDC provenance
- Add `--provenance` flag to `pnpm publish`
- NPM_TOKEN secret updated with Granular Access Token

🤖 Generated with [Claude Code](https://claude.com/claude-code)