### PR TITLE
test: add auto-discovery lightbend conformance tests with expected JSON

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,18 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Cache expected JSON
+        uses: actions/cache@v4
+        with:
+          path: |
+            tests/lightbend/testdata/expected
+            .xx-hocon-version
+          key: xx-hocon-expected-${{ github.run_id }}
+          restore-keys: xx-hocon-expected-
+
+      - name: Fetch expected JSON
+        run: make testdata
+
       - name: Type check
         run: pnpm typecheck
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
           path: |
             tests/lightbend/testdata/expected
             .xx-hocon-version
-          key: xx-hocon-expected-${{ github.run_id }}
+          key: xx-hocon-expected-${{ hashFiles('.xx-hocon-version') }}
           restore-keys: xx-hocon-expected-
 
       - name: Fetch expected JSON

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ docs/
 
 # Superpowers (development process artifacts)
 docs/superpowers/
+
+# Fetched testdata (from xx.hocon)
+tests/lightbend/testdata/expected/

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ docs/superpowers/
 
 # Fetched testdata (from xx.hocon)
 tests/lightbend/testdata/expected/
+.xx-hocon-version

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,21 @@ EXPECTED_DIR   := tests/lightbend/testdata/expected
 .PHONY: testdata test
 
 testdata:
-	@echo "Fetching expected JSON from $(TESTDATA_REPO)@$(TESTDATA_REF)..."
-	@tmpdir="$$(mktemp -d)"; \
+	@if [ -f .xx-hocon-version ] && [ -d "$(EXPECTED_DIR)" ]; then \
+	  remote_sha=$$(curl -s "https://api.github.com/repos/$(TESTDATA_REPO)/commits/$(TESTDATA_REF)" | grep '"sha"' | head -1 | cut -d'"' -f4); \
+	  local_sha=$$(cat .xx-hocon-version); \
+	  if [ "$$remote_sha" = "$$local_sha" ]; then \
+	    echo "Expected JSON up to date ($$local_sha)"; exit 0; \
+	  fi; \
+	fi; \
+	tmpdir="$$(mktemp -d)"; \
 	trap 'rm -rf "$$tmpdir"' EXIT INT TERM; \
 	mkdir -p "$(EXPECTED_DIR)"; \
 	curl -sL "https://github.com/$(TESTDATA_REPO)/archive/$(TESTDATA_REF).tar.gz" -o "$$tmpdir/archive.tar.gz"; \
 	tar xzf "$$tmpdir/archive.tar.gz" -C "$$tmpdir" --strip-components=1; \
 	cp -R "$$tmpdir/expected/hocon/." "$(EXPECTED_DIR)/"; \
-	echo "Done."
+	curl -s "https://api.github.com/repos/$(TESTDATA_REPO)/commits/$(TESTDATA_REF)" | grep '"sha"' | head -1 | cut -d'"' -f4 > .xx-hocon-version; \
+	echo "Done. Fetched $$(cat .xx-hocon-version)"
 
 test:
 	npx vitest run

--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,13 @@ EXPECTED_DIR   := tests/lightbend/testdata/expected
 
 testdata:
 	@echo "Fetching expected JSON from $(TESTDATA_REPO)@$(TESTDATA_REF)..."
-	@rm -rf /tmp/xx-hocon-dl
-	@mkdir -p /tmp/xx-hocon-dl $(EXPECTED_DIR)
-	@gh api repos/$(TESTDATA_REPO)/tarball/$(TESTDATA_REF) > /tmp/xx-hocon-dl/archive.tar.gz
-	@tar xzf /tmp/xx-hocon-dl/archive.tar.gz -C /tmp/xx-hocon-dl --strip-components=1
-	@rsync -a /tmp/xx-hocon-dl/expected/hocon/ $(EXPECTED_DIR)/
-	@rm -rf /tmp/xx-hocon-dl
-	@echo "Done."
+	@tmpdir="$$(mktemp -d)"; \
+	trap 'rm -rf "$$tmpdir"' EXIT INT TERM; \
+	mkdir -p "$(EXPECTED_DIR)"; \
+	curl -sL "https://github.com/$(TESTDATA_REPO)/archive/$(TESTDATA_REF).tar.gz" -o "$$tmpdir/archive.tar.gz"; \
+	tar xzf "$$tmpdir/archive.tar.gz" -C "$$tmpdir" --strip-components=1; \
+	cp -R "$$tmpdir/expected/hocon/." "$(EXPECTED_DIR)/"; \
+	echo "Done."
 
-test: testdata
+test:
 	npx vitest run

