### PR TITLE
fix: P0 Phase 2-4 — quoted paths, async includes, stray brace detection

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -69,7 +69,7 @@ export class Config {
   }
 
   private lookupNode(path: string): HoconValue | undefined {
-    const segments = path.split('.')
+    const segments = splitConfigPath(path)
     let current: HoconValue = this.root
     for (const seg of segments) {
       if (current.kind !== 'object') return undefined
@@ -86,6 +86,32 @@ export class Config {
     if (v.kind !== 'scalar') throw new ConfigError(`expected scalar at ${path}, got ${v.kind}`, path)
     return v.value
   }
+}
+
+function splitConfigPath(path: string): string[] {
+  const segments: string[] = []
+  let i = 0
+  while (i < path.length) {
+    if (path[i] === '"') {
+      const end = path.indexOf('"', i + 1)
+      if (end === -1) {
+        segments.push(path.slice(i + 1))
+        break
+      }
+      segments.push(path.slice(i + 1, end))
+      i = end + 1
+      if (i < path.length && path[i] === '.') i++
+    } else {
+      const dot = path.indexOf('.', i)
+      if (dot === -1) {
+        segments.push(path.slice(i))
+        break
+      }
+      segments.push(path.slice(i, dot))
+      i = dot + 1
+    }
+  }
+  return segments
 }
 
 function hoconToJs(v: HoconValue): unknown {

--- a/src/config.ts
+++ b/src/config.ts
@@ -93,13 +93,27 @@ function splitConfigPath(path: string): string[] {
   let i = 0
   while (i < path.length) {
     if (path[i] === '"') {
-      const end = path.indexOf('"', i + 1)
-      if (end === -1) {
-        segments.push(path.slice(i + 1))
-        break
+      i++
+      let segment = ''
+      let closed = false
+      while (i < path.length) {
+        const ch = path[i]
+        if (ch === '\\' && i + 1 < path.length) {
+          const next = path[i + 1]
+          segment += next
+          i += 2
+          continue
+        }
+        if (ch === '"') {
+          closed = true
+          i++
+          break
+        }
+        segment += ch
+        i++
       }
-      segments.push(path.slice(i + 1, end))
-      i = end + 1
+      segments.push(segment)
+      if (!closed) break
       if (i < path.length && path[i] === '.') i++
     } else {
       const dot = path.indexOf('.', i)

--- a/src/config.ts
+++ b/src/config.ts
@@ -112,8 +112,8 @@ function splitConfigPath(path: string): string[] {
         segment += ch
         i++
       }
+      if (!closed) throw new ConfigError(`unterminated quoted path segment: ${path}`, path)
       segments.push(segment)
-      if (!closed) break
       if (i < path.length && path[i] === '.') i++
     } else {
       const dot = path.indexOf('.', i)

--- a/src/internal/parser/parser.ts
+++ b/src/internal/parser/parser.ts
@@ -245,6 +245,13 @@ export function parseTokens(tokens: Token[]): AstNode {
       }
     }
 
+    // After merge loop, verify no remaining non-EOF tokens (e.g. stray `}`)
+    skip('newline')
+    const remaining = peek()
+    if (remaining.kind !== 'eof') {
+      throw new ParseError(`Unexpected token '${remaining.value}' after closing brace`, remaining.line, remaining.col)
+    }
+
     return { kind: 'object', fields: allFields, pos: first.pos }
   }
   return parseObject(false)

--- a/src/internal/resolver/resolver.ts
+++ b/src/internal/resolver/resolver.ts
@@ -51,6 +51,7 @@ export type ResolveOptions = {
   env: Record<string, string>
   baseDir: string | undefined
   readFileSync: (filePath: string) => string
+  readFile?: (filePath: string) => Promise<string>
   includeStack?: string[]
 }
 
@@ -60,6 +61,15 @@ export function resolve(ast: AstNode, opts: ResolveOptions): HoconValue {
   // Pass 1
   const root = buildResObj(ast, opts)
   // Pass 2
+  const resolving = new Set<string>()
+  const resolvedCache = new Map<string, HoconValue>()
+  return resolveResObj(root, root, resolving, resolvedCache, opts)
+}
+
+export async function resolveAsync(ast: AstNode, opts: ResolveOptions): Promise<HoconValue> {
+  // Pass 1 (async — awaits file reads for includes)
+  const root = await buildResObjAsync(ast, opts)
+  // Pass 2 (sync — no I/O needed for substitution resolution)
   const resolving = new Set<string>()
   const resolvedCache = new Map<string, HoconValue>()
   return resolveResObj(root, root, resolving, resolvedCache, opts)
@@ -459,5 +469,138 @@ function loadInclude(includePath: string, opts: ResolveOptions): ResObj {
   }
 
   // Missing includes are silently ignored per HOCON spec
+  return makeResObj()
+}
+
+// ---- Async Pass 1 helpers (mirror sync versions but await file reads) ----
+
+async function buildResObjAsync(ast: AstNode, opts: ResolveOptions): Promise<ResObj> {
+  if (ast.kind !== 'object') {
+    throw new ResolveError('root AST must be an object', '', ast.pos.line, ast.pos.col)
+  }
+  const obj = makeResObj()
+  for (const field of ast.fields) {
+    await applyFieldAsync(obj, field, opts)
+  }
+  return obj
+}
+
+async function applyFieldAsync(obj: ResObj, field: AstField, opts: ResolveOptions): Promise<void> {
+  if (field.key.length === 0 && field.value.kind === 'include') {
+    const included = await loadIncludeAsync(field.value.path, opts)
+    deepMergeResObjInto(obj, included)
+    return
+  }
+
+  const [head, ...tail] = field.key
+  if (!head) return
+
+  if (tail.length > 0) {
+    const syntheticAst: AstNode = {
+      kind: 'object',
+      fields: [{ key: tail, value: field.value, append: field.append, pos: field.pos }],
+      pos: field.pos,
+    }
+    await applyFieldAsync(obj, { key: [head], value: syntheticAst, append: false, pos: field.pos }, opts)
+    return
+  }
+
+  if (field.append) {
+    const existing: ResolverValue = obj.fields.get(head) ?? ({ kind: 'array', items: [] } satisfies HoconValue)
+    obj.priorValues.set(head, existing)
+    obj.fields.set(head, {
+      _kind: 'append-placeholder',
+      existing,
+      elem: await astToResolverValueAsync(field.value, opts),
+    })
+    return
+  }
+
+  const existing = obj.fields.get(head)
+  const newVal = await astToResolverValueAsync(field.value, opts)
+
+  if (existing !== undefined) {
+    obj.priorValues.set(head, existing)
+  }
+
+  if (existing !== undefined && isResObj(existing) && isResObj(newVal)) {
+    deepMergeResObjInto(existing, newVal)
+    return
+  }
+
+  obj.fields.set(head, newVal)
+}
+
+async function astToResolverValueAsync(ast: AstNode, opts: ResolveOptions): Promise<ResolverValue> {
+  switch (ast.kind) {
+    case 'scalar':
+      return ast._separator
+        ? { kind: 'scalar', value: ast.value, _separator: true }
+        : { kind: 'scalar', value: ast.value }
+    case 'array': {
+      const items = []
+      for (const i of ast.items) {
+        items.push(await astToResolverValueAsync(i, opts) as HoconValue)
+      }
+      return { kind: 'array', items }
+    }
+    case 'object':
+      return await buildResObjAsync(ast, opts)
+    case 'subst':
+      return { _kind: 'subst-placeholder', path: ast.path, optional: ast.optional, line: ast.pos.line, col: ast.pos.col }
+    case 'concat': {
+      const nodes = []
+      for (const n of ast.nodes) {
+        nodes.push(await astToResolverValueAsync(n, opts))
+      }
+      return { _kind: 'concat-placeholder', nodes }
+    }
+    case 'include':
+      return { kind: 'scalar', value: null }
+  }
+}
+
+async function loadIncludeAsync(includePath: string, opts: ResolveOptions): Promise<ResObj> {
+  const { baseDir, readFile, readFileSync, includeStack = [], env } = opts
+  const absPath = baseDir
+    ? nodePath.resolve(baseDir, includePath)
+    : nodePath.resolve(includePath)
+
+  if (includeStack.includes(absPath)) {
+    throw new ResolveError(`circular include: ${absPath}`, absPath, 0, 0)
+  }
+
+  const candidates = [absPath]
+  if (!absPath.endsWith('.conf') && !absPath.endsWith('.json') && !absPath.endsWith('.properties')) {
+    candidates.push(absPath + '.conf', absPath + '.json')
+  }
+
+  // Prefer async readFile if available, fall back to sync
+  const read = readFile
+    ? async (p: string) => readFile(p)
+    : async (p: string) => readFileSync(p)
+
+  for (const candidate of candidates) {
+    let content: string
+    try {
+      content = await read(candidate)
+    } catch {
+      continue
+    }
+
+    if (includeStack.includes(candidate)) {
+      throw new ResolveError(`circular include: ${candidate}`, candidate, 0, 0)
+    }
+
+    const ast = parseTokens(tokenize(content))
+    return buildResObjAsync(ast, {
+      env,
+      baseDir: nodePath.dirname(candidate),
+      readFileSync,
+      readFile,
+      includeStack: [...includeStack, candidate],
+    })
+  }
+
   return makeResObj()
 }

--- a/src/internal/resolver/resolver.ts
+++ b/src/internal/resolver/resolver.ts
@@ -30,6 +30,10 @@ type ResObj = {
 
 type ResolverValue = HoconValue | SubstPlaceholder | ConcatPlaceholder | AppendPlaceholder | ResObj
 
+// Track parser-inserted separator whitespace values without leaking _separator
+// into the public HoconValue type. Uses WeakSet so values can be GC'd normally.
+const separatorValues = new WeakSet<HoconValue>()
+
 function isSubst(v: ResolverValue): v is SubstPlaceholder {
   return (v as SubstPlaceholder)._kind === 'subst-placeholder'
 }
@@ -143,10 +147,11 @@ function applyField(obj: ResObj, field: AstField, opts: ResolveOptions): void {
 
 function astToResolverValue(ast: AstNode, opts: ResolveOptions): ResolverValue {
   switch (ast.kind) {
-    case 'scalar':
-      return ast._separator
-        ? { kind: 'scalar', value: ast.value, _separator: true }
-        : { kind: 'scalar', value: ast.value }
+    case 'scalar': {
+      const sv: HoconValue = { kind: 'scalar', value: ast.value }
+      if (ast._separator) separatorValues.add(sv)
+      return sv
+    }
     case 'array':
       return { kind: 'array', items: ast.items.map(i => astToResolverValue(i, opts) as HoconValue) }
     case 'object': {
@@ -300,9 +305,9 @@ function resolveConcat(
   if (resolved.length === 1) return resolved[0]!
 
   // Object concatenation: if all non-separator elements are objects, deep-merge them.
-  // Only filter parser-inserted separator whitespace (marked with _separator), NOT
-  // user-authored values like "" or " " which should prevent object merging.
-  const nonSep = resolved.filter(v => !(v.kind === 'scalar' && v._separator))
+  // Only filter parser-inserted separator whitespace (tracked via separatorValues WeakSet),
+  // NOT user-authored values like "" or " " which should prevent object merging.
+  const nonSep = resolved.filter(v => !separatorValues.has(v))
   if (nonSep.length > 0 && nonSep.every(v => v.kind === 'object')) {
     const merged = new Map<string, HoconValue>()
     for (const v of nonSep) {
@@ -533,10 +538,11 @@ async function applyFieldAsync(obj: ResObj, field: AstField, opts: ResolveOption
 
 async function astToResolverValueAsync(ast: AstNode, opts: ResolveOptions): Promise<ResolverValue> {
   switch (ast.kind) {
-    case 'scalar':
-      return ast._separator
-        ? { kind: 'scalar', value: ast.value, _separator: true }
-        : { kind: 'scalar', value: ast.value }
+    case 'scalar': {
+      const sv: HoconValue = { kind: 'scalar', value: ast.value }
+      if (ast._separator) separatorValues.add(sv)
+      return sv
+    }
     case 'array': {
       const items = []
       for (const i of ast.items) {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,6 +1,6 @@
 import { tokenize } from './internal/lexer/lexer.js'
 import { parseTokens } from './internal/parser/parser.js'
-import { resolve } from './internal/resolver/resolver.js'
+import { resolve, resolveAsync } from './internal/resolver/resolver.js'
 import { Config } from './config.js'
 import type { ResolveOptions } from './internal/resolver/resolver.js'
 import * as fs from 'node:fs'
@@ -41,13 +41,21 @@ export function parse(input: string, opts: ParseOptions = {}): Config {
 }
 
 /**
- * Async wrapper around `parse()`. Returns a resolved Promise — the parsing
- * itself is synchronous. Use `parseFileAsync()` for async file I/O.
- * Note: `include` directives in string input are resolved synchronously
- * via `readFileSync`; `readFile` is not used by this function.
+ * Truly async version of `parse()`. Include directives are resolved
+ * asynchronously via `readFile` when provided.
  */
 export async function parseAsync(input: string, opts: ParseOptions = {}): Promise<Config> {
-  return Promise.resolve(parse(input, opts))
+  const tokens = tokenize(input)
+  const ast = parseTokens(tokens)
+  const resolveOpts: ResolveOptions = {
+    env: getEnv(opts),
+    baseDir: opts.baseDir,
+    readFileSync: opts.readFileSync ?? defaultReadFileSync,
+    readFile: opts.readFile,
+  }
+  const value = await resolveAsync(ast, resolveOpts)
+  if (value.kind !== 'object') throw new Error('resolved value is not an object')
+  return new Config(value)
 }
 
 export function parseFile(filePath: string, opts: ParseOptions = {}): Config {
@@ -71,9 +79,10 @@ export async function parseFileAsync(filePath: string, opts: ParseOptions = {}):
   const resolvedPath = path.resolve(filePath)
   const readFile = opts.readFile ?? defaultReadFile
   const input = await readFile(resolvedPath)
-  return parse(input, {
+  return parseAsync(input, {
     ...opts,
     baseDir: opts.baseDir ?? path.dirname(resolvedPath),
+    readFile,
     readFileSync: opts.readFileSync ?? defaultReadFileSync,
   })
 }

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -27,14 +27,20 @@ async function defaultReadFile(filePath: string): Promise<string> {
   return fs.promises.readFile(filePath, 'utf-8')
 }
 
-export function parse(input: string, opts: ParseOptions = {}): Config {
+function buildResolveContext(input: string, opts: ParseOptions): { ast: ReturnType<typeof parseTokens>, resolveOpts: ResolveOptions } {
   const tokens = tokenize(input)
   const ast = parseTokens(tokens)
   const resolveOpts: ResolveOptions = {
     env: getEnv(opts),
     baseDir: opts.baseDir,
     readFileSync: opts.readFileSync ?? defaultReadFileSync,
+    readFile: opts.readFile,
   }
+  return { ast, resolveOpts }
+}
+
+export function parse(input: string, opts: ParseOptions = {}): Config {
+  const { ast, resolveOpts } = buildResolveContext(input, opts)
   const value = resolve(ast, resolveOpts)
   if (value.kind !== 'object') throw new Error('resolved value is not an object')
   return new Config(value)
@@ -45,14 +51,7 @@ export function parse(input: string, opts: ParseOptions = {}): Config {
  * asynchronously via `readFile` when provided.
  */
 export async function parseAsync(input: string, opts: ParseOptions = {}): Promise<Config> {
-  const tokens = tokenize(input)
-  const ast = parseTokens(tokens)
-  const resolveOpts: ResolveOptions = {
-    env: getEnv(opts),
-    baseDir: opts.baseDir,
-    readFileSync: opts.readFileSync ?? defaultReadFileSync,
-    readFile: opts.readFile,
-  }
+  const { ast, resolveOpts } = buildResolveContext(input, opts)
   const value = await resolveAsync(ast, resolveOpts)
   if (value.kind !== 'object') throw new Error('resolved value is not an object')
   return new Config(value)

--- a/src/value.ts
+++ b/src/value.ts
@@ -2,4 +2,4 @@
 export type HoconValue =
   | { kind: 'object'; fields: Map<string, HoconValue> }
   | { kind: 'array'; items: HoconValue[] }
-  | { kind: 'scalar'; value: string | number | boolean | null; _separator?: boolean }
+  | { kind: 'scalar'; value: string | number | boolean | null }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -185,4 +185,18 @@ describe('Config - quoted path segments', () => {
     const cfg = parse('a { b { c = 1 } }')
     expect(cfg.getNumber('a.b.c')).toBe(1)
   })
+
+  it('should access keys containing escaped quotes via quoted path', () => {
+    // HOCON: "a\"b" = 1  — lexer unescapes to key a"b
+    // path arg: '"a\\"b"' — which is the 7-char string: "a\"b"
+    const cfg = parse('"a\\"b" = 1')
+    expect(cfg.getNumber('"a\\"b"')).toBe(1)
+  })
+
+  it('should access keys containing backslash via quoted path', () => {
+    // HOCON: "a\\b" = 2  — lexer unescapes to key a\b
+    // path arg: '"a\\\\b"' — which is the 7-char string: "a\\b"
+    const cfg = parse('"a\\\\b" = 2')
+    expect(cfg.getNumber('"a\\\\b"')).toBe(2)
+  })
 })

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from 'vitest'
 import { Config } from '../src/config.js'
 import type { HoconValue } from '../src/value.js'
 import { ConfigError } from '../src/errors.js'
+import { parse } from '../src/index.js'
 
 function makeConfig(obj: Record<string, HoconValue>): Config {
   return new Config({ kind: 'object', fields: new Map(Object.entries(obj)) })
@@ -165,5 +166,23 @@ describe('Config', () => {
     const inner = new Map([['host', { kind: 'scalar', value: 'localhost' } satisfies HoconValue]])
     const c = new Config({ kind: 'object', fields: new Map([['server', { kind: 'object', fields: inner }]]) })
     expect(c.toObject()).toEqual({ server: { host: 'localhost' } })
+  })
+})
+
+describe('Config - quoted path segments', () => {
+  it('should access keys containing dots via quoted path', () => {
+    const cfg = parse('"a.b" = 1')
+    expect(cfg.has('"a.b"')).toBe(true)
+    expect(cfg.getNumber('"a.b"')).toBe(1)
+  })
+
+  it('should access nested keys with quoted segments', () => {
+    const cfg = parse('server { "web.api" { port = 8080 } }')
+    expect(cfg.getNumber('server."web.api".port')).toBe(8080)
+  })
+
+  it('should still work with normal dotted paths', () => {
+    const cfg = parse('a { b { c = 1 } }')
+    expect(cfg.getNumber('a.b.c')).toBe(1)
   })
 })

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -199,4 +199,9 @@ describe('Config - quoted path segments', () => {
     const cfg = parse('"a\\\\b" = 2')
     expect(cfg.getNumber('"a\\\\b"')).toBe(2)
   })
+
+  it('should throw on unterminated quoted path segment', () => {
+    const cfg = parse('a = 1')
+    expect(() => cfg.has('"unterminated')).toThrow(/unterminated/)
+  })
 })

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -5,6 +5,20 @@ import { ParseError, ResolveError } from '../src/errors.js'
 import * as fs from 'node:fs'
 import * as os from 'node:os'
 import * as path from 'node:path'
+import { resolveAsync } from '../src/internal/resolver/resolver.js'
+import { tokenize } from '../src/internal/lexer/lexer.js'
+import { parseTokens } from '../src/internal/parser/parser.js'
+
+// Helper: resolve HOCON string with async resolver
+function resolveAsyncStr(input: string, opts: Partial<Parameters<typeof resolveAsync>[1]> = {}) {
+  const ast = parseTokens(tokenize(input))
+  return resolveAsync(ast, {
+    env: {},
+    baseDir: undefined,
+    readFileSync: () => { throw new Error('no fs') },
+    ...opts,
+  })
+}
 
 describe('parse()', () => {
   it('parses basic config', () => {
@@ -152,5 +166,188 @@ describe('parseFileAsync()', () => {
     })
     expect(c.getNumber('main')).toBe(1)
     expect(c.getNumber('sub')).toBe(2)
+  })
+})
+
+// ---- Async resolver internals coverage ----
+
+describe('resolveAsync() — applyFieldAsync branches', () => {
+  it('handles dotted keys (nested key expansion)', async () => {
+    const v = await resolveAsyncStr('server.host = "localhost"\nserver.port = 8080')
+    if (v.kind !== 'object') throw new Error('expected object')
+    const server = v.fields.get('server')
+    expect(server?.kind).toBe('object')
+    if (server?.kind === 'object') {
+      expect(server.fields.get('host')).toEqual({ kind: 'scalar', value: 'localhost' })
+      expect(server.fields.get('port')).toEqual({ kind: 'scalar', value: 8080 })
+    }
+  })
+
+  it('handles += (append) operator', async () => {
+    const v = await resolveAsyncStr('items = [1, 2]\nitems += 3')
+    if (v.kind !== 'object') throw new Error('expected object')
+    const items = v.fields.get('items')
+    expect(items?.kind).toBe('array')
+    if (items?.kind === 'array') {
+      expect(items.items.map(i => (i as { kind: 'scalar'; value: unknown }).value)).toEqual([1, 2, 3])
+    }
+  })
+
+  it('deep-merges two objects at the same key', async () => {
+    const v = await resolveAsyncStr('db { host = "a" }\ndb { port = 5432 }')
+    if (v.kind !== 'object') throw new Error('expected object')
+    const db = v.fields.get('db')
+    expect(db?.kind).toBe('object')
+    if (db?.kind === 'object') {
+      expect(db.fields.get('host')).toEqual({ kind: 'scalar', value: 'a' })
+      expect(db.fields.get('port')).toEqual({ kind: 'scalar', value: 5432 })
+    }
+  })
+})
+
+describe('resolveAsync() — astToResolverValueAsync branches', () => {
+  it('handles array values', async () => {
+    const v = await resolveAsyncStr('list = [1, 2, 3]')
+    if (v.kind !== 'object') throw new Error('expected object')
+    const list = v.fields.get('list')
+    expect(list?.kind).toBe('array')
+    if (list?.kind === 'array') {
+      expect(list.items).toHaveLength(3)
+    }
+  })
+
+  it('handles nested object values', async () => {
+    const v = await resolveAsyncStr('outer { inner { x = 42 } }')
+    if (v.kind !== 'object') throw new Error('expected object')
+    const outer = v.fields.get('outer')
+    expect(outer?.kind).toBe('object')
+    if (outer?.kind === 'object') {
+      const inner = outer.fields.get('inner')
+      expect(inner?.kind).toBe('object')
+    }
+  })
+
+  it('handles substitution nodes', async () => {
+    const v = await resolveAsyncStr('base = 10\nderived = ${base}')
+    if (v.kind !== 'object') throw new Error('expected object')
+    expect(v.fields.get('derived')).toEqual({ kind: 'scalar', value: 10 })
+  })
+
+  it('handles concat nodes', async () => {
+    const v = await resolveAsyncStr('prefix = "hello"\nfull = ${prefix}" world"')
+    if (v.kind !== 'object') throw new Error('expected object')
+    expect(v.fields.get('full')).toEqual({ kind: 'scalar', value: 'hello world' })
+  })
+})
+
+describe('resolveAsync() — loadIncludeAsync branches', () => {
+  it('probes .conf extension when include has no extension', async () => {
+    // Include "base" (no extension) → should try base.conf
+    const files: Record<string, string> = {
+      '/cfg/base.conf': 'probed = true',
+    }
+    const v = await resolveAsyncStr('include "base"\napp = 1', {
+      baseDir: '/cfg',
+      readFile: async (p: string) => {
+        const content = files[p]
+        if (content === undefined) throw new Error(`not found: ${p}`)
+        return content
+      },
+    })
+    if (v.kind !== 'object') throw new Error('expected object')
+    expect(v.fields.get('probed')).toEqual({ kind: 'scalar', value: true })
+    expect(v.fields.get('app')).toEqual({ kind: 'scalar', value: 1 })
+  })
+
+  it('silently ignores missing optional includes', async () => {
+    // Include a file that doesn't exist — should not throw, just produce empty merge
+    const v = await resolveAsyncStr('include "nonexistent.conf"\napp = 42', {
+      baseDir: '/cfg',
+      readFile: async (_p: string) => { throw new Error('file not found') },
+    })
+    if (v.kind !== 'object') throw new Error('expected object')
+    expect(v.fields.get('app')).toEqual({ kind: 'scalar', value: 42 })
+    // nonexistent include is silently ignored
+    expect(v.fields.get('missing')).toBeUndefined()
+  })
+
+  it('detects circular include (direct self-reference)', async () => {
+    const files: Record<string, string> = {
+      '/cfg/self.conf': 'include "self.conf"\nval = 1',
+    }
+    await expect(
+      resolveAsyncStr('include "self.conf"', {
+        baseDir: '/cfg',
+        readFile: async (p: string) => {
+          const content = files[p]
+          if (content === undefined) throw new Error(`not found: ${p}`)
+          return content
+        },
+      })
+    ).rejects.toThrow(ResolveError)
+  })
+
+  it('falls back to sync readFileSync when no async readFile provided', async () => {
+    // loadIncludeAsync without readFile option — uses sync fallback
+    const files: Record<string, string> = {
+      '/cfg/sync.conf': 'synced = 99',
+    }
+    const v = await resolveAsyncStr('include "sync.conf"\nlocal = 1', {
+      baseDir: '/cfg',
+      readFileSync: (p: string) => {
+        const content = files[p]
+        if (content === undefined) throw new Error(`not found: ${p}`)
+        return content
+      },
+      // no readFile provided — exercises sync fallback path in loadIncludeAsync
+    })
+    if (v.kind !== 'object') throw new Error('expected object')
+    expect(v.fields.get('synced')).toEqual({ kind: 'scalar', value: 99 })
+    expect(v.fields.get('local')).toEqual({ kind: 'scalar', value: 1 })
+  })
+
+  it('detects circular include via extension-probed path (async)', async () => {
+    // "base" (no ext) resolves to base.conf, which then includes "base" again.
+    // The second pass: absPath=/cfg/base not in stack, but candidate /cfg/base.conf IS → line 598
+    const files: Record<string, string> = {
+      '/cfg/base.conf': 'include "base"\nval = 1',
+    }
+    await expect(
+      resolveAsyncStr('include "base"', {
+        baseDir: '/cfg',
+        readFile: async (p: string) => {
+          const content = files[p]
+          if (content === undefined) throw new Error(`not found: ${p}`)
+          return content
+        },
+      })
+    ).rejects.toThrow(ResolveError)
+  })
+})
+
+describe('resolve() — loadInclude sync branches', () => {
+  it('detects circular include via extension-probed path (sync)', () => {
+    // Mirrors the async test: "base" probes to base.conf, then base.conf re-includes "base"
+    const files: Record<string, string> = {
+      '/cfg/base.conf': 'include "base"\nval = 1',
+    }
+    expect(() =>
+      parse('include "base"', {
+        baseDir: '/cfg',
+        readFileSync: (p: string) => {
+          const content = files[p]
+          if (content === undefined) throw new Error(`not found: ${p}`)
+          return content
+        },
+      })
+    ).toThrow(ResolveError)
+  })
+
+  it('silently ignores missing sync includes', () => {
+    const c = parse('include "nonexistent.conf"\napp = 99', {
+      baseDir: '/cfg',
+      readFileSync: (_p: string) => { throw new Error('not found') },
+    })
+    expect(c.getNumber('app')).toBe(99)
   })
 })

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -44,6 +44,40 @@ describe('parseAsync()', () => {
     const c = await parseAsync('host = "localhost"')
     expect(c.getString('host')).toBe('localhost')
   })
+
+  it('resolves includes using async readFile', async () => {
+    const files: Record<string, string> = {
+      '/config/base.conf': 'base = 1',
+    }
+    const cfg = await parseAsync('include "base.conf"\napp = 2', {
+      baseDir: '/config',
+      readFile: async (p: string) => {
+        const content = files[p]
+        if (!content) throw new Error(`File not found: ${p}`)
+        return content
+      },
+    })
+    expect(cfg.getNumber('base')).toBe(1)
+    expect(cfg.getNumber('app')).toBe(2)
+  })
+
+  it('resolves nested includes asynchronously', async () => {
+    const files: Record<string, string> = {
+      '/config/a.conf': 'include "b.conf"\na = 1',
+      '/config/b.conf': 'b = 2',
+    }
+    const cfg = await parseAsync('include "a.conf"\nroot = 3', {
+      baseDir: '/config',
+      readFile: async (p: string) => {
+        const content = files[p]
+        if (!content) throw new Error(`File not found: ${p}`)
+        return content
+      },
+    })
+    expect(cfg.getNumber('a')).toBe(1)
+    expect(cfg.getNumber('b')).toBe(2)
+    expect(cfg.getNumber('root')).toBe(3)
+  })
 })
 
 describe('parseFile()', () => {
@@ -102,5 +136,21 @@ describe('parseFileAsync()', () => {
       baseDir: os.tmpdir(),
     })
     expect(c.getString('key')).toBe('async-reader')
+  })
+
+  it('resolves includes in file using async readFile', async () => {
+    const files: Record<string, string> = {
+      '/vfs/main.conf': 'include "sub.conf"\nmain = 1',
+      '/vfs/sub.conf': 'sub = 2',
+    }
+    const c = await parseFileAsync('/vfs/main.conf', {
+      readFile: async (p: string) => {
+        const content = files[p]
+        if (!content) throw new Error(`File not found: ${p}`)
+        return content
+      },
+    })
+    expect(c.getNumber('main')).toBe(1)
+    expect(c.getNumber('sub')).toBe(2)
   })
 })

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -187,4 +187,8 @@ describe('parseTokens', () => {
       expect(keys).toEqual([['a'], ['garbage']])
     }
   })
+
+  it('should error on stray } after braced root', () => {
+    expect(() => parseTokens(tokenize('{ a = 1 } }'))).toThrow()
+  })
 })

--- a/tests/resolver.test.ts
+++ b/tests/resolver.test.ts
@@ -1,14 +1,23 @@
 // tests/resolver.test.ts
-import { describe, it, expect } from 'vitest'
+import { describe, expect, it } from 'vitest'
+import { ResolveError } from '../src/errors.js'
 import { tokenize } from '../src/internal/lexer/lexer.js'
 import { parseTokens } from '../src/internal/parser/parser.js'
 import { resolve } from '../src/internal/resolver/resolver.js'
 import type { HoconValue } from '../src/value.js'
-import { ResolveError } from '../src/errors.js'
 
-function resolveStr(input: string, env: Record<string, string> = {}): HoconValue {
+function resolveStr(input: string, env: Record<string, string> = {}, files: Record<string, string> = {}): HoconValue {
   const ast = parseTokens(tokenize(input))
-  return resolve(ast, { env, baseDir: undefined, readFileSync: () => { throw new Error('no fs') } })
+  const hasFiles = Object.keys(files).length > 0
+  return resolve(ast, {
+    env,
+    baseDir: hasFiles ? '/' : undefined,
+    readFileSync: (p: string) => {
+      const content = files[p]
+      if (content !== undefined) return content
+      throw new Error(`file not found: ${p}`)
+    },
+  })
 }
 
 function obj(v: HoconValue): Map<string, HoconValue> {
@@ -228,5 +237,63 @@ describe('Resolver - include', () => {
         'b.conf': 'include "a.conf"',
       })
     ).toThrow(ResolveError)
+  })
+})
+
+describe('Resolver - resolveConcat edge cases', () => {
+  it('returns null scalar when concat resolves to zero elements (all optional missing)', () => {
+    // a concat of two missing optional substitutions → both resolve to undefined → empty
+    // resolveConcat returns null scalar for empty resolved list
+    const v = resolveStr('x = ${?missing1}${?missing2}')
+    const x = obj(v).get('x')
+    expect(x).toEqual({ kind: 'scalar', value: null })
+  })
+
+  it('concatenates arrays from substitution in concat context', () => {
+    // arr is resolved array; concat of arr subst + scalar item produces array concat
+    const v = resolveStr('arr = [1, 2]\nresult = ${arr}[3]')
+    const result = obj(v).get('result')
+    // array concat: [1,2] + [3] merged or string fallback — at minimum should not throw
+    expect(result).toBeDefined()
+  })
+})
+
+describe('Resolver - circular substitution without prior value', () => {
+  it('throws ResolveError for optional circular substitution with no prior', () => {
+    // ${?a} that cycles and has no prior value — should return undefined (field dropped)
+    const v = resolveStr('a = ${?a}')
+    // 'a' has no prior, so the optional circular sub resolves to undefined → field dropped
+    expect(obj(v).get('a')).toBeUndefined()
+  })
+})
+
+describe('Resolver - parseSubstPath quoted segments', () => {
+  it('resolves substitution with quoted path containing dots', () => {
+    // ${"a.b"} should treat "a.b" as a single key, not split at dot
+    const v = resolveStr('"a.b" = 42\nx = ${"a.b"}')
+    expect(obj(v).get('x')).toEqual({ kind: 'scalar', value: 42 })
+  })
+
+  it('resolves substitution with dot-starting path (empty segment)', () => {
+    // Paths starting with a dot produce an empty leading segment in parseSubstPath.
+    // If the key isn't found, optional sub returns undefined (field dropped).
+    const v = resolveStr('x = ${?.missing}')
+    expect(obj(v).get('x')).toBeUndefined()
+  })
+})
+
+describe('Resolver - include .conf extension probing (sync)', () => {
+  it('probes .conf extension when include name has no extension', () => {
+    const v = resolveStr('include "base"\nlocal = 1', {}, {
+      '/base.conf': 'probed = true',
+    })
+    expect(obj(v).get('probed')).toEqual({ kind: 'scalar', value: true })
+    expect(obj(v).get('local')).toEqual({ kind: 'scalar', value: 1 })
+  })
+
+  it('silently ignores include when no candidates found', () => {
+    const v = resolveStr('include "ghost"\nlocal = 7', {}, {})
+    expect(obj(v).get('local')).toEqual({ kind: 'scalar', value: 7 })
+    expect(obj(v).get('ghost')).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary
- **Quoted path segments** in Config lookups — keys with dots (e.g. `"a.b"`) now accessible via getter API (Closes #22)
- **Truly async `parseAsync`** — include resolution now uses async I/O, not just wrapping sync `parse()` (Closes #23)
- **Stray `}` detection** — error on trailing `}` after braced root object (Phase 1 Copilot followup)
- **`_separator` removed from public `HoconValue` type** — internal parser marker moved to WeakSet (Phase 1 Copilot followup)

## Test Plan
- [x] 196/196 tests passing (vitest)
- [x] Async include tests: basic, nested, and parseFileAsync
- [x] Quoted path tests: dotted keys, nested quoted segments, normal paths
- [x] Stray brace test: `{ a = 1 } }` throws ParseError
- [x] Reviewed by Claude (code-reviewer) and Codex CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)