### PR TITLE
feat: P1 include system hardening — required(), error propagation, url/classpath

### DIFF
--- a/src/internal/parser/ast.ts
+++ b/src/internal/parser/ast.ts
@@ -6,7 +6,7 @@ export type AstNode =
   | { kind: 'scalar'; value: string | number | boolean | null; pos: Pos; _separator?: boolean }
   | { kind: 'concat'; nodes: AstNode[]; pos: Pos }
   | { kind: 'subst'; path: string; optional: boolean; pos: Pos }
-  | { kind: 'include'; path: string; pos: Pos }
+  | { kind: 'include'; path: string; required: boolean; pos: Pos }
 
 // key が空配列のとき include ディレクティブを表す（value は include ノード）
 export type AstField = {

--- a/src/internal/parser/parser.ts
+++ b/src/internal/parser/parser.ts
@@ -126,6 +126,15 @@ export function parseTokens(tokens: Token[]): AstNode {
       // include required("path") or include required(file("path"))
       // The lexer may produce "required(" or "required(file(" as a single unquoted token
       // depending on whether there is whitespace before "file(".
+
+      // Reject bare `required` without a following `(`: e.g. `include required "file.conf"`
+      if (t.value === 'required') {
+        const next = tokens[pos + 1] ?? { kind: 'eof', value: '' }
+        if (next.kind !== 'unquoted' || !next.value.startsWith('(')) {
+          throw new ParseError('include required must be followed by (', t.line, t.col)
+        }
+      }
+
       required = true
       advance()
 
@@ -146,8 +155,8 @@ export function parseTokens(tokens: Token[]): AstNode {
       while (peek().kind !== 'string' && peek().kind !== 'eof') advance()
       if (peek().kind === 'eof') throw new ParseError('expected include path', t.line, t.col)
       path = advance().value
-      // Skip closing ) and anything else on this line
-      while (peek().kind !== 'newline' && peek().kind !== 'rbrace' && peek().kind !== 'eof') advance()
+      // Skip closing ) and anything else on this line (but stop at comma — next field)
+      while (peek().kind !== 'newline' && peek().kind !== 'rbrace' && peek().kind !== 'eof' && peek().kind !== 'comma') advance()
     } else if (t.kind === 'string') {
       // include "path"
       path = advance().value
@@ -158,8 +167,8 @@ export function parseTokens(tokens: Token[]): AstNode {
       while (peek().kind !== 'string' && peek().kind !== 'eof') advance()
       if (peek().kind === 'eof') throw new ParseError('expected include path', t.line, t.col)
       path = advance().value
-      // Skip closing ) and anything else on this line
-      while (peek().kind !== 'newline' && peek().kind !== 'rbrace' && peek().kind !== 'eof') advance()
+      // Skip closing ) and anything else on this line (but stop at comma — next field)
+      while (peek().kind !== 'newline' && peek().kind !== 'rbrace' && peek().kind !== 'eof' && peek().kind !== 'comma') advance()
     } else if (t.kind === 'unquoted' && (t.value === 'url' || t.value.startsWith('url('))) {
       throw new ParseError('include url(...) is not supported', t.line, t.col)
     } else if (t.kind === 'unquoted' && (t.value === 'classpath' || t.value.startsWith('classpath('))) {

--- a/src/internal/parser/parser.ts
+++ b/src/internal/parser/parser.ts
@@ -128,6 +128,20 @@ export function parseTokens(tokens: Token[]): AstNode {
       // depending on whether there is whitespace before "file(".
       required = true
       advance()
+
+      // Check for unsupported url/classpath forms inside required():
+      // Case 1 (no space): lexer produced a single token like "required(url(" or "required(classpath("
+      const innerPrefix = t.value.startsWith('required(') ? t.value.slice('required('.length) : ''
+      if (innerPrefix.startsWith('url') || innerPrefix.startsWith('classpath')) {
+        throw new ParseError('include url(...) and classpath(...) are not supported', t.line, t.col)
+      }
+      // Case 2 (with space): next token starts with url/classpath
+      const next = peek()
+      if (next.kind === 'unquoted' && (next.value === 'url' || next.value.startsWith('url(') ||
+          next.value === 'classpath' || next.value.startsWith('classpath('))) {
+        throw new ParseError('include url(...) and classpath(...) are not supported', next.line, next.col)
+      }
+
       // Skip tokens until we find the quoted path string
       while (peek().kind !== 'string' && peek().kind !== 'eof') advance()
       if (peek().kind === 'eof') throw new ParseError('expected include path', t.line, t.col)

--- a/src/internal/parser/parser.ts
+++ b/src/internal/parser/parser.ts
@@ -146,6 +146,10 @@ export function parseTokens(tokens: Token[]): AstNode {
       path = advance().value
       // Skip closing ) and anything else on this line
       while (peek().kind !== 'newline' && peek().kind !== 'rbrace' && peek().kind !== 'eof') advance()
+    } else if (t.kind === 'unquoted' && (t.value === 'url' || t.value.startsWith('url('))) {
+      throw new ParseError('include url(...) is not supported', t.line, t.col)
+    } else if (t.kind === 'unquoted' && (t.value === 'classpath' || t.value.startsWith('classpath('))) {
+      throw new ParseError('include classpath(...) is not supported', t.line, t.col)
     } else {
       throw new ParseError(`expected include path, got ${t.kind}`, t.line, t.col)
     }

--- a/src/internal/parser/parser.ts
+++ b/src/internal/parser/parser.ts
@@ -119,8 +119,22 @@ export function parseTokens(tokens: Token[]): AstNode {
     skip('newline')
     const t = peek()
     let path: string
+    let required = false
 
-    if (t.kind === 'string') {
+    if (t.kind === 'unquoted' && (t.value === 'required(' || t.value === 'required' ||
+        t.value.startsWith('required('))) {
+      // include required("path") or include required(file("path"))
+      // The lexer may produce "required(" or "required(file(" as a single unquoted token
+      // depending on whether there is whitespace before "file(".
+      required = true
+      advance()
+      // Skip tokens until we find the quoted path string
+      while (peek().kind !== 'string' && peek().kind !== 'eof') advance()
+      if (peek().kind === 'eof') throw new ParseError('expected include path', t.line, t.col)
+      path = advance().value
+      // Skip closing ) and anything else on this line
+      while (peek().kind !== 'newline' && peek().kind !== 'rbrace' && peek().kind !== 'eof') advance()
+    } else if (t.kind === 'string') {
       // include "path"
       path = advance().value
     } else if (t.kind === 'unquoted' && (t.value === 'file(' || t.value === 'file')) {
@@ -138,7 +152,7 @@ export function parseTokens(tokens: Token[]): AstNode {
 
     return {
       key: [],
-      value: { kind: 'include', path, pos: p },
+      value: { kind: 'include', path, required, pos: p },
       append: false,
       pos: p,
     }

--- a/src/internal/resolver/resolver.ts
+++ b/src/internal/resolver/resolver.ts
@@ -436,6 +436,15 @@ function parseSubstPath(raw: string): string[] {
   return segments
 }
 
+function isFileNotFoundError(e: unknown): boolean {
+  if (!(e instanceof Error)) return false
+  const code = (e as NodeJS.ErrnoException).code
+  if (code === 'ENOENT' || code === 'MODULE_NOT_FOUND') return true
+  // Fallback for custom readFile implementations that don't set .code
+  const msg = e.message.toLowerCase()
+  return msg.includes('not found') || msg.includes('no such file') || msg.includes('enoent')
+}
+
 function loadInclude(includePath: string, required: boolean, opts: ResolveOptions): ResObj {
   const { baseDir, readFileSync, includeStack = [], env } = opts
   const absPath = baseDir
@@ -457,8 +466,7 @@ function loadInclude(includePath: string, required: boolean, opts: ResolveOption
     try {
       content = readFileSync(candidate)
     } catch (e: unknown) {
-      if (e instanceof Error && (e as NodeJS.ErrnoException).code === 'ENOENT') continue
-      if (e instanceof Error && (e as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND') continue
+      if (isFileNotFoundError(e)) continue
       throw e
     }
 
@@ -596,8 +604,7 @@ async function loadIncludeAsync(includePath: string, required: boolean, opts: Re
     try {
       content = await read(candidate)
     } catch (e: unknown) {
-      if (e instanceof Error && (e as NodeJS.ErrnoException).code === 'ENOENT') continue
-      if (e instanceof Error && (e as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND') continue
+      if (isFileNotFoundError(e)) continue
       throw e
     }
 

--- a/src/internal/resolver/resolver.ts
+++ b/src/internal/resolver/resolver.ts
@@ -95,7 +95,7 @@ function buildResObj(ast: AstNode, opts: ResolveOptions): ResObj {
 function applyField(obj: ResObj, field: AstField, opts: ResolveOptions): void {
   // include directive: key is empty, value is include node
   if (field.key.length === 0 && field.value.kind === 'include') {
-    const included = loadInclude(field.value.path, opts)
+    const included = loadInclude(field.value.path, field.value.required, opts)
     deepMergeResObjInto(obj, included)
     return
   }
@@ -436,7 +436,7 @@ function parseSubstPath(raw: string): string[] {
   return segments
 }
 
-function loadInclude(includePath: string, opts: ResolveOptions): ResObj {
+function loadInclude(includePath: string, required: boolean, opts: ResolveOptions): ResObj {
   const { baseDir, readFileSync, includeStack = [], env } = opts
   const absPath = baseDir
     ? nodePath.resolve(baseDir, includePath)
@@ -473,7 +473,10 @@ function loadInclude(includePath: string, opts: ResolveOptions): ResObj {
     })
   }
 
-  // Missing includes are silently ignored per HOCON spec
+  // Missing required includes throw; others are silently ignored per HOCON spec
+  if (required) {
+    throw new ResolveError(`required include file not found: ${includePath}`, includePath, 0, 0)
+  }
   return makeResObj()
 }
 
@@ -492,7 +495,7 @@ async function buildResObjAsync(ast: AstNode, opts: ResolveOptions): Promise<Res
 
 async function applyFieldAsync(obj: ResObj, field: AstField, opts: ResolveOptions): Promise<void> {
   if (field.key.length === 0 && field.value.kind === 'include') {
-    const included = await loadIncludeAsync(field.value.path, opts)
+    const included = await loadIncludeAsync(field.value.path, field.value.required, opts)
     deepMergeResObjInto(obj, included)
     return
   }
@@ -566,7 +569,7 @@ async function astToResolverValueAsync(ast: AstNode, opts: ResolveOptions): Prom
   }
 }
 
-async function loadIncludeAsync(includePath: string, opts: ResolveOptions): Promise<ResObj> {
+async function loadIncludeAsync(includePath: string, required: boolean, opts: ResolveOptions): Promise<ResObj> {
   const { baseDir, readFile, readFileSync, includeStack = [], env } = opts
   const absPath = baseDir
     ? nodePath.resolve(baseDir, includePath)
@@ -608,5 +611,9 @@ async function loadIncludeAsync(includePath: string, opts: ResolveOptions): Prom
     })
   }
 
+  // Missing required includes throw; others are silently ignored per HOCON spec
+  if (required) {
+    throw new ResolveError(`required include file not found: ${includePath}`, includePath, 0, 0)
+  }
   return makeResObj()
 }

--- a/src/internal/resolver/resolver.ts
+++ b/src/internal/resolver/resolver.ts
@@ -456,8 +456,10 @@ function loadInclude(includePath: string, required: boolean, opts: ResolveOption
     let content: string
     try {
       content = readFileSync(candidate)
-    } catch {
-      continue // file not found, try next candidate
+    } catch (e: unknown) {
+      if (e instanceof Error && (e as NodeJS.ErrnoException).code === 'ENOENT') continue
+      if (e instanceof Error && (e as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND') continue
+      throw e
     }
 
     if (includeStack.includes(candidate)) {
@@ -593,8 +595,10 @@ async function loadIncludeAsync(includePath: string, required: boolean, opts: Re
     let content: string
     try {
       content = await read(candidate)
-    } catch {
-      continue
+    } catch (e: unknown) {
+      if (e instanceof Error && (e as NodeJS.ErrnoException).code === 'ENOENT') continue
+      if (e instanceof Error && (e as NodeJS.ErrnoException).code === 'MODULE_NOT_FOUND') continue
+      throw e
     }
 
     if (includeStack.includes(candidate)) {

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -250,7 +250,7 @@ describe('resolveAsync() — loadIncludeAsync branches', () => {
       baseDir: '/cfg',
       readFile: async (p: string) => {
         const content = files[p]
-        if (content === undefined) throw new Error(`not found: ${p}`)
+        if (content === undefined) throw Object.assign(new Error(`ENOENT: ${p}`), { code: 'ENOENT' })
         return content
       },
     })
@@ -263,7 +263,7 @@ describe('resolveAsync() — loadIncludeAsync branches', () => {
     // Include a file that doesn't exist — should not throw, just produce empty merge
     const v = await resolveAsyncStr('include "nonexistent.conf"\napp = 42', {
       baseDir: '/cfg',
-      readFile: async (_p: string) => { throw new Error('file not found') },
+      readFile: async (_p: string) => { throw Object.assign(new Error('ENOENT: not found'), { code: 'ENOENT' }) },
     })
     if (v.kind !== 'object') throw new Error('expected object')
     expect(v.fields.get('app')).toEqual({ kind: 'scalar', value: 42 })
@@ -280,7 +280,7 @@ describe('resolveAsync() — loadIncludeAsync branches', () => {
         baseDir: '/cfg',
         readFile: async (p: string) => {
           const content = files[p]
-          if (content === undefined) throw new Error(`not found: ${p}`)
+          if (content === undefined) throw Object.assign(new Error(`ENOENT: ${p}`), { code: 'ENOENT' })
           return content
         },
       })
@@ -296,7 +296,7 @@ describe('resolveAsync() — loadIncludeAsync branches', () => {
       baseDir: '/cfg',
       readFileSync: (p: string) => {
         const content = files[p]
-        if (content === undefined) throw new Error(`not found: ${p}`)
+        if (content === undefined) throw Object.assign(new Error(`ENOENT: ${p}`), { code: 'ENOENT' })
         return content
       },
       // no readFile provided — exercises sync fallback path in loadIncludeAsync
@@ -317,7 +317,7 @@ describe('resolveAsync() — loadIncludeAsync branches', () => {
         baseDir: '/cfg',
         readFile: async (p: string) => {
           const content = files[p]
-          if (content === undefined) throw new Error(`not found: ${p}`)
+          if (content === undefined) throw Object.assign(new Error(`ENOENT: ${p}`), { code: 'ENOENT' })
           return content
         },
       })
@@ -336,7 +336,7 @@ describe('resolve() — loadInclude sync branches', () => {
         baseDir: '/cfg',
         readFileSync: (p: string) => {
           const content = files[p]
-          if (content === undefined) throw new Error(`not found: ${p}`)
+          if (content === undefined) throw Object.assign(new Error(`ENOENT: ${p}`), { code: 'ENOENT' })
           return content
         },
       })
@@ -346,7 +346,7 @@ describe('resolve() — loadInclude sync branches', () => {
   it('silently ignores missing sync includes', () => {
     const c = parse('include "nonexistent.conf"\napp = 99', {
       baseDir: '/cfg',
-      readFileSync: (_p: string) => { throw new Error('not found') },
+      readFileSync: (_p: string) => { throw Object.assign(new Error('ENOENT: not found'), { code: 'ENOENT' }) },
     })
     expect(c.getNumber('app')).toBe(99)
   })

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -350,4 +350,34 @@ describe('resolve() — loadInclude sync branches', () => {
     })
     expect(c.getNumber('app')).toBe(99)
   })
+
+  it('propagates parse errors from included files during sync probing', () => {
+    const files: Record<string, string> = {
+      '/config/broken.conf': '{ invalid = }',  // syntax error
+    }
+    expect(() => parse('include "broken"', {
+      baseDir: '/config',
+      readFileSync: (path: string) => {
+        const content = files[path]
+        if (content === undefined) throw Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' })
+        return content
+      },
+    })).toThrow()
+  })
+})
+
+describe('resolveAsync() — parse error propagation in include probing', () => {
+  it('propagates parse errors from included files during async probing', async () => {
+    const files: Record<string, string> = {
+      '/config/broken.conf': '{ invalid = }',  // syntax error
+    }
+    await expect(parseAsync('include "broken"', {
+      baseDir: '/config',
+      readFile: async (path: string) => {
+        const content = files[path]
+        if (content === undefined) throw Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' })
+        return content
+      },
+    })).rejects.toThrow()
+  })
 })

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -410,4 +410,25 @@ describe('parseAsync — required include error paths', () => {
       },
     })).rejects.toThrow(/EACCES/)
   })
+
+  it('silently ignores custom readFile errors without .code for missing files', async () => {
+    // Custom readFile may throw plain Error without .code property
+    const cfg = await parseAsync('include "missing"\na = 1', {
+      baseDir: '/nowhere',
+      readFile: async (p: string) => {
+        throw new Error(`File not found: ${p}`)
+      },
+    })
+    expect(cfg.getNumber('a')).toBe(1) // include silently ignored
+  })
+
+  it('silently ignores custom sync readFileSync errors without .code for missing files', () => {
+    const cfg = parse('include "missing"\na = 1', {
+      baseDir: '/nowhere',
+      readFileSync: (p: string) => {
+        throw new Error(`no such file or directory: ${p}`)
+      },
+    })
+    expect(cfg.getNumber('a')).toBe(1)
+  })
 })

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -381,3 +381,33 @@ describe('resolveAsync() — parse error propagation in include probing', () => 
     })).rejects.toThrow()
   })
 })
+
+describe('parseAsync — required include error paths', () => {
+  it('errors on required include when file missing (async path)', async () => {
+    await expect(parseAsync('include required("nonexistent.conf")', {
+      baseDir: '/nowhere',
+      readFile: async (p: string) => {
+        throw Object.assign(new Error(`ENOENT: ${p}`), { code: 'ENOENT' })
+      },
+    })).rejects.toThrow(/required/)
+  })
+
+  it('silently ignores MODULE_NOT_FOUND in async probing', async () => {
+    const cfg = await parseAsync('include "mod"\na = 1', {
+      baseDir: '/nowhere',
+      readFile: async (p: string) => {
+        throw Object.assign(new Error(`MODULE_NOT_FOUND: ${p}`), { code: 'MODULE_NOT_FOUND' })
+      },
+    })
+    expect(cfg.getNumber('a')).toBe(1) // include silently ignored
+  })
+
+  it('re-throws non-ENOENT errors in async include probing', async () => {
+    await expect(parseAsync('include "perm"\na = 1', {
+      baseDir: '/nowhere',
+      readFile: async (p: string) => {
+        throw Object.assign(new Error(`EACCES: ${p}`), { code: 'EACCES' })
+      },
+    })).rejects.toThrow(/EACCES/)
+  })
+})

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -273,4 +273,18 @@ describe('parseTokens', () => {
     const aField = node.fields.find(f => f.key[0] === 'a')
     expect(aField).toBeDefined()
   })
+
+  it('should error on include with invalid token (catch-all)', () => {
+    // A number token after include should hit the catch-all error path
+    expect(() => parseTokens(tokenize('include 12345'))).toThrow()
+  })
+
+  it('should error on include required(url()) when url is space-separated from required(', () => {
+    // Tests the case where required( and url are separate tokens
+    expect(() => parseTokens(tokenize('include required( url("http://example.com") )'))).toThrow(/not supported/)
+  })
+
+  it('should error on include required(classpath()) when classpath is space-separated', () => {
+    expect(() => parseTokens(tokenize('include required( classpath("reference.conf") )'))).toThrow(/not supported/)
+  })
 })

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -237,4 +237,12 @@ describe('parseTokens', () => {
   it('should error on include classpath() with "not supported" message', () => {
     expect(() => parseTokens(tokenize('include classpath("reference.conf")'))).toThrow(/not supported/)
   })
+
+  it('should error on include required(url()) with "not supported" message', () => {
+    expect(() => parseTokens(tokenize('include required(url("http://example.com"))'))).toThrow(/not supported/)
+  })
+
+  it('should error on include required(classpath()) with "not supported" message', () => {
+    expect(() => parseTokens(tokenize('include required(classpath("reference.conf"))'))).toThrow(/not supported/)
+  })
 })

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -245,4 +245,32 @@ describe('parseTokens', () => {
   it('should error on include required(classpath()) with "not supported" message', () => {
     expect(() => parseTokens(tokenize('include required(classpath("reference.conf"))'))).toThrow(/not supported/)
   })
+
+  // Fix 1: required without ( must error
+  it('should error on include required "file.conf" (missing parens)', () => {
+    expect(() => parseTokens(tokenize('include required "file.conf"'))).toThrow()
+  })
+
+  // Fix 2: skip loops stop on comma
+  it('parses include file(...) followed by comma-separated field', () => {
+    const node = parseTokens(tokenize('{ include file("base.conf"), a = 1 }'))
+    if (node.kind !== 'object') throw new Error('expected object')
+    // The 'a' field must not be swallowed by the skip loop
+    const aField = node.fields.find(f => f.key[0] === 'a')
+    expect(aField).toBeDefined()
+  })
+
+  it('parses include "..." followed by comma-separated field', () => {
+    const node = parseTokens(tokenize('{ include "base.conf", a = 1 }'))
+    if (node.kind !== 'object') throw new Error('expected object')
+    const aField = node.fields.find(f => f.key[0] === 'a')
+    expect(aField).toBeDefined()
+  })
+
+  it('parses include required(...) followed by comma-separated field', () => {
+    const node = parseTokens(tokenize('{ include required("base.conf"), a = 1 }'))
+    if (node.kind !== 'object') throw new Error('expected object')
+    const aField = node.fields.find(f => f.key[0] === 'a')
+    expect(aField).toBeDefined()
+  })
 })

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -229,4 +229,12 @@ describe('parseTokens', () => {
   it('should error on stray } after braced root', () => {
     expect(() => parseTokens(tokenize('{ a = 1 } }'))).toThrow()
   })
+
+  it('should error on include url() with "not supported" message', () => {
+    expect(() => parseTokens(tokenize('include url("http://example.com")'))).toThrow(/not supported/)
+  })
+
+  it('should error on include classpath() with "not supported" message', () => {
+    expect(() => parseTokens(tokenize('include classpath("reference.conf")'))).toThrow(/not supported/)
+  })
 })

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -138,6 +138,44 @@ describe('parseTokens', () => {
     }
   })
 
+  it('parses include required("base.conf") with required: true', () => {
+    const node = parse('include required("base.conf")')
+    if (node.kind !== 'object') return
+    const field = node.fields[0]
+    if (!field) return
+    const inc = field.value
+    expect(inc.kind).toBe('include')
+    if (inc.kind === 'include') {
+      expect(inc.path).toBe('base.conf')
+      expect(inc.required).toBe(true)
+    }
+  })
+
+  it('parses include required(file("base.conf")) with required: true', () => {
+    const node = parse('include required(file("base.conf"))')
+    if (node.kind !== 'object') return
+    const field = node.fields[0]
+    if (!field) return
+    const inc = field.value
+    expect(inc.kind).toBe('include')
+    if (inc.kind === 'include') {
+      expect(inc.path).toBe('base.conf')
+      expect(inc.required).toBe(true)
+    }
+  })
+
+  it('regular include "base.conf" has required: false', () => {
+    const node = parse('include "base.conf"')
+    if (node.kind !== 'object') return
+    const field = node.fields[0]
+    if (!field) return
+    const inc = field.value
+    expect(inc.kind).toBe('include')
+    if (inc.kind === 'include') {
+      expect(inc.required).toBe(false)
+    }
+  })
+
   it('chains two quoted key segments with a dot', () => {
     const node = parse('"a"."b" = 1')
     if (node.kind === 'object') {

--- a/tests/resolver.test.ts
+++ b/tests/resolver.test.ts
@@ -297,3 +297,29 @@ describe('Resolver - include .conf extension probing (sync)', () => {
     expect(obj(v).get('ghost')).toBeUndefined()
   })
 })
+
+describe('Resolver - include required()', () => {
+  function resolveWithFs(input: string, files: Record<string, string>): HoconValue {
+    const ast = parseTokens(tokenize(input))
+    return resolve(ast, {
+      env: {},
+      baseDir: '/fake',
+      readFileSync: (p: string) => {
+        const key = p.replace('/fake/', '')
+        if (!(key in files)) throw new Error(`file not found: ${p}`)
+        return files[key] ?? ''
+      },
+    })
+  }
+
+  it('throws error containing "required" when required include file is missing', () => {
+    expect(() =>
+      resolveWithFs('include required("nonexistent.conf")\na = 1', {})
+    ).toThrow(/required/)
+  })
+
+  it('silently ignores missing non-required include and preserves other keys', () => {
+    const v = resolveWithFs('include "nonexistent.conf"\na = 1', {})
+    expect(obj(v).get('a')).toEqual({ kind: 'scalar', value: 1 })
+  })
+})

--- a/tests/resolver.test.ts
+++ b/tests/resolver.test.ts
@@ -15,7 +15,7 @@ function resolveStr(input: string, env: Record<string, string> = {}, files: Reco
     readFileSync: (p: string) => {
       const content = files[p]
       if (content !== undefined) return content
-      throw new Error(`file not found: ${p}`)
+      throw Object.assign(new Error(`ENOENT: ${p}`), { code: 'ENOENT' })
     },
   })
 }
@@ -216,7 +216,7 @@ describe('Resolver - include', () => {
       baseDir: '/fake',
       readFileSync: (p: string) => {
         const key = p.replace('/fake/', '')
-        if (!(key in files)) throw new Error(`file not found: ${p}`)
+        if (!(key in files)) throw Object.assign(new Error(`ENOENT: ${p}`), { code: 'ENOENT' })
         return files[key] ?? ''
       },
     })
@@ -306,7 +306,7 @@ describe('Resolver - include required()', () => {
       baseDir: '/fake',
       readFileSync: (p: string) => {
         const key = p.replace('/fake/', '')
-        if (!(key in files)) throw new Error(`file not found: ${p}`)
+        if (!(key in files)) throw Object.assign(new Error(`ENOENT: ${p}`), { code: 'ENOENT' })
         return files[key] ?? ''
       },
     })
@@ -320,6 +320,31 @@ describe('Resolver - include required()', () => {
 
   it('silently ignores missing non-required include and preserves other keys', () => {
     const v = resolveWithFs('include "nonexistent.conf"\na = 1', {})
+    expect(obj(v).get('a')).toEqual({ kind: 'scalar', value: 1 })
+  })
+})
+
+describe('Resolver - ENOENT narrowing in loadInclude', () => {
+  it('re-throws non-ENOENT errors from readFileSync (sync)', () => {
+    const ast = parseTokens(tokenize('include "boom.conf"\na = 1'))
+    const permError = Object.assign(new Error('Permission denied'), { code: 'EACCES' })
+    expect(() =>
+      resolve(ast, {
+        env: {},
+        baseDir: '/fake',
+        readFileSync: () => { throw permError },
+      })
+    ).toThrow('Permission denied')
+  })
+
+  it('silently ignores ENOENT errors from readFileSync (sync)', () => {
+    const ast = parseTokens(tokenize('include "missing.conf"\na = 1'))
+    const enoent = Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    const v = resolve(ast, {
+      env: {},
+      baseDir: '/fake',
+      readFileSync: () => { throw enoent },
+    })
     expect(obj(v).get('a')).toEqual({ kind: 'scalar', value: 1 })
   })
 })


### PR DESCRIPTION
## Summary
- **`include required("file")`** support — errors when file is missing, per HOCON spec
- **`include required(file("file"))`** support — same with file() wrapper
- **Parse error propagation** in extension probing — only file-not-found is silently skipped (was already correct, tests added)
- **Explicit error** for `include url(...)`, `include classpath(...)`, and their `required()` variants

## Test Plan
- [x] All 231 tests passing (vitest)
- [x] Parser: required() parsing with bare path, file() form
- [x] Resolver: required missing → error, optional missing → silent ignore
- [x] Probing: parse errors propagate, file-not-found skipped
- [x] url/classpath: clear "not supported" error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)