### PR TITLE
test: change Phase 3 self-reference to tracking issue #70 (Copilot follow-up)

### DIFF
--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -425,7 +425,7 @@ describe('spec compliance Phase 2 — concatenation, paths, and +=', () => {
   })
 })
 
-// Spec compliance Phase 3 (issue #85): substitution & include (parser-level)
+// Spec compliance Phase 3 (tracking issue #70): substitution & include (parser-level)
 // Convention: it.fails(...) pins known violations; plain it(...) for ✅ items.
 // -----------------------------------------------------------------------------
 

--- a/tests/resolver.test.ts
+++ b/tests/resolver.test.ts
@@ -706,7 +706,7 @@ describe('spec compliance Phase 2 — concatenation and += (resolver-level)', ()
   })
 })
 
-// Spec compliance Phase 3 (issue #85): substitution & include (resolver-level)
+// Spec compliance Phase 3 (tracking issue #70): substitution & include (resolver-level)
 // Convention: it.fails(...) pins known violations; plain it(...) for ✅ items.
 // -----------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Follow-up to [#85](https://github.com/o3co/ts.hocon/pull/85) (Phase 3 spec compliance). Copilot review flagged that the header comment "Phase 3 (issue #85)" is the PR itself, not a tracking issue — readers navigating between phases can get confused. Point it at [#70](https://github.com/o3co/ts.hocon/issues/70), which is the umbrella tracking issue for spec-compliance test debt.

## Test plan
- [x] \`pnpm test\` clean — 415 passed + 26 expected fail + 1 skipped
- [x] \`pnpm typecheck\` clean
- [ ] CI green on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)