### PR TITLE
chore: add CHANGELOG 1.0.0 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] — 2026-04-04
+
+### Added
+
+- `getDuration(path, unit?)` — parse HOCON duration strings (`30s`, `5m`, `2h`) with configurable output unit (default: ms)
+- `getBytes(path, unit?)` — parse HOCON byte size strings (`512MB`, `1GiB`) with configurable output unit (default: bytes)
+- `DurationUnit` and `ByteUnit` types exported from package root
+- `.properties` file support for includes (P1)
+- `include required()` and `include required(file())` directives
+- Include depth limit (max 50 levels)
+- TypeDoc API documentation deployed to GitHub Pages on minor/major releases
+- Security Considerations section in README
+- Known Limitations section in README
+- Performance benchmarks in README
+
+### Fixed
+
+- Include probing: changed from first-match to merge-all per HOCON spec
+- Include probe order: `.properties → .json → .conf` (`.conf` wins via last-merge-wins)
+- `\uXXXX` unicode escape validation in lexer
+- Error on unknown escape sequences in quoted strings
+- Circular include check moved before file read
+- `parseBytes` supports fractional values and case-insensitive units
+- Stray `}` after braced root now errors
+- Package metadata: `license`, `engines`, `homepage`, `bugs` fields added
+
+### Changed
+
+- Cross-language spec alignment with go.hocon and rs.hocon
+
 ## [0.1.0] — 2026-03-20
 
 ### Added


### PR DESCRIPTION
## Summary

- Add CHANGELOG entry for v1.0.0 release (2026-04-04)
- Documents new features (getDuration, getBytes, include required), fixes (probe order, unicode escapes, stray braces), and cross-language alignment

## Test plan

- [ ] Verify CHANGELOG formatting renders correctly on GitHub
- [ ] Confirm 0.1.0 entry is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)