### PR TITLE
fix: P1 lexer/parser spec compliance — unicode escapes, unknown escapes, .properties parser

### DIFF
--- a/src/internal/lexer/lexer.ts
+++ b/src/internal/lexer/lexer.ts
@@ -138,7 +138,8 @@ export function tokenize(input: string): Token[] {
               for (let i = 0; i < 4; i++) advance()
               break
             }
-            default: value += esc
+            default:
+              throw new ParseError(`Unknown escape sequence: \\${esc}`, line, col)
           }
         } else {
           value += advance()

--- a/src/internal/lexer/lexer.ts
+++ b/src/internal/lexer/lexer.ts
@@ -127,7 +127,13 @@ export function tokenize(input: string): Token[] {
             case 'b': value += '\b'; break
             case 'f': value += '\f'; break
             case 'u': {
+              if (pos + 4 > input.length) {
+                throw new ParseError('Invalid unicode escape: not enough characters', line, col)
+              }
               const hex = input.slice(pos, pos + 4)
+              if (!/^[0-9a-fA-F]{4}$/.test(hex)) {
+                throw new ParseError(`Invalid unicode escape: \\u${hex}`, line, col)
+              }
               value += String.fromCharCode(parseInt(hex, 16))
               for (let i = 0; i < 4; i++) advance()
               break

--- a/src/internal/properties/properties.ts
+++ b/src/internal/properties/properties.ts
@@ -1,0 +1,61 @@
+import type { HoconValue } from '../../value.js'
+
+export function parseProperties(input: string): Record<string, unknown> {
+  const root: Record<string, unknown> = {}
+
+  for (const line of input.split('\n')) {
+    const trimmed = line.trim()
+    if (trimmed === '' || trimmed.startsWith('#') || trimmed.startsWith('!')) continue
+
+    const sepIdx = findSeparator(trimmed)
+    if (sepIdx === -1) continue
+
+    const key = trimmed.slice(0, sepIdx).trim()
+    const value = trimmed.slice(sepIdx + 1).trim()
+    if (key === '') continue
+
+    setNested(root, key.split('.'), value)
+  }
+
+  return root
+}
+
+function findSeparator(line: string): number {
+  for (let i = 0; i < line.length; i++) {
+    if (line[i] === '=' || line[i] === ':') return i
+  }
+  return -1
+}
+
+function setNested(obj: Record<string, unknown>, segments: string[], value: string): void {
+  let current = obj
+  for (let i = 0; i < segments.length - 1; i++) {
+    const seg = segments[i]
+    if (!(seg in current) || typeof current[seg] !== 'object' || current[seg] === null) {
+      current[seg] = {}
+    }
+    current = current[seg] as Record<string, unknown>
+  }
+  current[segments[segments.length - 1]!] = value
+}
+
+/**
+ * Convert a .properties file string into a HoconValue (object with string scalars).
+ * All values remain as strings — no type coercion is applied.
+ */
+export function propertiesToHoconValue(input: string): HoconValue {
+  const parsed = parseProperties(input)
+  return recordToHoconValue(parsed)
+}
+
+function recordToHoconValue(obj: Record<string, unknown>): HoconValue & { kind: 'object' } {
+  const fields = new Map<string, HoconValue>()
+  for (const [key, val] of Object.entries(obj)) {
+    if (typeof val === 'string') {
+      fields.set(key, { kind: 'scalar', value: val })
+    } else if (val !== null && typeof val === 'object') {
+      fields.set(key, recordToHoconValue(val as Record<string, unknown>))
+    }
+  }
+  return { kind: 'object', fields }
+}

--- a/src/internal/properties/properties.ts
+++ b/src/internal/properties/properties.ts
@@ -1,7 +1,7 @@
 import type { HoconValue } from '../../value.js'
 
 export function parseProperties(input: string): Record<string, unknown> {
-  const root: Record<string, unknown> = {}
+  const root: Record<string, unknown> = Object.create(null)
 
   for (const line of input.split('\n')) {
     const trimmed = line.trim()
@@ -27,16 +27,21 @@ function findSeparator(line: string): number {
   return -1
 }
 
+const DANGEROUS_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+
 function setNested(obj: Record<string, unknown>, segments: string[], value: string): void {
   let current = obj
   for (let i = 0; i < segments.length - 1; i++) {
     const seg = segments[i]
+    if (seg === undefined || DANGEROUS_KEYS.has(seg)) return
     if (!(seg in current) || typeof current[seg] !== 'object' || current[seg] === null) {
-      current[seg] = {}
+      current[seg] = Object.create(null)
     }
     current = current[seg] as Record<string, unknown>
   }
-  current[segments[segments.length - 1]!] = value
+  const last = segments[segments.length - 1]
+  if (last === undefined || DANGEROUS_KEYS.has(last)) return
+  current[last] = value
 }
 
 /**

--- a/src/internal/resolver/resolver.ts
+++ b/src/internal/resolver/resolver.ts
@@ -469,10 +469,10 @@ function loadInclude(includePath: string, required: boolean, opts: ResolveOption
     throw new ResolveError(`circular include: ${absPath}`, absPath, 0, 0)
   }
 
-  // Try the path as-is, then with .conf and .json extensions
+  // Try the path as-is, then with .conf, .json, and .properties extensions
   const candidates = [absPath]
   if (!absPath.endsWith('.conf') && !absPath.endsWith('.json') && !absPath.endsWith('.properties')) {
-    candidates.push(absPath + '.conf', absPath + '.json')
+    candidates.push(`${absPath}.conf`, `${absPath}.json`, `${absPath}.properties`)
   }
 
   for (const candidate of candidates) {
@@ -609,7 +609,7 @@ async function loadIncludeAsync(includePath: string, required: boolean, opts: Re
 
   const candidates = [absPath]
   if (!absPath.endsWith('.conf') && !absPath.endsWith('.json') && !absPath.endsWith('.properties')) {
-    candidates.push(absPath + '.conf', absPath + '.json')
+    candidates.push(`${absPath}.conf`, `${absPath}.json`, `${absPath}.properties`)
   }
 
   // Prefer async readFile if available, fall back to sync

--- a/src/internal/resolver/resolver.ts
+++ b/src/internal/resolver/resolver.ts
@@ -4,6 +4,7 @@ import type { HoconValue } from '../../value.js'
 import type { AstNode, AstField } from '../parser/ast.js'
 import { tokenize } from '../lexer/lexer.js'
 import { parseTokens } from '../parser/parser.js'
+import { propertiesToHoconValue } from '../properties/properties.js'
 
 // ---- Internal placeholder types (not exported) ----
 type SubstPlaceholder = {
@@ -165,6 +166,19 @@ function astToResolverValue(ast: AstNode, opts: ResolveOptions): ResolverValue {
     case 'include':
       return { kind: 'scalar', value: null } // handled by applyField; should not reach here
   }
+}
+
+function hoconValueToResObj(hv: HoconValue): ResObj {
+  const obj = makeResObj()
+  if (hv.kind !== 'object') return obj
+  for (const [key, val] of hv.fields) {
+    if (val.kind === 'object') {
+      obj.fields.set(key, hoconValueToResObj(val))
+    } else {
+      obj.fields.set(key, val)
+    }
+  }
+  return obj
 }
 
 function deepMergeResObjInto(dst: ResObj, src: ResObj): void {
@@ -474,6 +488,10 @@ function loadInclude(includePath: string, required: boolean, opts: ResolveOption
       throw new ResolveError(`circular include: ${candidate}`, candidate, 0, 0)
     }
 
+    if (candidate.endsWith('.properties')) {
+      return hoconValueToResObj(propertiesToHoconValue(content))
+    }
+
     const ast = parseTokens(tokenize(content))
     return buildResObj(ast, {
       env,
@@ -610,6 +628,10 @@ async function loadIncludeAsync(includePath: string, required: boolean, opts: Re
 
     if (includeStack.includes(candidate)) {
       throw new ResolveError(`circular include: ${candidate}`, candidate, 0, 0)
+    }
+
+    if (candidate.endsWith('.properties')) {
+      return hoconValueToResObj(propertiesToHoconValue(content))
     }
 
     const ast = parseTokens(tokenize(content))

--- a/tests/lexer.test.ts
+++ b/tests/lexer.test.ts
@@ -55,6 +55,18 @@ describe('tokenize', () => {
     expect(t.value).toBe('A')
   })
 
+  it('throws on \\uZZZZ (invalid hex digits)', () => {
+    expect(() => tokenize('"\\uZZZZ"')).toThrow(ParseError)
+  })
+
+  it('throws on \\u41 (too few hex digits)', () => {
+    expect(() => tokenize('"\\u41"')).toThrow(ParseError)
+  })
+
+  it('throws on \\u at end of string (no hex digits)', () => {
+    expect(() => tokenize('"\\u"')).toThrow(ParseError)
+  })
+
   it('tokenizes triple-quoted strings', () => {
     const [t] = tokenize('"""hello\nworld"""')
     expect(t.kind).toBe('triple_string')

--- a/tests/lexer.test.ts
+++ b/tests/lexer.test.ts
@@ -67,6 +67,14 @@ describe('tokenize', () => {
     expect(() => tokenize('"\\u"')).toThrow(ParseError)
   })
 
+  it('throws on unknown escape sequence \\q', () => {
+    expect(() => tokenize('"hello\\qworld"')).toThrow(/unknown escape/i)
+  })
+
+  it('throws on unknown escape sequence \\a', () => {
+    expect(() => tokenize('"\\a"')).toThrow(/unknown escape/i)
+  })
+
   it('tokenizes triple-quoted strings', () => {
     const [t] = tokenize('"""hello\nworld"""')
     expect(t.kind).toBe('triple_string')

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -452,3 +452,20 @@ describe('parseAsync — required include error paths', () => {
     expect(cfg.getNumber('a')).toBe(1)
   })
 })
+
+describe('parseAsync — .properties extension probing', () => {
+  it('should probe .properties extension during include resolution', async () => {
+    const files: Record<string, string> = {
+      '/config/app.properties': 'key=from-properties',
+    }
+    const cfg = await parseAsync('include "app"\nother = 1', {
+      baseDir: '/config',
+      readFile: async (path: string) => {
+        const content = files[path]
+        if (!content) throw Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' })
+        return content
+      },
+    })
+    expect(cfg.getString('key')).toBe('from-properties')
+  })
+})

--- a/tests/parse.test.ts
+++ b/tests/parse.test.ts
@@ -382,6 +382,26 @@ describe('resolveAsync() — parse error propagation in include probing', () => 
   })
 })
 
+describe('parseAsync — .properties include', () => {
+  it('should include .properties file with string values and nested keys', async () => {
+    const files: Record<string, string> = {
+      '/config/app.properties': 'server.host=localhost\nserver.port=8080\ndebug=true',
+    }
+    const cfg = await parseAsync('include "app.properties"\napp = 1', {
+      baseDir: '/config',
+      readFile: async (path: string) => {
+        const content = files[path]
+        if (!content) throw Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' })
+        return content
+      },
+    })
+    expect(cfg.getString('server.host')).toBe('localhost')
+    expect(cfg.getString('server.port')).toBe('8080')  // string, not number
+    expect(cfg.getString('debug')).toBe('true')  // string, not boolean
+    expect(cfg.getNumber('app')).toBe(1)
+  })
+})
+
 describe('parseAsync — required include error paths', () => {
   it('errors on required include when file missing (async path)', async () => {
     await expect(parseAsync('include required("nonexistent.conf")', {

--- a/tests/properties.test.ts
+++ b/tests/properties.test.ts
@@ -38,4 +38,9 @@ describe('parseProperties', () => {
     const result = parseProperties('num=42\nbool=true\nnull=null')
     expect(result).toEqual({ num: '42', bool: 'true', null: 'null' })
   })
+
+  it('should not pollute prototype via __proto__ key', () => {
+    parseProperties('__proto__.polluted=true')
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined()
+  })
 })

--- a/tests/properties.test.ts
+++ b/tests/properties.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { parseProperties } from '../src/internal/properties/properties.js'
+
+describe('parseProperties', () => {
+  it('parses simple key=value pairs', () => {
+    const result = parseProperties('host=localhost\nport=8080')
+    expect(result).toEqual({ host: 'localhost', port: '8080' })
+  })
+
+  it('parses key:value with colon separator', () => {
+    const result = parseProperties('host:localhost')
+    expect(result).toEqual({ host: 'localhost' })
+  })
+
+  it('trims whitespace around key and value', () => {
+    const result = parseProperties('  host  =  localhost  ')
+    expect(result).toEqual({ host: 'localhost' })
+  })
+
+  it('skips comment lines (# and !)', () => {
+    const result = parseProperties('# comment\n! also comment\nkey=val')
+    expect(result).toEqual({ key: 'val' })
+  })
+
+  it('skips empty lines', () => {
+    const result = parseProperties('\n\nkey=val\n\n')
+    expect(result).toEqual({ key: 'val' })
+  })
+
+  it('expands dotted keys into nested objects', () => {
+    const result = parseProperties('server.host=localhost\nserver.port=8080')
+    expect(result).toEqual({
+      server: { host: 'localhost', port: '8080' }
+    })
+  })
+
+  it('all values are strings (no type coercion)', () => {
+    const result = parseProperties('num=42\nbool=true\nnull=null')
+    expect(result).toEqual({ num: '42', bool: 'true', null: 'null' })
+  })
+})


### PR DESCRIPTION
## Summary
- **`\uXXXX` validation** — hex digits and length checked, errors on invalid (Closes #28)
- **Unknown escape sequences** — `\q`, `\a` etc. now error instead of silently dropping backslash
- **Dedicated `.properties` parser** — flat `key=value` format, all values strings, dotted keys expand to nested objects

## Test Plan
- [x] 258 tests passing (vitest), coverage 96.79%
- [x] Unicode: valid `\u0041`→A, invalid `\uZZZZ`/`\u41`/`\u` throw
- [x] Unknown escapes: `\q`, `\a` throw with "unknown escape" message
- [x] Properties: unit tests (7) + integration test via parseAsync
- [x] Lightbend conformance: all pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)