### PR TITLE
chore: drop Node.js 18 support, require >=20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ["18", "20", "22"]
+        node: ["20", "22"]
         os: [ubuntu-latest]
         include:
           - node: "22"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **BREAKING**: Minimum Node.js version raised from 18 to 20. Node 18 reached EOL on 2025-04-30.
+
 ## [1.1.0] — 2026-04-05
 
 ### Changed

--- a/README.ja.md
+++ b/README.ja.md
@@ -22,7 +22,7 @@
 npm install @o3co/ts.hocon
 ```
 
-Node.js 18 以上が必要です。
+Node.js 20 以上が必要です。
 
 ### 2. 使い方
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A full [Lightbend HOCON](https://github.com/lightbend/config/blob/main/HOCON.md)
 npm install @o3co/ts.hocon
 ```
 
-Requires Node.js 18+.
+Requires Node.js 20+.
 
 ### 2. Use
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "homepage": "https://o3co.github.io/ts.hocon/",
   "bugs": "https://github.com/o3co/ts.hocon/issues",


### PR DESCRIPTION
## Summary
- Update `engines.node` from `>=18` to `>=20`
- Remove Node 18 from CI test matrix
- Node 18 reached EOL on 2025-04-30
- Dev tooling (vitest 4.x, vite 7.x) already requires Node >=20

Addresses Copilot review feedback on #65.

## Test plan
- [x] CI passes on Node 20 and 22
- [ ] No Node 18 job in CI matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)