### PR TITLE
refactor: convert lexer and parser to class-based architecture (#51)

### DIFF
--- a/src/internal/lexer/lexer.ts
+++ b/src/internal/lexer/lexer.ts
@@ -1,6 +1,15 @@
 import { ParseError } from '../../errors.js'
 import type { Token, TokenKind } from './token.js'
 
+const SINGLE_CHAR_TOKENS: Record<string, TokenKind> = {
+  '{': 'lbrace',
+  '}': 'rbrace',
+  '[': 'lbracket',
+  ']': 'rbracket',
+  ',': 'comma',
+  ':': 'colon',
+}
+
 class Lexer {
   private pos = 0
   private line = 1
@@ -42,8 +51,7 @@ class Lexer {
       }
 
       // Single-char punctuation
-      const single: Record<string, TokenKind> = { '{': 'lbrace', '}': 'rbrace', '[': 'lbracket', ']': 'rbracket', ',': 'comma', ':': 'colon' }
-      if (ch in single) { this.advance(); this.push(single[ch] as TokenKind, ch, sl, sc); continue }
+      if (ch in SINGLE_CHAR_TOKENS) { this.advance(); this.push(SINGLE_CHAR_TOKENS[ch], ch, sl, sc); continue }
 
       // = and +=
       if (ch === '=') { this.advance(); this.push('equals', '=', sl, sc); continue }

--- a/src/internal/lexer/lexer.ts
+++ b/src/internal/lexer/lexer.ts
@@ -1,171 +1,179 @@
 import { ParseError } from '../../errors.js'
 import type { Token, TokenKind } from './token.js'
 
-export function tokenize(input: string): Token[] {
-  if (input.charCodeAt(0) === 0xfeff) input = input.slice(1)
+class Lexer {
+  private pos = 0
+  private line = 1
+  private col = 1
+  private hadSpace = false
+  private tokens: Token[] = []
 
-  const tokens: Token[] = []
-  let pos = 0
-  let line = 1
-  let col = 1
-  let hadSpace = false
+  constructor(private input: string) {
+    if (input.charCodeAt(0) === 0xfeff) this.input = input.slice(1)
+  }
 
-  function peek(offset = 0): string { return input[pos + offset] ?? '' }
+  tokenize(): Token[] {
+    while (this.pos < this.input.length) {
+      const sl = this.line, sc = this.col
+      const ch = this.peek()
 
-  function advance(): string {
-    const ch = input[pos++] ?? ''
-    if (ch === '\n') { line++; col = 1 } else { col++ }
+      // Whitespace (not newline)
+      if (ch === ' ' || ch === '\t' || ch === '\r') {
+        this.advance(); this.hadSpace = true; continue
+      }
+
+      // Newline
+      if (ch === '\n') {
+        this.advance()
+        if (this.tokens[this.tokens.length - 1]?.kind !== 'newline') {
+          this.push('newline', '\n', sl, sc)
+        }
+        continue
+      }
+
+      // Comments
+      if (ch === '/' && this.peek(1) === '/') {
+        while (this.pos < this.input.length && this.peek() !== '\n') this.advance()
+        this.hadSpace = true; continue
+      }
+      if (ch === '#') {
+        while (this.pos < this.input.length && this.peek() !== '\n') this.advance()
+        this.hadSpace = true; continue
+      }
+
+      // Single-char punctuation
+      const single: Record<string, TokenKind> = { '{': 'lbrace', '}': 'rbrace', '[': 'lbracket', ']': 'rbracket', ',': 'comma', ':': 'colon' }
+      if (ch in single) { this.advance(); this.push(single[ch] as TokenKind, ch, sl, sc); continue }
+
+      // = and +=
+      if (ch === '=') { this.advance(); this.push('equals', '=', sl, sc); continue }
+      if (ch === '+' && this.peek(1) === '=') { this.advance(); this.advance(); this.push('plus_equals', '+=', sl, sc); continue }
+
+      // Substitution ${...} or ${?...}
+      if (ch === '$' && this.peek(1) === '{') {
+        this.advance(); this.advance()
+        const optional = this.peek() === '?'
+        if (optional) this.advance()
+        let path = ''
+        while (this.pos < this.input.length && this.peek() !== '}') {
+          if (this.peek() === '\n') throw new ParseError('unterminated substitution', sl, sc)
+          path += this.advance()
+        }
+        if (this.peek() !== '}') throw new ParseError('unterminated substitution', sl, sc)
+        this.advance()
+        this.push(optional ? 'opt_subst' : 'subst', path.trim(), sl, sc)
+        continue
+      }
+
+      // Triple-quoted string
+      if (ch === '"' && this.peek(1) === '"' && this.peek(2) === '"') {
+        this.advance(); this.advance(); this.advance()
+        let value = ''
+        let closed = false
+        while (this.pos < this.input.length) {
+          if (this.peek() === '"') {
+            // Count consecutive quotes
+            let quoteCount = 0
+            while (this.pos < this.input.length && this.peek() === '"') {
+              quoteCount++
+              this.advance()
+            }
+            if (quoteCount >= 3) {
+              // Last 3 quotes are the closing delimiter; extras are content
+              for (let i = 0; i < quoteCount - 3; i++) value += '"'
+              closed = true
+              break
+            }
+            // Fewer than 3 quotes — they are content
+            for (let i = 0; i < quoteCount; i++) value += '"'
+            continue
+          }
+          value += this.advance()
+        }
+        if (!closed) {
+          throw new ParseError('unterminated triple-quoted string', sl, sc)
+        }
+        if (value.startsWith('\n')) value = value.slice(1)
+        this.push('triple_string', value, sl, sc, true)
+        continue
+      }
+
+      // Quoted string
+      if (ch === '"') {
+        this.advance()
+        let value = ''
+        while (this.pos < this.input.length && this.peek() !== '"') {
+          if (this.peek() === '\n') throw new ParseError('unterminated string', sl, sc)
+          if (this.peek() === '\\') {
+            this.advance()
+            const esc = this.advance()
+            switch (esc) {
+              case 'n': value += '\n'; break
+              case 't': value += '\t'; break
+              case 'r': value += '\r'; break
+              case '"': value += '"'; break
+              case '\\': value += '\\'; break
+              case '/': value += '/'; break
+              case 'b': value += '\b'; break
+              case 'f': value += '\f'; break
+              case 'u': {
+                if (this.pos + 4 > this.input.length) {
+                  throw new ParseError('Invalid unicode escape: not enough characters', this.line, this.col)
+                }
+                const hex = this.input.slice(this.pos, this.pos + 4)
+                if (!/^[0-9a-fA-F]{4}$/.test(hex)) {
+                  throw new ParseError(`Invalid unicode escape: \\u${hex}`, this.line, this.col)
+                }
+                value += String.fromCharCode(parseInt(hex, 16))
+                for (let i = 0; i < 4; i++) this.advance()
+                break
+              }
+              default:
+                throw new ParseError(`Unknown escape sequence: \\${esc}`, this.line, this.col)
+            }
+          } else {
+            value += this.advance()
+          }
+        }
+        if (this.peek() !== '"') throw new ParseError('unterminated string', sl, sc)
+        this.advance()
+        this.push('string', value, sl, sc, true)
+        continue
+      }
+
+      // Unquoted string (stops at terminators and $)
+      if (isUnquotedStart(ch)) {
+        let value = ''
+        while (this.pos < this.input.length && isUnquotedContinue(this.peek(), () => this.peek(1))) {
+          value += this.advance()
+        }
+        this.push('unquoted', value.trimEnd(), sl, sc)
+        continue
+      }
+
+      throw new ParseError(`unexpected character: ${JSON.stringify(ch)}`, sl, sc)
+    }
+
+    this.tokens.push({ kind: 'eof', value: '', line: this.line, col: this.col, isQuoted: false, precedingSpace: false })
+    return this.tokens
+  }
+
+  private peek(offset = 0): string { return this.input[this.pos + offset] ?? '' }
+
+  private advance(): string {
+    const ch = this.input[this.pos++] ?? ''
+    if (ch === '\n') { this.line++; this.col = 1 } else { this.col++ }
     return ch
   }
 
-  function push(kind: TokenKind, value: string, l: number, c: number, isQuoted = false): void {
-    tokens.push({ kind, value, line: l, col: c, isQuoted, precedingSpace: hadSpace })
-    hadSpace = false
+  private push(kind: TokenKind, value: string, l: number, c: number, isQuoted = false): void {
+    this.tokens.push({ kind, value, line: l, col: c, isQuoted, precedingSpace: this.hadSpace })
+    this.hadSpace = false
   }
+}
 
-  while (pos < input.length) {
-    const sl = line, sc = col
-    const ch = peek()
-
-    // Whitespace (not newline)
-    if (ch === ' ' || ch === '\t' || ch === '\r') {
-      advance(); hadSpace = true; continue
-    }
-
-    // Newline
-    if (ch === '\n') {
-      advance()
-      if (tokens[tokens.length - 1]?.kind !== 'newline') {
-        push('newline', '\n', sl, sc)
-      }
-      continue
-    }
-
-    // Comments
-    if (ch === '/' && peek(1) === '/') {
-      while (pos < input.length && peek() !== '\n') advance()
-      hadSpace = true; continue
-    }
-    if (ch === '#') {
-      while (pos < input.length && peek() !== '\n') advance()
-      hadSpace = true; continue
-    }
-
-    // Single-char punctuation
-    const single: Record<string, TokenKind> = { '{': 'lbrace', '}': 'rbrace', '[': 'lbracket', ']': 'rbracket', ',': 'comma', ':': 'colon' }
-    if (ch in single) { advance(); push(single[ch] as TokenKind, ch, sl, sc); continue }
-
-    // = and +=
-    if (ch === '=') { advance(); push('equals', '=', sl, sc); continue }
-    if (ch === '+' && peek(1) === '=') { advance(); advance(); push('plus_equals', '+=', sl, sc); continue }
-
-    // Substitution ${...} or ${?...}
-    if (ch === '$' && peek(1) === '{') {
-      advance(); advance()
-      const optional = peek() === '?'
-      if (optional) advance()
-      let path = ''
-      while (pos < input.length && peek() !== '}') {
-        if (peek() === '\n') throw new ParseError('unterminated substitution', sl, sc)
-        path += advance()
-      }
-      if (peek() !== '}') throw new ParseError('unterminated substitution', sl, sc)
-      advance()
-      push(optional ? 'opt_subst' : 'subst', path.trim(), sl, sc)
-      continue
-    }
-
-    // Triple-quoted string
-    if (ch === '"' && peek(1) === '"' && peek(2) === '"') {
-      advance(); advance(); advance()
-      let value = ''
-      let closed = false
-      while (pos < input.length) {
-        if (peek() === '"') {
-          // Count consecutive quotes
-          let quoteCount = 0
-          while (pos < input.length && peek() === '"') {
-            quoteCount++
-            advance()
-          }
-          if (quoteCount >= 3) {
-            // Last 3 quotes are the closing delimiter; extras are content
-            for (let i = 0; i < quoteCount - 3; i++) value += '"'
-            closed = true
-            break
-          }
-          // Fewer than 3 quotes — they are content
-          for (let i = 0; i < quoteCount; i++) value += '"'
-          continue
-        }
-        value += advance()
-      }
-      if (!closed) {
-        throw new ParseError('unterminated triple-quoted string', sl, sc)
-      }
-      if (value.startsWith('\n')) value = value.slice(1)
-      push('triple_string', value, sl, sc, true)
-      continue
-    }
-
-    // Quoted string
-    if (ch === '"') {
-      advance()
-      let value = ''
-      while (pos < input.length && peek() !== '"') {
-        if (peek() === '\n') throw new ParseError('unterminated string', sl, sc)
-        if (peek() === '\\') {
-          advance()
-          const esc = advance()
-          switch (esc) {
-            case 'n': value += '\n'; break
-            case 't': value += '\t'; break
-            case 'r': value += '\r'; break
-            case '"': value += '"'; break
-            case '\\': value += '\\'; break
-            case '/': value += '/'; break
-            case 'b': value += '\b'; break
-            case 'f': value += '\f'; break
-            case 'u': {
-              if (pos + 4 > input.length) {
-                throw new ParseError('Invalid unicode escape: not enough characters', line, col)
-              }
-              const hex = input.slice(pos, pos + 4)
-              if (!/^[0-9a-fA-F]{4}$/.test(hex)) {
-                throw new ParseError(`Invalid unicode escape: \\u${hex}`, line, col)
-              }
-              value += String.fromCharCode(parseInt(hex, 16))
-              for (let i = 0; i < 4; i++) advance()
-              break
-            }
-            default:
-              throw new ParseError(`Unknown escape sequence: \\${esc}`, line, col)
-          }
-        } else {
-          value += advance()
-        }
-      }
-      if (peek() !== '"') throw new ParseError('unterminated string', sl, sc)
-      advance()
-      push('string', value, sl, sc, true)
-      continue
-    }
-
-    // Unquoted string (stops at terminators and $)
-    if (isUnquotedStart(ch)) {
-      let value = ''
-      while (pos < input.length && isUnquotedContinue(peek(), () => peek(1))) {
-        value += advance()
-      }
-      push('unquoted', value.trimEnd(), sl, sc)
-      continue
-    }
-
-    throw new ParseError(`unexpected character: ${JSON.stringify(ch)}`, sl, sc)
-  }
-
-  tokens.push({ kind: 'eof', value: '', line, col, isQuoted: false, precedingSpace: false })
-  return tokens
+export function tokenize(input: string): Token[] {
+  return new Lexer(input).tokenize()
 }
 
 function isUnquotedStart(ch: string): boolean {

--- a/src/internal/parser/parser.ts
+++ b/src/internal/parser/parser.ts
@@ -48,7 +48,7 @@ class Parser {
     return this.parseObject(false)
   }
 
-  private peek(): Token { return this.tokens[this.pos] ?? EOF_TOKEN }
+  private peek(offset = 0): Token { return this.tokens[this.pos + offset] ?? EOF_TOKEN }
   private advance(): Token {
     const t = this.tokens[this.pos]
     if (this.pos < this.tokens.length) this.pos++
@@ -172,7 +172,7 @@ class Parser {
 
       // Reject bare `required` without a following `(`: e.g. `include required "file.conf"`
       if (t.value === 'required') {
-        const next = this.tokens[this.pos + 1] ?? { kind: 'eof', value: '' }
+        const next = this.peek(1)
         if (next.kind !== 'unquoted' || !next.value.startsWith('(')) {
           throw new ParseError('include required must be followed by (', t.line, t.col)
         }

--- a/src/internal/parser/parser.ts
+++ b/src/internal/parser/parser.ts
@@ -2,90 +2,133 @@ import { ParseError } from '../../errors.js'
 import type { Token } from '../lexer/token.js'
 import type { AstNode, AstField, Pos } from './ast.js'
 
-export function parseTokens(tokens: Token[]): AstNode {
-  let pos = 0
+const EOF_TOKEN: Token = { kind: 'eof', value: '', line: 0, col: 0, isQuoted: false, precedingSpace: false }
 
-  function peek(): Token { return tokens[pos] ?? { kind: 'eof', value: '', line: 0, col: 0, isQuoted: false, precedingSpace: false } }
-  function advance(): Token {
-    const t = tokens[pos]
-    if (pos < tokens.length) pos++
-    return t ?? { kind: 'eof', value: '', line: 0, col: 0, isQuoted: false, precedingSpace: false }
-  }
-  function skip(...kinds: string[]): void {
-    while (kinds.includes(peek().kind)) advance()
+class Parser {
+  private pos = 0
+
+  constructor(private tokens: Token[]) {}
+
+  parse(): AstNode {
+    this.skip('newline')
+    const t = this.peek()
+    if (t.kind === 'lbrace') {
+      // Braced root: parse first braced object, then continue parsing
+      // any trailing content as additional root fields to merge (per HOCON spec,
+      // root is always an object and content after } is still part of the root).
+      this.advance()
+      const first = this.parseObject(true)
+      const allFields = first.kind === 'object' ? [...first.fields] : []
+
+      // Merge any additional braced objects or unbraced key-value content
+      while (true) {
+        this.skip('newline')
+        if (this.peek().kind === 'eof') break
+        if (this.peek().kind === 'lbrace') {
+          this.advance()
+          const extra = this.parseObject(true)
+          if (extra.kind === 'object') allFields.push(...extra.fields)
+        } else {
+          // Remaining tokens are unbraced root content (key-value pairs, includes)
+          const rest = this.parseObject(false)
+          if (rest.kind === 'object') allFields.push(...rest.fields)
+          break
+        }
+      }
+
+      // After merge loop, verify no remaining non-EOF tokens (e.g. stray `}`)
+      this.skip('newline')
+      const remaining = this.peek()
+      if (remaining.kind !== 'eof') {
+        throw new ParseError(`Unexpected token '${remaining.value}' after closing brace`, remaining.line, remaining.col)
+      }
+
+      return { kind: 'object', fields: allFields, pos: first.pos }
+    }
+    return this.parseObject(false)
   }
 
-  function currentPos(): Pos {
-    const t = peek()
+  private peek(): Token { return this.tokens[this.pos] ?? EOF_TOKEN }
+  private advance(): Token {
+    const t = this.tokens[this.pos]
+    if (this.pos < this.tokens.length) this.pos++
+    return t ?? EOF_TOKEN
+  }
+  private skip(...kinds: string[]): void {
+    while (kinds.includes(this.peek().kind)) this.advance()
+  }
+
+  private currentPos(): Pos {
+    const t = this.peek()
     return { line: t.line, col: t.col }
   }
 
-  function parseObject(expectClosingBrace: boolean): AstNode {
-    const p = currentPos()
+  private parseObject(expectClosingBrace: boolean): AstNode {
+    const p = this.currentPos()
     const fields: AstField[] = []
 
     while (true) {
-      skip('newline')
-      const t = peek()
+      this.skip('newline')
+      const t = this.peek()
       if (t.kind === 'eof' || t.kind === 'rbrace') break
 
       // include directive
       if (t.kind === 'unquoted' && t.value === 'include') {
-        advance()
-        fields.push(parseInclude())
+        this.advance()
+        fields.push(this.parseInclude())
         // trailing separator after include
-        skip('newline')
-        if (peek().kind === 'comma') advance()
-        skip('newline')
+        this.skip('newline')
+        if (this.peek().kind === 'comma') this.advance()
+        this.skip('newline')
         continue
       }
 
       // key
-      const keyPos = currentPos()
-      const key = parseKey()
+      const keyPos = this.currentPos()
+      const key = this.parseKey()
 
       // value separator (optional)
-      skip('newline')
+      this.skip('newline')
       let append = false
-      const sep = peek()
-      if (sep.kind === 'equals') advance()
-      else if (sep.kind === 'plus_equals') { advance(); append = true }
-      else if (sep.kind === 'colon') advance()
+      const sep = this.peek()
+      if (sep.kind === 'equals') this.advance()
+      else if (sep.kind === 'plus_equals') { this.advance(); append = true }
+      else if (sep.kind === 'colon') this.advance()
       else if (sep.kind === 'lbrace') { /* key { ... } shorthand — no advance, value parser handles it */ }
       else if (sep.kind !== 'newline' && sep.kind !== 'eof') {
         throw new ParseError(`unexpected token after key: ${sep.kind}`, sep.line, sep.col)
       }
 
-      skip('newline')
-      const value = parseValue()
+      this.skip('newline')
+      const value = this.parseValue()
       fields.push({ key, value, append, pos: keyPos })
 
       // trailing separator
-      skip('newline')
-      if (peek().kind === 'comma') advance()
-      skip('newline')
+      this.skip('newline')
+      if (this.peek().kind === 'comma') this.advance()
+      this.skip('newline')
     }
 
     if (expectClosingBrace) {
-      const t = peek()
+      const t = this.peek()
       if (t.kind !== 'rbrace') throw new ParseError('expected }', t.line, t.col)
-      advance()
+      this.advance()
     }
 
     return { kind: 'object', fields, pos: p }
   }
 
-  function parseKey(): string[] {
+  private parseKey(): string[] {
     const segments: string[] = []
     let trailingDot = false
     while (true) {
-      const t = peek()
+      const t = this.peek()
       if (t.kind === 'string') {
-        advance()
+        this.advance()
         segments.push(t.value) // quoted: no dot split
         trailingDot = false
       } else if (t.kind === 'unquoted') {
-        advance()
+        this.advance()
         // Split unquoted key at dots
         const parts = t.value.split('.')
         const filtered = parts.filter(s => s.length > 0)
@@ -102,9 +145,9 @@ export function parseTokens(tokens: Token[]): AstNode {
 
       // Check for explicit dot separator between segments (e.g. "a"."b")
       // A lone dot as an unquoted token with no preceding space continues the key
-      const next = peek()
+      const next = this.peek()
       if (next.kind === 'unquoted' && next.value === '.' && !next.precedingSpace) {
-        advance() // consume the dot separator
+        this.advance() // consume the dot separator
         trailingDot = true
         continue
       }
@@ -114,10 +157,10 @@ export function parseTokens(tokens: Token[]): AstNode {
     return segments
   }
 
-  function parseInclude(): AstField {
-    const p = currentPos()
-    skip('newline')
-    const t = peek()
+  private parseInclude(): AstField {
+    const p = this.currentPos()
+    this.skip('newline')
+    const t = this.peek()
     let path: string
     let required = false
 
@@ -129,14 +172,14 @@ export function parseTokens(tokens: Token[]): AstNode {
 
       // Reject bare `required` without a following `(`: e.g. `include required "file.conf"`
       if (t.value === 'required') {
-        const next = tokens[pos + 1] ?? { kind: 'eof', value: '' }
+        const next = this.tokens[this.pos + 1] ?? { kind: 'eof', value: '' }
         if (next.kind !== 'unquoted' || !next.value.startsWith('(')) {
           throw new ParseError('include required must be followed by (', t.line, t.col)
         }
       }
 
       required = true
-      advance()
+      this.advance()
 
       // Check for unsupported url/classpath forms inside required():
       // Case 1 (no space): lexer produced a single token like "required(url(" or "required(classpath("
@@ -145,30 +188,30 @@ export function parseTokens(tokens: Token[]): AstNode {
         throw new ParseError('include url(...) and classpath(...) are not supported', t.line, t.col)
       }
       // Case 2 (with space): next token starts with url/classpath
-      const next = peek()
+      const next = this.peek()
       if (next.kind === 'unquoted' && (next.value === 'url' || next.value.startsWith('url(') ||
           next.value === 'classpath' || next.value.startsWith('classpath('))) {
         throw new ParseError('include url(...) and classpath(...) are not supported', next.line, next.col)
       }
 
       // Skip tokens until we find the quoted path string
-      while (peek().kind !== 'string' && peek().kind !== 'eof') advance()
-      if (peek().kind === 'eof') throw new ParseError('expected include path', t.line, t.col)
-      path = advance().value
+      while (this.peek().kind !== 'string' && this.peek().kind !== 'eof') this.advance()
+      if (this.peek().kind === 'eof') throw new ParseError('expected include path', t.line, t.col)
+      path = this.advance().value
       // Skip closing ) and anything else on this line (but stop at comma — next field)
-      while (peek().kind !== 'newline' && peek().kind !== 'rbrace' && peek().kind !== 'eof' && peek().kind !== 'comma') advance()
+      while (this.peek().kind !== 'newline' && this.peek().kind !== 'rbrace' && this.peek().kind !== 'eof' && this.peek().kind !== 'comma') this.advance()
     } else if (t.kind === 'string') {
       // include "path"
-      path = advance().value
+      path = this.advance().value
     } else if (t.kind === 'unquoted' && (t.value === 'file(' || t.value === 'file')) {
       // include file("path")
-      advance()
+      this.advance()
       // Skip tokens until we find the quoted path string
-      while (peek().kind !== 'string' && peek().kind !== 'eof') advance()
-      if (peek().kind === 'eof') throw new ParseError('expected include path', t.line, t.col)
-      path = advance().value
+      while (this.peek().kind !== 'string' && this.peek().kind !== 'eof') this.advance()
+      if (this.peek().kind === 'eof') throw new ParseError('expected include path', t.line, t.col)
+      path = this.advance().value
       // Skip closing ) and anything else on this line (but stop at comma — next field)
-      while (peek().kind !== 'newline' && peek().kind !== 'rbrace' && peek().kind !== 'eof' && peek().kind !== 'comma') advance()
+      while (this.peek().kind !== 'newline' && this.peek().kind !== 'rbrace' && this.peek().kind !== 'eof' && this.peek().kind !== 'comma') this.advance()
     } else if (t.kind === 'unquoted' && (t.value === 'url' || t.value.startsWith('url('))) {
       throw new ParseError('include url(...) is not supported', t.line, t.col)
     } else if (t.kind === 'unquoted' && (t.value === 'classpath' || t.value.startsWith('classpath('))) {
@@ -185,12 +228,12 @@ export function parseTokens(tokens: Token[]): AstNode {
     }
   }
 
-  function parseValue(): AstNode {
-    const p = currentPos()
+  private parseValue(): AstNode {
+    const p = this.currentPos()
     const parts: AstNode[] = []
 
     while (true) {
-      const t = peek()
+      const t = this.peek()
       if (t.kind === 'eof' || t.kind === 'newline' || t.kind === 'rbrace' || t.kind === 'rbracket' || t.kind === 'comma') break
 
       // If there was whitespace before this token and we already have parts,
@@ -199,24 +242,24 @@ export function parseTokens(tokens: Token[]): AstNode {
 
       let node: AstNode
       if (t.kind === 'lbrace') {
-        advance()
-        node = parseObject(true)
+        this.advance()
+        node = this.parseObject(true)
       } else if (t.kind === 'lbracket') {
-        advance()
-        node = parseArray()
+        this.advance()
+        node = this.parseArray()
       } else if (t.kind === 'subst' || t.kind === 'opt_subst') {
-        advance()
+        this.advance()
         node = { kind: 'subst', path: t.value, optional: t.kind === 'opt_subst', pos: { line: t.line, col: t.col } }
       } else if (t.kind === 'string' || t.kind === 'triple_string') {
-        advance()
+        this.advance()
         node = { kind: 'scalar', value: t.value, pos: { line: t.line, col: t.col } }
       } else if (t.kind === 'unquoted') {
-        advance()
-        node = { kind: 'scalar', value: parseScalarValue(t.value), pos: { line: t.line, col: t.col } }
+        this.advance()
+        node = { kind: 'scalar', value: this.parseScalarValue(t.value), pos: { line: t.line, col: t.col } }
       } else if ((t.kind === 'colon' || t.kind === 'equals') && parts.length > 0) {
         // In value concat context, colon/equals after at least one part are plain string chars
         // e.g.  url = ${host}:/path  or  x = ${a}=b
-        advance()
+        this.advance()
         node = { kind: 'scalar', value: t.value, pos: { line: t.line, col: t.col } }
       } else {
         break
@@ -227,31 +270,31 @@ export function parseTokens(tokens: Token[]): AstNode {
       parts.push(node)
     }
 
-    if (parts.length === 0) throw new ParseError('expected value', peek().line, peek().col)
+    if (parts.length === 0) throw new ParseError('expected value', this.peek().line, this.peek().col)
     if (parts.length === 1) return parts[0]!
     return { kind: 'concat', nodes: parts, pos: p }
   }
 
-  function parseArray(): AstNode {
-    const p = currentPos()
+  private parseArray(): AstNode {
+    const p = this.currentPos()
     const items: AstNode[] = []
 
     while (true) {
-      skip('newline')
-      if (peek().kind === 'rbracket' || peek().kind === 'eof') break
-      items.push(parseValue())
-      skip('newline')
-      if (peek().kind === 'comma') advance()
-      skip('newline')
+      this.skip('newline')
+      if (this.peek().kind === 'rbracket' || this.peek().kind === 'eof') break
+      items.push(this.parseValue())
+      this.skip('newline')
+      if (this.peek().kind === 'comma') this.advance()
+      this.skip('newline')
     }
 
-    const t = peek()
+    const t = this.peek()
     if (t.kind !== 'rbracket') throw new ParseError('expected ]', t.line, t.col)
-    advance()
+    this.advance()
     return { kind: 'array', items, pos: p }
   }
 
-  function parseScalarValue(raw: string): string | number | boolean | null {
+  private parseScalarValue(raw: string): string | number | boolean | null {
     if (raw === 'true') return true
     if (raw === 'false') return false
     if (raw === 'null') return null
@@ -259,41 +302,9 @@ export function parseTokens(tokens: Token[]): AstNode {
     if (!isNaN(n) && raw.trim() !== '') return n
     return raw
   }
+}
 
-  skip('newline')
-  const t = peek()
-  if (t.kind === 'lbrace') {
-    // Braced root: parse first braced object, then continue parsing
-    // any trailing content as additional root fields to merge (per HOCON spec,
-    // root is always an object and content after } is still part of the root).
-    advance()
-    const first = parseObject(true)
-    const allFields = first.kind === 'object' ? [...first.fields] : []
-
-    // Merge any additional braced objects or unbraced key-value content
-    while (true) {
-      skip('newline')
-      if (peek().kind === 'eof') break
-      if (peek().kind === 'lbrace') {
-        advance()
-        const extra = parseObject(true)
-        if (extra.kind === 'object') allFields.push(...extra.fields)
-      } else {
-        // Remaining tokens are unbraced root content (key-value pairs, includes)
-        const rest = parseObject(false)
-        if (rest.kind === 'object') allFields.push(...rest.fields)
-        break
-      }
-    }
-
-    // After merge loop, verify no remaining non-EOF tokens (e.g. stray `}`)
-    skip('newline')
-    const remaining = peek()
-    if (remaining.kind !== 'eof') {
-      throw new ParseError(`Unexpected token '${remaining.value}' after closing brace`, remaining.line, remaining.col)
-    }
-
-    return { kind: 'object', fields: allFields, pos: first.pos }
-  }
-  return parseObject(false)
+// Public API unchanged
+export function parseTokens(tokens: Token[]): AstNode {
+  return new Parser(tokens).parse()
 }


### PR DESCRIPTION
## Summary

Convert lexer and parser from closure-based patterns to class-based architecture, matching the resolver refactor (#25/#50).

### Lexer (`src/internal/lexer/lexer.ts`)
- `Lexer` class with private fields: `pos`, `line`, `col`, `hadSpace`, `tokens`
- Private methods: `peek`, `advance`, `push`
- Public `tokenize(input)` stays as thin wrapper: `new Lexer(input).tokenize()`

### Parser (`src/internal/parser/parser.ts`)
- `Parser` class with private fields: `pos`, `tokens`
- Private methods: `peek`, `advance`, `skip`, `parseObject`, `parseField`, `parseKey`, `parseValue`, etc.
- Public `parseTokens(tokens)` stays as thin wrapper: `new Parser(tokens).parse()`

### Benefits
- Mutable state is explicit via class fields instead of hidden in closures
- Methods are testable independently
- Consistent with resolver's class-based architecture

## Test plan
- [x] All 319 tests pass after lexer refactor
- [x] All 319 tests pass after parser refactor
- [x] No public API changes

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)