--- a/Makefile
+++ b/Makefile
@@ -6,19 +6,19 @@ EXPECTED_DIR   := tests/lightbend/testdata/expected
 
 testdata:
 	@if [ -f .xx-hocon-version ] && [ -d "$(EXPECTED_DIR)" ]; then \
-	  remote_sha=$$(curl -s "https://api.github.com/repos/$(TESTDATA_REPO)/commits/$(TESTDATA_REF)" | grep '"sha"' | head -1 | cut -d'"' -f4); \
-	  local_sha=$$(cat .xx-hocon-version); \
+	  remote_sha=$$(curl -sf "https://api.github.com/repos/$(TESTDATA_REPO)/commits/$(TESTDATA_REF)" | grep '"sha"' | head -1 | cut -d'"' -f4) && \
+	  local_sha=$$(cat .xx-hocon-version) && \
 	  if [ "$$remote_sha" = "$$local_sha" ]; then \
 	    echo "Expected JSON up to date ($$local_sha)"; exit 0; \
 	  fi; \
 	fi; \
-	tmpdir="$$(mktemp -d)"; \
-	trap 'rm -rf "$$tmpdir"' EXIT INT TERM; \
-	mkdir -p "$(EXPECTED_DIR)"; \
-	curl -sL "https://github.com/$(TESTDATA_REPO)/archive/$(TESTDATA_REF).tar.gz" -o "$$tmpdir/archive.tar.gz"; \
-	tar xzf "$$tmpdir/archive.tar.gz" -C "$$tmpdir" --strip-components=1; \
-	cp -R "$$tmpdir/expected/hocon/." "$(EXPECTED_DIR)/"; \
-	curl -s "https://api.github.com/repos/$(TESTDATA_REPO)/commits/$(TESTDATA_REF)" | grep '"sha"' | head -1 | cut -d'"' -f4 > .xx-hocon-version; \
+	tmpdir="$$(mktemp -d)" && \
+	trap 'rm -rf "$$tmpdir"' EXIT INT TERM && \
+	mkdir -p "$(EXPECTED_DIR)" && \
+	curl -sfL "https://github.com/$(TESTDATA_REPO)/archive/$(TESTDATA_REF).tar.gz" -o "$$tmpdir/archive.tar.gz" && \
+	tar xzf "$$tmpdir/archive.tar.gz" -C "$$tmpdir" --strip-components=1 && \
+	cp -R "$$tmpdir/expected/hocon/." "$(EXPECTED_DIR)/" && \
+	curl -sf "https://api.github.com/repos/$(TESTDATA_REPO)/commits/$(TESTDATA_REF)" | grep '"sha"' | head -1 | cut -d'"' -f4 > .xx-hocon-version && \
 	echo "Done. Fetched $$(cat .xx-hocon-version)"
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+TESTDATA_REPO  := o3co/xx.hocon
+TESTDATA_REF   := main
+EXPECTED_DIR   := tests/lightbend/testdata/expected
+
+.PHONY: testdata test
+
+testdata:
+	@echo "Fetching expected JSON from $(TESTDATA_REPO)@$(TESTDATA_REF)..."
+	@rm -rf /tmp/xx-hocon-dl
+	@mkdir -p /tmp/xx-hocon-dl $(EXPECTED_DIR)
+	@gh api repos/$(TESTDATA_REPO)/tarball/$(TESTDATA_REF) > /tmp/xx-hocon-dl/archive.tar.gz
+	@tar xzf /tmp/xx-hocon-dl/archive.tar.gz -C /tmp/xx-hocon-dl --strip-components=1
+	@rsync -a /tmp/xx-hocon-dl/expected/hocon/ $(EXPECTED_DIR)/
+	@rm -rf /tmp/xx-hocon-dl
+	@echo "Done."
+
+test: testdata
+	npx vitest run

