### PR TITLE
ci: switch to tokenless OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,9 @@ jobs:
         with:
           node-version: "22"
           cache: pnpm
-          registry-url: "https://registry.npmjs.org"
+
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -50,5 +52,3 @@ jobs:
 
       - name: Publish
         run: pnpm publish --access public --no-git-checks --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Remove `NODE_AUTH_TOKEN` / `NPM_TOKEN` — OIDC handles auth
- Remove `registry-url` from setup-node (conflicts with OIDC)
- Add `npm install -g npm@latest` (OIDC requires npm ≥ 11.5.1)

Trusted publisher already configured on npmjs.com for this repo + `release.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)