### PR TITLE
fix: resolve include file() paths relative to CWD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `include file("path")` now resolves relative to the process working directory (CWD) instead of the including file's directory, matching Lightbend reference behavior. Bare `include "path"` is unchanged (resolves relative to including file).
 - `.33` (no leading zero) now correctly classified as string, not number — aligned with Lightbend reference implementation.
 - Number literal detection restricted to tokens starting with `0-9` or `-`. `0xff`, `Infinity`, etc. are no longer classified as numbers.
 - Quoted-key include relativization: `${"a.b".c}` inside included files now resolves correctly.

--- a/src/internal/parser/ast.ts
+++ b/src/internal/parser/ast.ts
@@ -8,7 +8,7 @@ export type AstNode =
   | { kind: 'scalar'; raw: string; valueType: ScalarValueType; pos: Pos; _separator?: boolean }
   | { kind: 'concat'; nodes: AstNode[]; pos: Pos }
   | { kind: 'subst'; path: string; optional: boolean; pos: Pos }
-  | { kind: 'include'; path: string; required: boolean; pos: Pos }
+  | { kind: 'include'; path: string; required: boolean; isFile?: boolean; pos: Pos }
 
 // key が空配列のとき include ディレクティブを表す（value は include ノード）
 export type AstField = {

--- a/src/internal/parser/parser.ts
+++ b/src/internal/parser/parser.ts
@@ -165,6 +165,7 @@ class Parser {
     const t = this.peek()
     let path: string
     let required = false
+    let isFile = false
 
     if (t.kind === 'unquoted' && (t.value === 'required(' || t.value === 'required' ||
         t.value.startsWith('required('))) {
@@ -189,11 +190,18 @@ class Parser {
       if (innerPrefix.startsWith('url') || innerPrefix.startsWith('classpath')) {
         throw new ParseError('include url(...) and classpath(...) are not supported', t.line, t.col)
       }
-      // Case 2 (with space): next token starts with url/classpath
+      // Detect file() inside required(): "required(file(" as single token or "file(" as next token
+      if (innerPrefix.startsWith('file')) {
+        isFile = true
+      }
+      // Case 2 (with space): next token starts with url/classpath/file
       const next = this.peek()
       if (next.kind === 'unquoted' && (next.value === 'url' || next.value.startsWith('url(') ||
           next.value === 'classpath' || next.value.startsWith('classpath('))) {
         throw new ParseError('include url(...) and classpath(...) are not supported', next.line, next.col)
+      }
+      if (next.kind === 'unquoted' && (next.value === 'file(' || next.value === 'file' || next.value.startsWith('file('))) {
+        isFile = true
       }
 
       // Skip tokens until we find the quoted path string
@@ -207,6 +215,7 @@ class Parser {
       path = this.advance().value
     } else if (t.kind === 'unquoted' && (t.value === 'file(' || t.value === 'file')) {
       // include file("path")
+      isFile = true
       this.advance()
       // Skip tokens until we find the quoted path string
       while (this.peek().kind !== 'string' && this.peek().kind !== 'eof') this.advance()
@@ -224,7 +233,7 @@ class Parser {
 
     return {
       key: [],
-      value: { kind: 'include', path, required, pos: p },
+      value: { kind: 'include', path, required, ...(isFile ? { isFile: true } : {}), pos: p },
       append: false,
       pos: p,
     }

--- a/src/internal/resolver/include-loader.ts
+++ b/src/internal/resolver/include-loader.ts
@@ -27,11 +27,14 @@ export class IncludeLoader {
     this.opts = opts
   }
 
-  load(includePath: string, required: boolean): ResObj {
+  load(includePath: string, required: boolean, isFile?: boolean): ResObj {
     const { baseDir, includeStack = [] } = this.opts
-    const absPath = baseDir
-      ? nodePath.resolve(baseDir, includePath)
-      : nodePath.resolve(includePath)
+    // file() includes resolve relative to CWD (or as absolute paths),
+    // NOT relative to the including file's directory.
+    // Bare includes resolve relative to the including file's directory (baseDir).
+    const absPath = isFile
+      ? nodePath.resolve(includePath)
+      : (baseDir ? nodePath.resolve(baseDir, includePath) : nodePath.resolve(includePath))
 
     if (includeStack.includes(absPath)) {
       throw new ResolveError(`circular include: ${absPath}`, absPath, 0, 0)
@@ -71,11 +74,11 @@ export class IncludeLoader {
     return merged
   }
 
-  async loadAsync(includePath: string, required: boolean): Promise<ResObj> {
+  async loadAsync(includePath: string, required: boolean, isFile?: boolean): Promise<ResObj> {
     const { baseDir, includeStack = [] } = this.opts
-    const absPath = baseDir
-      ? nodePath.resolve(baseDir, includePath)
-      : nodePath.resolve(includePath)
+    const absPath = isFile
+      ? nodePath.resolve(includePath)
+      : (baseDir ? nodePath.resolve(baseDir, includePath) : nodePath.resolve(includePath))
 
     if (includeStack.includes(absPath)) {
       throw new ResolveError(`circular include: ${absPath}`, absPath, 0, 0)

--- a/src/internal/resolver/include-loader.ts
+++ b/src/internal/resolver/include-loader.ts
@@ -27,14 +27,21 @@ export class IncludeLoader {
     this.opts = opts
   }
 
-  load(includePath: string, required: boolean, isFile?: boolean): ResObj {
-    const { baseDir, includeStack = [] } = this.opts
-    // file() includes resolve relative to CWD (or as absolute paths),
-    // NOT relative to the including file's directory.
-    // Bare includes resolve relative to the including file's directory (baseDir).
-    const absPath = isFile
+  /**
+   * Resolve an include path to an absolute path.
+   * - file() includes resolve relative to CWD (or as absolute paths),
+   *   NOT relative to the including file's directory.
+   * - Bare includes resolve relative to the including file's directory (baseDir).
+   */
+  private resolveIncludePath(includePath: string, baseDir: string | undefined, isFile: boolean): string {
+    return isFile
       ? nodePath.resolve(includePath)
       : (baseDir ? nodePath.resolve(baseDir, includePath) : nodePath.resolve(includePath))
+  }
+
+  load(includePath: string, required: boolean, isFile?: boolean): ResObj {
+    const { baseDir, includeStack = [] } = this.opts
+    const absPath = this.resolveIncludePath(includePath, baseDir, !!isFile)
 
     if (includeStack.includes(absPath)) {
       throw new ResolveError(`circular include: ${absPath}`, absPath, 0, 0)
@@ -76,9 +83,7 @@ export class IncludeLoader {
 
   async loadAsync(includePath: string, required: boolean, isFile?: boolean): Promise<ResObj> {
     const { baseDir, includeStack = [] } = this.opts
-    const absPath = isFile
-      ? nodePath.resolve(includePath)
-      : (baseDir ? nodePath.resolve(baseDir, includePath) : nodePath.resolve(includePath))
+    const absPath = this.resolveIncludePath(includePath, baseDir, !!isFile)
 
     if (includeStack.includes(absPath)) {
       throw new ResolveError(`circular include: ${absPath}`, absPath, 0, 0)

--- a/src/internal/resolver/structure-builder.ts
+++ b/src/internal/resolver/structure-builder.ts
@@ -60,7 +60,7 @@ export class StructureBuilder {
     if (field.key.length === 0 && field.value.kind === 'include') {
       // Included files are parsed at their own root (pathPrefix=[]),
       // then relativized to the current scope's prefix.
-      const included = this.loader.load(field.value.path, field.value.required)
+      const included = this.loader.load(field.value.path, field.value.required, field.value.isFile)
       if (pathPrefix.length > 0) {
         this.relativizeResObj(included, pathPrefix)
       }
@@ -117,7 +117,7 @@ export class StructureBuilder {
 
   private async applyFieldAsync(obj: ResObj, field: AstField, pathPrefix: string[]): Promise<void> {
     if (field.key.length === 0 && field.value.kind === 'include') {
-      const included = await this.loader.loadAsync(field.value.path, field.value.required)
+      const included = await this.loader.loadAsync(field.value.path, field.value.required, field.value.isFile)
       if (pathPrefix.length > 0) {
         this.relativizeResObj(included, pathPrefix)
       }

--- a/tests/lightbend/lightbend.test.ts
+++ b/tests/lightbend/lightbend.test.ts
@@ -46,7 +46,7 @@ describe('Lightbend HOCON suite tests (expected JSON)', () => {
 
   // Known failures — skip these with reasons
   const skip = new Set([
-    'file-include-expected.json',  // file include resolves extra keys (bar-file, baz) not in expected
+    // 'file-include-expected.json',  // FIXED: file() includes now resolve relative to CWD
     'test01-expected.json',        // env vars (system.path/pwd) differ per machine; key ordering; null handling; arrays.firstElementNotASubst
     'test02-expected.json',        // empty-string key substitution ${""."".""}  not resolved
     // 'test10-expected.json',     // FIXED: nested include substitution scope (relativize)

--- a/tests/resolver.test.ts
+++ b/tests/resolver.test.ts
@@ -533,3 +533,76 @@ describe('segmentsToKey', () => {
     expect(parseSubstPath('"a\\nb"')).toEqual(['a\\nb'])
   })
 })
+
+describe('include file() resolution', () => {
+  // file() includes resolve relative to CWD (via nodePath.resolve), not the including file's dir.
+  // Bare includes resolve relative to the including file's dir (baseDir).
+  function resolveWithBaseDir(input: string, baseDir: string, files: Record<string, string>): HoconValue {
+    const ast = parseTokens(tokenize(input))
+    return resolve(ast, {
+      env: {},
+      baseDir,
+      readFileSync: (p: string) => {
+        const content = files[p]
+        if (content !== undefined) return content
+        throw Object.assign(new Error(`ENOENT: ${p}`), { code: 'ENOENT' })
+      },
+    })
+  }
+
+  it('include file() resolves relative to CWD, not including file dir', () => {
+    // CWD-resolved absolute paths for file() includes.
+    // nodePath.resolve('bar-file.conf') => <CWD>/bar-file.conf
+    const cwd = process.cwd()
+    const files: Record<string, string> = {
+      '/root/sub/foo.conf': 'foo=42\ninclude "bar.conf"\ninclude file("bar-file.conf")',
+      '/root/sub/bar.conf': 'bar=43',
+      '/root/sub/bar-file.conf': 'bar-file=44',
+      // file("bar-file.conf") resolves to CWD/bar-file.conf
+      [`${cwd}/bar-file.conf`]: 'bar-file-cwd=99',
+    }
+    const input = 'base=41\ninclude "sub/foo.conf"'
+    const v = resolveWithBaseDir(input, '/root', files)
+    const fields = obj(v)
+    // file() resolved to CWD/bar-file.conf
+    expect(fields.get('bar-file-cwd')).toEqual({ kind: 'scalar', raw: '99', valueType: 'number' })
+    // sub/bar-file.conf should NOT be loaded (that would be the old broken behavior)
+    expect(fields.has('bar-file')).toBe(false)
+    expect(fields.get('base')).toEqual({ kind: 'scalar', raw: '41', valueType: 'number' })
+    expect(fields.get('foo')).toEqual({ kind: 'scalar', raw: '42', valueType: 'number' })
+    expect(fields.get('bar')).toEqual({ kind: 'scalar', raw: '43', valueType: 'number' })
+  })
+
+  it('include file() with absolute path resolves as-is', () => {
+    const files: Record<string, string> = {
+      '/absolute/target.conf': 'abs=100',
+    }
+    const input = 'base=1\ninclude file("/absolute/target.conf")'
+    const v = resolveWithBaseDir(input, '/root', files)
+    const fields = obj(v)
+    expect(fields.get('abs')).toEqual({ kind: 'scalar', raw: '100', valueType: 'number' })
+  })
+
+  it('include file() silently skips missing files (non-required)', () => {
+    const files: Record<string, string> = {
+      '/root/sub/foo.conf': 'foo=42\ninclude file("nonexistent.conf")',
+    }
+    const input = 'base=41\ninclude "sub/foo.conf"'
+    const v = resolveWithBaseDir(input, '/root', files)
+    const fields = obj(v)
+    expect(fields.get('base')).toEqual({ kind: 'scalar', raw: '41', valueType: 'number' })
+    expect(fields.get('foo')).toEqual({ kind: 'scalar', raw: '42', valueType: 'number' })
+  })
+
+  it('bare include still resolves relative to including file dir', () => {
+    const files: Record<string, string> = {
+      '/root/sub/foo.conf': 'foo=42\ninclude "bar.conf"',
+      '/root/sub/bar.conf': 'bar=43',
+    }
+    const input = 'include "sub/foo.conf"'
+    const v = resolveWithBaseDir(input, '/root', files)
+    const fields = obj(v)
+    expect(fields.get('foo')).toEqual({ kind: 'scalar', raw: '42', valueType: 'number' })
+    expect(fields.get('bar')).toEqual({ kind: 'scalar', raw: '43', valueType: 'number' })
+  })
+})

--- a/tests/resolver.test.ts
+++ b/tests/resolver.test.ts
@@ -1,4 +1,5 @@
 // tests/resolver.test.ts
+import * as nodePath from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { ResolveError } from '../src/errors.js'
 import { tokenize } from '../src/internal/lexer/lexer.js'
@@ -559,7 +560,7 @@ describe('include file() resolution', () => {
       '/root/sub/bar.conf': 'bar=43',
       '/root/sub/bar-file.conf': 'bar-file=44',
       // file("bar-file.conf") resolves to CWD/bar-file.conf
-      [`${cwd}/bar-file.conf`]: 'bar-file-cwd=99',
+      [nodePath.resolve(cwd, 'bar-file.conf')]: 'bar-file-cwd=99',
     }
     const input = 'base=41\ninclude "sub/foo.conf"'
     const v = resolveWithBaseDir(input, '/root', files)
@@ -592,6 +593,23 @@ describe('include file() resolution', () => {
     const fields = obj(v)
     expect(fields.get('base')).toEqual({ kind: 'scalar', raw: '41', valueType: 'number' })
     expect(fields.get('foo')).toEqual({ kind: 'scalar', raw: '42', valueType: 'number' })
+  })
+
+  it('include required(file()) errors when file does not exist', () => {
+    const files: Record<string, string> = {}
+    const input = 'include required(file("missing.conf"))'
+    expect(() => resolveWithBaseDir(input, '/root', files)).toThrow(/required include file not found/)
+  })
+
+  it('include required(file()) succeeds when file exists', () => {
+    const cwd = process.cwd()
+    const files: Record<string, string> = {
+      [nodePath.resolve(cwd, 'exists.conf')]: 'found=true',
+    }
+    const input = 'include required(file("exists.conf"))'
+    const v = resolveWithBaseDir(input, '/root', files)
+    const fields = obj(v)
+    expect(fields.get('found')).toEqual({ kind: 'scalar', raw: 'true', valueType: 'boolean' })
   })
 
   it('bare include still resolves relative to including file dir', () => {


### PR DESCRIPTION
## Summary

- `include file("path")` was incorrectly resolving relative to the including file's directory (same as bare `include "path"`). Per the HOCON spec and Lightbend reference, `file()` paths resolve relative to the process working directory (CWD) or as absolute paths.
- Added `isFile` flag to AST include node, propagated through parser and resolver pipeline
- Lightbend `file-include` conformance test now passes (removed from skip list)

## Changes

| File | Change |
|------|--------|
| `src/internal/parser/ast.ts` | Added `isFile?: boolean` to include AST variant |
| `src/internal/parser/parser.ts` | Set `isFile: true` for `file()` and `required(file())` forms |
| `src/internal/resolver/include-loader.ts` | Use `nodePath.resolve(includePath)` (CWD-based) when `isFile` is true |
| `src/internal/resolver/structure-builder.ts` | Pass `isFile` flag to include loader |
| `tests/resolver.test.ts` | 4 new unit tests for file() resolution behavior |
| `tests/lightbend/lightbend.test.ts` | Removed `file-include` from skip list |
| `CHANGELOG.md` | Documented fix in [Unreleased] |

## Test plan

- [x] New unit tests verify file() resolves relative to CWD, bare include resolves relative to including file
- [x] Lightbend `file-include.conf` conformance test passes
- [x] Full test suite: 340 passed, 2 skipped (pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)