### PR TITLE
fix: use Node 24 for npm OIDC publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,8 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "24"
           cache: pnpm
-
-      - name: Update npm
-        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- Use Node 24 (ships npm >=11.5.1 required for OIDC)
- Remove broken `npm install -g npm@latest` step

🤖 Generated with [Claude Code](https://claude.com/claude-code)