### PR TITLE
docs: add library stance and cross-language conformance notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ A full [Lightbend HOCON](https://github.com/lightbend/config/blob/main/HOCON.md)
 
 [日本語](README.ja.md)
 
+> **Library stance:** ts.hocon is a HOCON config loader — its purpose is reading `.hocon` config files and providing typed access via the Config API (`getString`, `getNumber`, `getBoolean`, `getDuration`, `getBytes`, `toObject`). It is not a low-level parser API. Internal types like `HoconValue` may change between minor versions.
+>
+> **Cross-language conformance:** This implementation is tested against shared expected-JSON fixtures from [o3co/xx.hocon](https://github.com/o3co/xx.hocon) alongside [go.hocon](https://github.com/o3co/go.hocon) and [rs.hocon](https://github.com/o3co/rs.hocon) to ensure all three implementations meet the same Lightbend HOCON specification.
+
 ---
 
 ## Quick Start


### PR DESCRIPTION
## Summary

- Add a "Library stance" note clarifying that ts.hocon is a config loader API, not a low-level parser. Internal types like `HoconValue` may change between minor versions.
- Add a "Cross-language conformance" note explaining that this implementation is tested against shared expected-JSON fixtures from xx.hocon alongside go.hocon and rs.hocon.

Both notes are placed as blockquotes near the top of the README, after the attribution block and before Quick Start.

## Test plan

- [ ] Verify README renders correctly on GitHub (blockquotes, links)

Generated with [Claude Code](https://claude.com/claude-code)