### PR TITLE
fix: resolve empty-string key substitution

### DIFF
--- a/src/internal/resolver/structure-builder.ts
+++ b/src/internal/resolver/structure-builder.ts
@@ -69,7 +69,7 @@ export class StructureBuilder {
     }
 
     const [head, ...tail] = field.key
-    if (!head) return
+    if (head === undefined) return
 
     if (tail.length > 0) {
       // Nested key: server.host = "x" → create synthetic object AST
@@ -126,7 +126,7 @@ export class StructureBuilder {
     }
 
     const [head, ...tail] = field.key
-    if (!head) return
+    if (head === undefined) return
 
     if (tail.length > 0) {
       const syntheticAst: AstNode = {

--- a/tests/lightbend/lightbend.test.ts
+++ b/tests/lightbend/lightbend.test.ts
@@ -49,7 +49,7 @@ describe('Lightbend HOCON suite tests (expected JSON)', () => {
   const skip = new Set([
     // 'file-include-expected.json',  // FIXED: file() includes now resolve relative to CWD
     'test01-expected.json',        // env vars (system.path/pwd) differ per machine; key ordering; null handling; arrays.firstElementNotASubst
-    'test02-expected.json',        // empty-string key substitution ${""."".""}  not resolved
+    // 'test02-expected.json',     // FIXED: empty-string key substitution ${""."".""}  now resolved
     // 'test10-expected.json',     // FIXED: nested include substitution scope (relativize)
   ])
 


### PR DESCRIPTION
## Summary
- Fix `!head` guard in `applyField`/`applyFieldAsync` that falsely discarded fields with empty-string keys (`""`) due to JavaScript's falsy evaluation
- Changed to `head === undefined` which correctly guards only against empty key arrays (include directives)
- Removed test02 from known failures skip list — now passes

## Test plan
- [x] Verified test02.conf (`${""."".""}` → 42) resolves correctly
- [x] All 343 tests pass, typecheck clean
- [x] Reviewed by Claude (design & logic) and Codex (security & performance) — both PASS

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)