### PR TITLE
docs: improve README titles, add registry links and package metadata

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,4 +1,4 @@
-# ts.hocon
+# ts.hocon — TypeScript 向け HOCON パーサー
 
 [![npm](https://img.shields.io/npm/v/@o3co/ts.hocon.svg)](https://www.npmjs.com/package/@o3co/ts.hocon)
 [![CI](https://github.com/o3co/ts.hocon/actions/workflows/test.yml/badge.svg)](https://github.com/o3co/ts.hocon/actions/workflows/test.yml)
@@ -288,11 +288,11 @@ const config = parseWithSchema(hoconInput, schema) // 起動時に即座に失�
 
 ## 関連プロジェクト
 
-| プロジェクト | 言語 | 説明 |
-|---------|----------|-------------|
-| [go.hocon](https://github.com/o3co/go.hocon) | Go | Go 向け HOCON パーサー |
-| [rs.hocon](https://github.com/o3co/rs.hocon) | Rust | Rust 向け HOCON パーサー |
-| [hocon2](https://github.com/o3co/hocon2) | Go | HOCON → JSON/YAML/TOML/Properties 変換 CLI ツール |
+| プロジェクト | 言語 | レジストリ | 説明 |
+|---------|----------|----------|-------------|
+| [go.hocon](https://github.com/o3co/go.hocon) | Go | [pkg.go.dev](https://pkg.go.dev/github.com/o3co/go.hocon) | Go 向け HOCON パーサー |
+| [rs.hocon](https://github.com/o3co/rs.hocon) | Rust | [crates.io](https://crates.io/crates/o3co-hocon) | Rust 向け HOCON パーサー |
+| [hocon2](https://github.com/o3co/hocon2) | Go | [pkg.go.dev](https://pkg.go.dev/github.com/o3co/hocon2) | HOCON → JSON/YAML/TOML/Properties 変換 CLI |
 
 すべての実装が Lightbend HOCON 仕様に完全準拠しています。
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ts.hocon
+# ts.hocon — HOCON Parser for TypeScript
 
 [![npm](https://img.shields.io/npm/v/@o3co/ts.hocon.svg)](https://www.npmjs.com/package/@o3co/ts.hocon)
 [![CI](https://github.com/o3co/ts.hocon/actions/workflows/test.yml/badge.svg)](https://github.com/o3co/ts.hocon/actions/workflows/test.yml)
@@ -288,11 +288,11 @@ const config = parseWithSchema(hoconInput, schema) // fails fast on startup
 
 ## Related Projects
 
-| Project | Language | Description |
-|---------|----------|-------------|
-| [go.hocon](https://github.com/o3co/go.hocon) | Go | HOCON parser for Go |
-| [rs.hocon](https://github.com/o3co/rs.hocon) | Rust | HOCON parser for Rust |
-| [hocon2](https://github.com/o3co/hocon2) | Go | CLI tools to convert HOCON → JSON/YAML/TOML/Properties |
+| Project | Language | Registry | Description |
+|---------|----------|----------|-------------|
+| [go.hocon](https://github.com/o3co/go.hocon) | Go | [pkg.go.dev](https://pkg.go.dev/github.com/o3co/go.hocon) | HOCON parser for Go |
+| [rs.hocon](https://github.com/o3co/rs.hocon) | Rust | [crates.io](https://crates.io/crates/o3co-hocon) | HOCON parser for Rust |
+| [hocon2](https://github.com/o3co/hocon2) | Go | [pkg.go.dev](https://pkg.go.dev/github.com/o3co/hocon2) | HOCON → JSON/YAML/TOML/Properties CLI |
 
 All implementations are full Lightbend HOCON spec compliant.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
   "name": "@o3co/ts.hocon",
   "version": "0.1.4",
+  "description": "Full Lightbend HOCON spec-compliant parser and config library for TypeScript",
+  "keywords": ["hocon", "config", "configuration", "parser", "typescript", "lightbend"],
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary
- Add descriptive h1 titles (`ts.hocon — HOCON Parser for TypeScript`) for npm/GitHub discoverability
- Add `description` and `keywords` to package.json for npm registry SEO
- Add Registry column with direct npm/crates.io/pkg.go.dev links to Related Projects table
- Applied to both EN and JA READMEs

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Verify package.json fields appear on npm after next publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)