### PR TITLE
feat: add getDuration and getBytes to Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ parseFileAsync(path: string, opts?: ParseOptions): Promise<Config>
 | `getBoolean(path)` | `boolean` | missing, wrong type |
 | `getConfig(path)` | `Config` | missing, not an object |
 | `getList(path)` | `unknown[]` | missing, not an array |
-| `getDuration(path, unit?)` | `number` | Duration value. Input: `"30s"`, `"5m"`, etc. Default unit: `ms`. |
-| `getBytes(path, unit?)` | `number` | Byte size value. Input: `"512MB"`, `"1GiB"`, etc. Default unit: `B`. |
+| `getDuration(path, unit?)` | `number` | missing, not a string, or invalid duration format |
+| `getBytes(path, unit?)` | `number` | missing, not a string, or invalid byte size format |
 | `has(path)` | `boolean` | — |
 | `keys()` | `string[]` | — |
 | `withFallback(fallback)` | `Config` | — |

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ HOCON gives you the readability of YAML, the structure of JSON, and features tha
 - `+=` append operator
 - `include "file.conf"` and `include file("file.conf")` directives
 - Triple-quoted strings (`"""..."""`)
+- Duration and byte size parsing (`getDuration()`, `getBytes()`)
 - Sync and async API (`parse` / `parseAsync` / `parseFile` / `parseFileAsync`)
 - ESM + CJS dual package
 - Optional [Zod](https://zod.dev/) integration for schema validation
@@ -101,6 +102,8 @@ parseFileAsync(path: string, opts?: ParseOptions): Promise<Config>
 | `getBoolean(path)` | `boolean` | missing, wrong type |
 | `getConfig(path)` | `Config` | missing, not an object |
 | `getList(path)` | `unknown[]` | missing, not an array |
+| `getDuration(path, unit?)` | `number` | Duration value. Input: `"30s"`, `"5m"`, etc. Default unit: `ms`. |
+| `getBytes(path, unit?)` | `number` | Byte size value. Input: `"512MB"`, `"1GiB"`, etc. Default unit: `B`. |
 | `has(path)` | `boolean` | — |
 | `keys()` | `string[]` | — |
 | `withFallback(fallback)` | `Config` | — |
@@ -174,6 +177,26 @@ description = """
   multiline string.
 """
 ```
+
+### Duration and Byte Sizes
+
+```ts
+const c = parse(`
+  timeout   = "30s"
+  cache-ttl = "5m"
+  max-size  = "512MiB"
+`)
+
+c.getDuration('timeout')        // 30000 (ms)
+c.getDuration('timeout', 's')   // 30
+c.getDuration('cache-ttl', 'm') // 5
+
+c.getBytes('max-size')          // 536870912 (bytes)
+c.getBytes('max-size', 'MiB')  // 512
+```
+
+Supported duration units: `ns`, `us`, `ms`, `s`, `m`, `h`, `d` (and long forms like `seconds`, `minutes`).
+Supported byte units: `B`, `KB`/`KiB`, `MB`/`MiB`, `GB`/`GiB`, `TB`/`TiB` (and long forms like `megabytes`, `mebibytes`).
 
 ## Spec Compliance
 

--- a/src/coerce.ts
+++ b/src/coerce.ts
@@ -40,7 +40,7 @@ export function parseDuration(value: string, outputUnit: DurationUnit = 'ms'): n
   if (i === 0) return NaN
   const num = Number(trimmed.slice(0, i))
   if (Number.isNaN(num)) return NaN
-  const unit = trimmed.slice(i).trim()
+  const unit = trimmed.slice(i).trim().toLowerCase()
   const mult = DURATION_UNITS[unit]
   if (mult === undefined) return NaN
   const ms = num * mult
@@ -80,7 +80,12 @@ export function parseBytes(value: string, outputUnit: ByteUnit = 'B'): number {
   const num = Number(trimmed.slice(0, i))
   if (Number.isNaN(num)) return NaN
   const unit = trimmed.slice(i).trim()
-  const mult = BYTE_UNITS[unit]
+  // Try exact match first (preserves KB vs KiB distinction)
+  let mult = BYTE_UNITS[unit]
+  // Try lowercase for long-form names (megabytes, Megabytes, MEGABYTES)
+  if (mult === undefined) {
+    mult = BYTE_UNITS[unit.toLowerCase()]
+  }
   if (mult === undefined) return NaN
   const bytes = num * mult
   const divisor = OUTPUT_BYTE_UNITS[outputUnit]

--- a/src/coerce.ts
+++ b/src/coerce.ts
@@ -12,3 +12,39 @@ export function coerceNumber(value: string): number | undefined {
   if (!/^-?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/.test(value)) return undefined
   return Number(value)
 }
+
+const DURATION_UNITS: Record<string, number> = {
+  ns: 1e-6, nanosecond: 1e-6, nanoseconds: 1e-6,
+  us: 1e-3, microsecond: 1e-3, microseconds: 1e-3,
+  ms: 1, millisecond: 1, milliseconds: 1,
+  s: 1_000, second: 1_000, seconds: 1_000,
+  m: 60_000, minute: 60_000, minutes: 60_000,
+  h: 3_600_000, hour: 3_600_000, hours: 3_600_000,
+  d: 86_400_000, day: 86_400_000, days: 86_400_000,
+}
+
+const OUTPUT_DURATION_UNITS: Record<string, number> = {
+  ns: 1e-6, us: 1e-3, ms: 1, s: 1_000, m: 60_000, h: 3_600_000, d: 86_400_000,
+}
+
+export type DurationUnit = 'ns' | 'us' | 'ms' | 's' | 'm' | 'h' | 'd'
+
+export function parseDuration(value: string, outputUnit: DurationUnit = 'ms'): number {
+  const trimmed = value.trim()
+  let i = 0
+  while (i < trimmed.length) {
+    const ch = trimmed[i]
+    if (ch !== '-' && ch !== '.' && (ch < '0' || ch > '9')) break
+    i++
+  }
+  if (i === 0) return NaN
+  const num = Number(trimmed.slice(0, i))
+  if (Number.isNaN(num)) return NaN
+  const unit = trimmed.slice(i).trim()
+  const mult = DURATION_UNITS[unit]
+  if (mult === undefined) return NaN
+  const ms = num * mult
+  const divisor = OUTPUT_DURATION_UNITS[outputUnit]
+  if (divisor === undefined) return NaN
+  return ms / divisor
+}

--- a/src/coerce.ts
+++ b/src/coerce.ts
@@ -48,3 +48,42 @@ export function parseDuration(value: string, outputUnit: DurationUnit = 'ms'): n
   if (divisor === undefined) return NaN
   return ms / divisor
 }
+
+const BYTE_UNITS: Record<string, number> = {
+  B: 1, byte: 1, bytes: 1,
+  KB: 1_000, kilobyte: 1_000, kilobytes: 1_000,
+  KiB: 1_024, kibibyte: 1_024, kibibytes: 1_024,
+  MB: 1_000_000, megabyte: 1_000_000, megabytes: 1_000_000,
+  MiB: 1_048_576, mebibyte: 1_048_576, mebibytes: 1_048_576,
+  GB: 1_000_000_000, gigabyte: 1_000_000_000, gigabytes: 1_000_000_000,
+  GiB: 1_073_741_824, gibibyte: 1_073_741_824, gibibytes: 1_073_741_824,
+  TB: 1_000_000_000_000, terabyte: 1_000_000_000_000, terabytes: 1_000_000_000_000,
+  TiB: 1_099_511_627_776, tebibyte: 1_099_511_627_776, tebibytes: 1_099_511_627_776,
+}
+
+const OUTPUT_BYTE_UNITS: Record<string, number> = {
+  B: 1, KB: 1_000, KiB: 1_024, MB: 1_000_000, MiB: 1_048_576,
+  GB: 1_000_000_000, GiB: 1_073_741_824, TB: 1_000_000_000_000, TiB: 1_099_511_627_776,
+}
+
+export type ByteUnit = 'B' | 'KB' | 'KiB' | 'MB' | 'MiB' | 'GB' | 'GiB' | 'TB' | 'TiB'
+
+export function parseBytes(value: string, outputUnit: ByteUnit = 'B'): number {
+  const trimmed = value.trim()
+  let i = 0
+  while (i < trimmed.length) {
+    const ch = trimmed[i]
+    if (ch < '0' || ch > '9') break
+    i++
+  }
+  if (i === 0) return NaN
+  const num = Number(trimmed.slice(0, i))
+  if (Number.isNaN(num)) return NaN
+  const unit = trimmed.slice(i).trim()
+  const mult = BYTE_UNITS[unit]
+  if (mult === undefined) return NaN
+  const bytes = num * mult
+  const divisor = OUTPUT_BYTE_UNITS[outputUnit]
+  if (divisor === undefined) return NaN
+  return bytes / divisor
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
-import { coerceBoolean, coerceNumber, parseDuration } from './coerce.js'
-import type { DurationUnit } from './coerce.js'
+import { coerceBoolean, coerceNumber, parseBytes, parseDuration } from './coerce.js'
+import type { ByteUnit, DurationUnit } from './coerce.js'
 import { ConfigError } from './errors.js'
 import type { HoconValue } from './value.js'
 
@@ -43,6 +43,14 @@ export class Config {
     if (typeof v !== 'string') throw new ConfigError(`expected duration string at ${path}, got ${typeof v}`, path)
     const result = parseDuration(v, unit)
     if (Number.isNaN(result)) throw new ConfigError(`invalid duration at ${path}: ${JSON.stringify(v)}`, path)
+    return result
+  }
+
+  getBytes(path: string, unit?: ByteUnit): number {
+    const v = this.requireScalar(path)
+    if (typeof v !== 'string') throw new ConfigError(`expected byte size string at ${path}, got ${typeof v}`, path)
+    const result = parseBytes(v, unit)
+    if (Number.isNaN(result)) throw new ConfigError(`invalid byte size at ${path}: ${JSON.stringify(v)}`, path)
     return result
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
-import { coerceBoolean, coerceNumber } from './coerce.js'
+import { coerceBoolean, coerceNumber, parseDuration } from './coerce.js'
+import type { DurationUnit } from './coerce.js'
 import { ConfigError } from './errors.js'
 import type { HoconValue } from './value.js'
 
@@ -35,6 +36,14 @@ export class Config {
       if (coerced !== undefined) return coerced
     }
     throw new ConfigError(`expected boolean at ${path}, got ${typeof v}`, path)
+  }
+
+  getDuration(path: string, unit?: DurationUnit): number {
+    const v = this.requireScalar(path)
+    if (typeof v !== 'string') throw new ConfigError(`expected duration string at ${path}, got ${typeof v}`, path)
+    const result = parseDuration(v, unit)
+    if (Number.isNaN(result)) throw new ConfigError(`invalid duration at ${path}: ${JSON.stringify(v)}`, path)
+    return result
   }
 
   getConfig(path: string): Config {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -205,3 +205,76 @@ describe('Config - quoted path segments', () => {
     expect(() => cfg.has('"unterminated')).toThrow(/unterminated/)
   })
 })
+
+describe('getDuration', () => {
+  it('parses seconds to ms', () => {
+    const c = parse('timeout = "30s"')
+    expect(c.getDuration('timeout')).toBe(30_000)
+  })
+
+  it('parses minutes to ms', () => {
+    const c = parse('ttl = "5m"')
+    expect(c.getDuration('ttl')).toBe(300_000)
+  })
+
+  it('parses hours to ms', () => {
+    const c = parse('expiry = "2h"')
+    expect(c.getDuration('expiry')).toBe(7_200_000)
+  })
+
+  it('parses days to ms', () => {
+    const c = parse('retention = "7d"')
+    expect(c.getDuration('retention')).toBe(604_800_000)
+  })
+
+  it('parses milliseconds', () => {
+    const c = parse('delay = "100ms"')
+    expect(c.getDuration('delay')).toBe(100)
+  })
+
+  it('parses nanoseconds to ms', () => {
+    const c = parse('tick = "5000000ns"')
+    expect(c.getDuration('tick')).toBe(5)
+  })
+
+  it('parses microseconds to ms', () => {
+    const c = parse('tick = "5000us"')
+    expect(c.getDuration('tick')).toBe(5)
+  })
+
+  it('supports long unit names', () => {
+    const c = parse('timeout = "30 seconds"')
+    expect(c.getDuration('timeout')).toBe(30_000)
+  })
+
+  it('supports fractional values', () => {
+    const c = parse('timeout = "1.5s"')
+    expect(c.getDuration('timeout')).toBe(1_500)
+  })
+
+  it('returns in requested unit', () => {
+    const c = parse('timeout = "30s"')
+    expect(c.getDuration('timeout', 's')).toBe(30)
+    expect(c.getDuration('timeout', 'm')).toBeCloseTo(0.5)
+  })
+
+  it('throws on missing path', () => {
+    const c = parse('a = 1')
+    expect(() => c.getDuration('missing')).toThrow(ConfigError)
+  })
+
+  it('throws on non-string value', () => {
+    const c = parse('a = 123')
+    expect(() => c.getDuration('a')).toThrow(ConfigError)
+  })
+
+  it('throws on unknown unit', () => {
+    const c = parse('a = "30x"')
+    expect(() => c.getDuration('a')).toThrow(ConfigError)
+  })
+
+  it('throws on no number', () => {
+    const c = parse('a = "seconds"')
+    expect(() => c.getDuration('a')).toThrow(ConfigError)
+  })
+})

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -278,3 +278,76 @@ describe('getDuration', () => {
     expect(() => c.getDuration('a')).toThrow(ConfigError)
   })
 })
+
+describe('getBytes', () => {
+  it('parses plain bytes', () => {
+    const c = parse('size = "1024B"')
+    expect(c.getBytes('size')).toBe(1024)
+  })
+
+  it('parses kilobytes (SI)', () => {
+    const c = parse('size = "10KB"')
+    expect(c.getBytes('size')).toBe(10_000)
+  })
+
+  it('parses kibibytes (IEC)', () => {
+    const c = parse('size = "10KiB"')
+    expect(c.getBytes('size')).toBe(10_240)
+  })
+
+  it('parses megabytes', () => {
+    const c = parse('size = "512MB"')
+    expect(c.getBytes('size')).toBe(512_000_000)
+  })
+
+  it('parses mebibytes', () => {
+    const c = parse('size = "512MiB"')
+    expect(c.getBytes('size')).toBe(536_870_912)
+  })
+
+  it('parses gigabytes', () => {
+    const c = parse('size = "2GB"')
+    expect(c.getBytes('size')).toBe(2_000_000_000)
+  })
+
+  it('parses gibibytes', () => {
+    const c = parse('size = "1GiB"')
+    expect(c.getBytes('size')).toBe(1_073_741_824)
+  })
+
+  it('parses terabytes', () => {
+    const c = parse('size = "1TB"')
+    expect(c.getBytes('size')).toBe(1_000_000_000_000)
+  })
+
+  it('parses tebibytes', () => {
+    const c = parse('size = "1TiB"')
+    expect(c.getBytes('size')).toBe(1_099_511_627_776)
+  })
+
+  it('supports long unit names', () => {
+    const c = parse('size = "512 megabytes"')
+    expect(c.getBytes('size')).toBe(512_000_000)
+  })
+
+  it('returns in requested unit', () => {
+    const c = parse('size = "1GiB"')
+    expect(c.getBytes('size', 'MiB')).toBe(1024)
+    expect(c.getBytes('size', 'MB')).toBeCloseTo(1073.741824)
+  })
+
+  it('throws on missing path', () => {
+    const c = parse('a = 1')
+    expect(() => c.getBytes('missing')).toThrow(ConfigError)
+  })
+
+  it('throws on non-string value', () => {
+    const c = parse('a = 123')
+    expect(() => c.getBytes('a')).toThrow(ConfigError)
+  })
+
+  it('throws on unknown unit', () => {
+    const c = parse('a = "512XB"')
+    expect(() => c.getBytes('a')).toThrow(ConfigError)
+  })
+})


### PR DESCRIPTION
## Summary

- Add `getDuration(path, unit?)` — parses HOCON duration strings (`30s`, `5m`, `2h`, etc.) with configurable output unit (default: ms)
- Add `getBytes(path, unit?)` — parses HOCON byte size strings (`512MB`, `1GiB`, etc.) with configurable output unit (default: bytes)
- Closes feature gap with go.hocon and rs.hocon

## Test plan

- [ ] 14 duration tests (units, fractional, output unit, errors)
- [ ] 14 bytes tests (SI, IEC, long names, output unit, errors)
- [ ] Full test suite passes (292 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)