--- a/tests/lightbend/lightbend.test.ts
+++ b/tests/lightbend/lightbend.test.ts
@@ -21,7 +21,7 @@ describe('Lightbend HOCON equiv tests', () => {
     if (!existsSync(jsonPath)) continue
 
     const expected = JSON.parse(readFileSync(jsonPath, 'utf-8'))
-    const entries = readdirSync(dir)
+    const entries = readdirSync(dir).sort()
 
     for (const entry of entries) {
       if (!entry.endsWith('.conf')) continue
@@ -41,8 +41,7 @@ describe('Lightbend HOCON equiv tests', () => {
 describe('Lightbend HOCON suite tests (expected JSON)', () => {
   const expectedDir = join(dataDir, 'expected')
   if (!existsSync(expectedDir)) {
-    it.skip('expected JSON not found — run `make testdata` first', () => {})
-    return
+    throw new Error(`Missing expected JSON fixtures at ${expectedDir}. Run \`make testdata\` first.`)
   }
 
   // Known failures — skip these with reasons
@@ -54,12 +53,17 @@ describe('Lightbend HOCON suite tests (expected JSON)', () => {
     'test10-expected.json',        // nested include substitution scope
   ])
 
-  const entries = readdirSync(expectedDir)
+  const entries = readdirSync(expectedDir).sort()
   for (const entry of entries) {
     if (!entry.endsWith('-expected.json') || entry.includes('-expected-error')) continue
-    if (skip.has(entry)) continue
 
     const confName = entry.replace('-expected.json', '.conf')
+
+    if (skip.has(entry)) {
+      it.skip(`${confName} (known failure)`, () => {})
+      continue
+    }
+
     const confPath = join(dataDir, confName)
     if (!existsSync(confPath)) continue
 
@@ -78,9 +82,11 @@ describe('Lightbend HOCON suite tests (expected JSON)', () => {
 
 describe('Lightbend HOCON suite tests (expected errors)', () => {
   const expectedDir = join(dataDir, 'expected')
-  if (!existsSync(expectedDir)) return
+  if (!existsSync(expectedDir)) {
+    throw new Error(`Missing expected JSON fixtures at ${expectedDir}. Run \`make testdata\` first.`)
+  }
 
-  const entries = readdirSync(expectedDir)
+  const entries = readdirSync(expectedDir).sort()
   for (const entry of entries) {
     if (!entry.endsWith('-expected-error.json')) continue
 

--- a/tests/lightbend/lightbend.test.ts
+++ b/tests/lightbend/lightbend.test.ts
@@ -37,3 +37,60 @@ describe('Lightbend HOCON equiv tests', () => {
     }
   }
 })
+
+describe('Lightbend HOCON suite tests (expected JSON)', () => {
+  const expectedDir = join(dataDir, 'expected')
+  if (!existsSync(expectedDir)) {
+    it.skip('expected JSON not found — run `make testdata` first', () => {})
+    return
+  }
+
+  // Known failures — skip these with reasons
+  const skip = new Set([
+    'file-include-expected.json',  // file include resolves extra keys (bar-file, baz) not in expected
+    'test01-expected.json',        // env vars (system.path/pwd) differ per machine; also .33 parsed as number vs string, null handling
+    'test02-expected.json',        // empty-string key substitution ${""."".""}  not resolved
+    'test09-expected.json',        // object merge / += substitution scope differences
+    'test10-expected.json',        // nested include substitution scope
+  ])
+
+  const entries = readdirSync(expectedDir)
+  for (const entry of entries) {
+    if (!entry.endsWith('-expected.json') || entry.includes('-expected-error')) continue
+    if (skip.has(entry)) continue
+
+    const confName = entry.replace('-expected.json', '.conf')
+    const confPath = join(dataDir, confName)
+    if (!existsSync(confPath)) continue
+
+    it(confName, () => {
+      const confContent = readFileSync(confPath, 'utf-8')
+      const config = parse(confContent, { baseDir: dataDir })
+      const got = config.toObject()
+
+      const expectedContent = readFileSync(join(expectedDir, entry), 'utf-8')
+      const expected = JSON.parse(expectedContent)
+
+      expect(got).toEqual(expected)
+    })
+  }
+})
+
+describe('Lightbend HOCON suite tests (expected errors)', () => {
+  const expectedDir = join(dataDir, 'expected')
+  if (!existsSync(expectedDir)) return
+
+  const entries = readdirSync(expectedDir)
+  for (const entry of entries) {
+    if (!entry.endsWith('-expected-error.json')) continue
+
+    const confName = entry.replace('-expected-error.json', '.conf')
+    const confPath = join(dataDir, confName)
+    if (!existsSync(confPath)) continue
+
+    it(`${confName} should error`, () => {
+      const confContent = readFileSync(confPath, 'utf-8')
+      expect(() => parse(confContent, { baseDir: dataDir })).toThrow()
+    })
+  }
+})


### PR DESCRIPTION
## Summary
- Add `make testdata` to fetch expected JSON from [o3co/xx.hocon](https://github.com/o3co/xx.hocon)
- Add `Lightbend HOCON suite tests (expected JSON)` and `(expected errors)` describe blocks
- 10 JSON comparison tests pass, 2 error tests pass, 5 skipped (known issues)

## Discovered issues
- test02: empty-string key substitution not resolved
- test09: object merge via substitution doesn't propagate all fields
- test01: env-dependent values + `.33` parsed as number instead of string
- file-include: resolves extra keys vs reference implementation

## Test plan
- [x] `make testdata` fetches expected JSON
- [x] `npx vitest run tests/lightbend/` passes (all 25 tests)
- [x] Full test suite passes with zero regressions (311 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)