### PR TITLE
fix: implement delayed merge for objects with prior substitution values (#43)

### DIFF
--- a/src/internal/resolver/resolver.ts
+++ b/src/internal/resolver/resolver.ts
@@ -308,8 +308,11 @@ function resolveSubst(
       // Delayed merge in substitution context: if the resolved value is an object
       // and there's a prior value for the root segment that also resolves to an object,
       // deep merge them (prior as base, current on top).
-      if (result !== undefined && result.kind === 'object') {
-        const rootSeg = parseSubstPath(s.path)[0] ?? ''
+      // Only for single-segment paths — multi-segment paths (e.g. ${a.b}) would
+      // incorrectly merge the prior of "a" into the resolved value of "a.b".
+      const segments = parseSubstPath(s.path)
+      if (segments.length === 1 && result !== undefined && result.kind === 'object') {
+        const rootSeg = segments[0] ?? ''
         const prior = scope.priorValues.get(rootSeg) ?? root.priorValues.get(rootSeg)
         if (prior !== undefined) {
           const priorResolved = resolveVal(prior, scope, root, resolving, resolvedCache, opts)

--- a/src/internal/resolver/resolver.ts
+++ b/src/internal/resolver/resolver.ts
@@ -206,6 +206,20 @@ function resolveResObj(
   for (const [key, val] of obj.fields) {
     const resolved = resolveVal(val, obj, root, resolving, resolvedCache, opts)
     if (resolved !== undefined) {
+      // Delayed merge: if both current and prior resolve to objects, deep merge
+      if (resolved.kind === 'object') {
+        const prior = obj.priorValues.get(key)
+        if (prior !== undefined) {
+          const priorResolved = resolveVal(prior, obj, root, resolving, resolvedCache, opts)
+          if (priorResolved !== undefined && priorResolved.kind === 'object') {
+            result.set(key, deepMergeHoconValues(
+              priorResolved as HoconValue & { kind: 'object' },
+              resolved as HoconValue & { kind: 'object' },
+            ))
+            continue
+          }
+        }
+      }
       result.set(key, resolved)
     } else {
       // Unresolved optional substitution: fall back to prior value per HOCON spec
@@ -272,18 +286,41 @@ function resolveSubst(
   try {
     const found = lookupPath(root, parseSubstPath(s.path))
     if (found !== undefined) {
-      // If the found value is still a subst/concat placeholder pointing at itself,
-      // use the prior value (self-referential overwrite case).
+      // Only fall back to prior value for actual self-referential substitutions
+      // (e.g. b=${b}), not for any substitution found during lookup.
       if (isSubst(found) || isConcat(found)) {
+        const isSelfRef = isSubst(found)
+          ? found.path === s.path
+          : isConcat(found) && found.nodes.some(
+              (n: ResolverValue) => isSubst(n) && n.path === s.path
+            )
+        if (isSelfRef) {
+          const rootSeg = parseSubstPath(s.path)[0] ?? ''
+          const prior = scope.priorValues.get(rootSeg) ?? root.priorValues.get(rootSeg)
+          if (prior !== undefined) {
+            const result = resolveVal(prior, scope, root, resolving, resolvedCache, opts)
+            if (result !== undefined) resolvedCache.set(s.path, result)
+            return result
+          }
+        }
+      }
+      let result = resolveVal(found, scope, root, resolving, resolvedCache, opts)
+      // Delayed merge in substitution context: if the resolved value is an object
+      // and there's a prior value for the root segment that also resolves to an object,
+      // deep merge them (prior as base, current on top).
+      if (result !== undefined && result.kind === 'object') {
         const rootSeg = parseSubstPath(s.path)[0] ?? ''
         const prior = scope.priorValues.get(rootSeg) ?? root.priorValues.get(rootSeg)
         if (prior !== undefined) {
-          const result = resolveVal(prior, scope, root, resolving, resolvedCache, opts)
-          if (result !== undefined) resolvedCache.set(s.path, result)
-          return result
+          const priorResolved = resolveVal(prior, scope, root, resolving, resolvedCache, opts)
+          if (priorResolved !== undefined && priorResolved.kind === 'object') {
+            result = deepMergeHoconValues(
+              priorResolved as HoconValue & { kind: 'object' },
+              result as HoconValue & { kind: 'object' },
+            )
+          }
         }
       }
-      const result = resolveVal(found, scope, root, resolving, resolvedCache, opts)
       if (result !== undefined) resolvedCache.set(s.path, result)
       return result
     }

--- a/tests/lightbend/lightbend.test.ts
+++ b/tests/lightbend/lightbend.test.ts
@@ -49,7 +49,6 @@ describe('Lightbend HOCON suite tests (expected JSON)', () => {
     'file-include-expected.json',  // file include resolves extra keys (bar-file, baz) not in expected
     'test01-expected.json',        // env vars (system.path/pwd) differ per machine; also .33 parsed as number vs string, null handling
     'test02-expected.json',        // empty-string key substitution ${""."".""}  not resolved
-    'test09-expected.json',        // object merge / += substitution scope differences
     'test10-expected.json',        // nested include substitution scope
   ])
 

--- a/tests/resolver.test.ts
+++ b/tests/resolver.test.ts
@@ -208,6 +208,34 @@ describe('Resolver - object concatenation deep merge', () => {
   })
 })
 
+describe('Resolver - delayed merge', () => {
+  it('delayed merge: object with substitution merges fields', () => {
+    const v = resolveStr('x={q:10}\na=${x}\na={c:3}')
+    const a = obj(v).get('a')
+    if (a?.kind !== 'object') throw new Error('expected object')
+    expect(a.fields.get('q')).toEqual({ kind: 'scalar', value: 10 })
+    expect(a.fields.get('c')).toEqual({ kind: 'scalar', value: 3 })
+  })
+
+  it('last assignment wins for non-self-referential substitution', () => {
+    const v = resolveStr('x={q:10}\ny=5\nb=${x}\nb=${y}')
+    expect(obj(v).get('b')).toEqual({ kind: 'scalar', value: 5 })
+  })
+
+  it('delayed merge with nested reference (c.e=${a})', () => {
+    const v = resolveStr('x={q:10}\ny=5\na=${x}\na={c:3}\nc=${x}\nc={d:600, e:${a}, f:${b}}\nb=${x}\nb=${y}')
+    const c = obj(v).get('c')
+    if (c?.kind !== 'object') throw new Error('expected object')
+    expect(c.fields.get('q')).toEqual({ kind: 'scalar', value: 10 })
+    expect(c.fields.get('d')).toEqual({ kind: 'scalar', value: 600 })
+    const e = c.fields.get('e')
+    if (e?.kind !== 'object') throw new Error('expected object for c.e')
+    expect(e.fields.get('q')).toEqual({ kind: 'scalar', value: 10 })
+    expect(e.fields.get('c')).toEqual({ kind: 'scalar', value: 3 })
+    expect(c.fields.get('f')).toEqual({ kind: 'scalar', value: 5 })
+  })
+})
+
 describe('Resolver - include', () => {
   function resolveWithFs(input: string, files: Record<string, string>): HoconValue {
     const ast = parseTokens(tokenize(input))


### PR DESCRIPTION
## Summary
- Fix self-referential substitution detection: only fall back to priorValues when the substitution path actually matches
- Implement delayed merge in resolveResObj AND resolveSubst: when both current and prior resolve to objects, deep merge them
- test09 conformance now passes against Lightbend reference expected JSON

## Test plan
- [x] 3 new delayed merge tests pass
- [x] Lightbend test09 expected JSON comparison passes
- [x] Full test suite (315 tests) passes with zero regressions

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)