### PR TITLE
ci: switch to tag-based versioning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,14 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Verify tag matches package.json version
+      - name: Set version from tag
         run: |
           TAG="${GITHUB_REF#refs/tags/v}"
-          PKG_VER="$(node -p 'require("./package.json").version')"
-          if [ "$TAG" != "$PKG_VER" ]; then
-            echo "::error::Tag v${TAG} does not match package.json version ${PKG_VER}"
-            exit 1
-          fi
+          echo "Publishing version ${TAG}"
+          npm version "${TAG}" --no-git-tag-version --no-commit-hooks
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set version from tag
-        run: |
-          TAG="${GITHUB_REF#refs/tags/v}"
-          echo "Publishing version ${TAG}"
-          npm version "${TAG}" --no-git-tag-version --no-commit-hooks
-
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
 
@@ -31,6 +25,9 @@ jobs:
         with:
           node-version: "24"
           cache: pnpm
+
+      - name: Set version from tag
+        run: pnpm version "${GITHUB_REF#refs/tags/v}" --no-git-tag-version --no-commit-hooks
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@o3co/ts.hocon",
-  "version": "0.1.4",
+  "version": "0.0.0-snapshot",
   "description": "Full Lightbend HOCON spec-compliant parser and config library for TypeScript",
   "keywords": ["hocon", "config", "configuration", "parser", "typescript", "lightbend"],
   "type": "module",


### PR DESCRIPTION
## Summary
- Replace version verification with tag-based version injection in release workflow
- Set `package.json` version to `0.0.0-snapshot` (version derived from git tag at publish time)
- Eliminates need for version bump PRs before releases

## How it works
1. Push a tag like `v0.1.5`
2. Release CI extracts `0.1.5` from the tag
3. `npm version 0.1.5 --no-git-tag-version` sets it in package.json
4. Build + publish proceeds as before

## Test plan
- [ ] Verify release workflow runs correctly on next tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)