### PR TITLE
fix: add repository URL for npm trusted publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,5 +44,9 @@
     "vitest": "^4.1.2",
     "zod": "^4.3.6"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/o3co/ts.hocon"
+  },
   "packageManager": "pnpm@10.30.2"
 }


### PR DESCRIPTION
## Summary
- Add `repository.url` to package.json
- Required by npm OIDC provenance verification (must match GitHub repo URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)