### PR TITLE
test: Phase 5 — clear per-impl 🤷 (20 items)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -177,12 +177,12 @@ description = """
 
 ## 仕様準拠
 
-[Lightbend HOCON 仕様](https://github.com/lightbend/config/blob/main/HOCON.md) への準拠状況は [`docs/spec-compliance.md`](docs/spec-compliance.md) に項目単位で記載しています。以下の表は 2026-05-12 時点のスナップショットです — 最新値は [`xx.hocon/docs/compliance-matrix.md`](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) を参照してください。
+[Lightbend HOCON 仕様](https://github.com/lightbend/config/blob/main/HOCON.md) への準拠状況は [`docs/spec-compliance.md`](docs/spec-compliance.md) に項目単位で記載しています。以下の表は 2026-05-13 時点のスナップショットです — 最新値は [`xx.hocon/docs/compliance-matrix.md`](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) を参照してください。
 
 | 指標                                   | 状況          |
 | -------------------------------------- | ------------- |
-| 仕様全体（out-of-scope を含む）        | **68.7%**     |
-| In-scope のみ                          | **76.3%**     |
+| 仕様全体（out-of-scope を含む）        | **74.2%**     |
+| In-scope のみ                          | **83.3%**     |
 | Lightbend `test01`–`test13` テスト群   | 13/13 合格    |
 
 v0.1.0 で未対応の機能:

--- a/README.md
+++ b/README.md
@@ -206,12 +206,12 @@ Supported byte units: `B`, `KB`/`KiB`, `MB`/`MiB`, `GB`/`GiB`, `TB`/`TiB` (and l
 
 ## Spec Compliance
 
-Conformance against the [Lightbend HOCON specification](https://github.com/lightbend/config/blob/main/HOCON.md) is tracked at item granularity in [`docs/spec-compliance.md`](docs/spec-compliance.md). The table below is a snapshot as of 2026-05-12; see [`xx.hocon/docs/compliance-matrix.md`](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) for live cross-impl values.
+Conformance against the [Lightbend HOCON specification](https://github.com/lightbend/config/blob/main/HOCON.md) is tracked at item granularity in [`docs/spec-compliance.md`](docs/spec-compliance.md). The table below is a snapshot as of 2026-05-13; see [`xx.hocon/docs/compliance-matrix.md`](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) for live cross-impl values.
 
 | Metric                                | Status        |
 | ------------------------------------- | ------------- |
-| Spec total (incl. out-of-scope)       | **68.7%**     |
-| In-scope only                         | **76.3%**     |
+| Spec total (incl. out-of-scope)       | **74.2%**     |
+| In-scope only                         | **83.3%**     |
 | Lightbend `test01`–`test13` suite     | 13/13 passing |
 
 Not supported in v0.1.0:

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -15,8 +15,14 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
 ## S1. Unchanged from JSON
 
 - **S1.1** Files must be valid UTF-8 — §Unchanged from JSON (L117)
-  tests: —
-  status: 🤷
+  out-of-scope: The public `parse()` API accepts a JS `string`, which is already a decoded
+  Unicode sequence — Node.js (and browsers) perform UTF-8 decoding at the I/O boundary before
+  the string reaches the parser. `parseFile()` uses `fs.readFileSync(path, 'utf-8')`, which
+  rejects invalid UTF-8 bytes at the OS/Node layer. The HOCON parser itself therefore cannot
+  observe raw byte sequences and has no mechanism to reject invalid UTF-8. UTF-8 validity is
+  structurally enforced at the I/O layer, not the parse layer, in all JS runtimes.
+  tests: tests/config.test.ts (S1.1 describe block — sanity checks multi-byte chars accepted)
+  status: ➖
 - **S1.2.1** Quoted strings accept valid JSON escape sequences (`\" \\ \/ \b \f \n \r \t`) — §Unchanged from JSON (L118)
   tests: tests/lexer.test.ts:49; tests/lightbend/testdata/subst-tokenize/st10-escape-newline.conf (fixture)
   status: ✅
@@ -58,8 +64,12 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
 ## S3. Omit root braces
 
 - **S3.1** Empty file is invalid — §Omit root braces (L130)
-  tests: —
-  status: 🤷
+  tests: tests/config.test.ts (S3.1 describe block)
+  status: ❌
+  notes: `parse('')` and `parse('   \n  ')` both return an empty Config without throwing.
+  Spec L130: "Empty files are invalid documents." The parser accepts empty input as an
+  empty object at the AST level; the fix requires a guard in `parse()` or `parseTokens()`.
+  Tests pinned with `it.fails`.
 - **S3.2** Root non-object/non-array is invalid (when explicitly enclosed) — §Omit root braces (L131)
   tests: tests/parser.test.ts:355
   status: ✅
@@ -115,8 +125,8 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
   tests: tests/lexer.test.ts:333; tests/lexer.test.ts:339; tests/lexer.test.ts:344; tests/lexer.test.ts:350; tests/lexer.test.ts:356
   status: ⚠️ ([#72](https://github.com/o3co/ts.hocon/issues/72)) — 2 of 8 sub-rules pass: tab (0x09) and CR (0x0D) are recognized; vtab (0x0B), FF (0x0C), FS–US (0x1C–0x1F) are not. The ⚠️ glyph contributes 0.5 to the rate per legend; the actual sub-rule coverage is 25%
 - **S6.5** "newline" means specifically 0x000A (LF) — §Whitespace (L183)
-  tests: —
-  status: 🤷
+  tests: tests/resolver.test.ts (S6.5 describe block)
+  status: ✅
 
 ## S7. Duplicate keys and object merging
 
@@ -136,8 +146,8 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
   tests: tests/resolver.test.ts:159; tests/lightbend/testdata/equiv02/path-keys.conf (fixture)
   status: ✅
 - **S7.6** Intermediate non-object value breaks merge with later object — §Duplicate keys (L207)
-  tests: —
-  status: 🤷
+  tests: tests/resolver.test.ts (S7.6 describe block)
+  status: ✅
 
 ## S8. Unquoted strings
 
@@ -211,11 +221,11 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
   tests: tests/parser.test.ts:381
   status: ❌ (see #76) — parser rejects unquoted-space-unquoted as key with "unexpected token after key: unquoted"
 - **S10.9** `true`/`false` stringify to `"true"`/`"false"` in concat — §String value concatenation (L363)
-  tests: —
-  status: 🤷
+  tests: tests/resolver.test.ts (S10.9 describe block)
+  status: ✅
 - **S10.10** `null` stringifies to `"null"` in concat — §String value concatenation (L364)
-  tests: —
-  status: 🤷
+  tests: tests/resolver.test.ts (S10.10 describe block)
+  status: ✅
 - **S10.11** Numbers stringify as written in the source file — §String value concatenation (L366)
   tests: tests/config.test.ts:183
   status: ✅
@@ -232,8 +242,8 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
   tests: tests/resolver.test.ts:181
   status: ✅
 - **S10.16** Non-newline whitespace in arrays is concat, not separator — §Arrays without commas or newlines (L447)
-  tests: —
-  status: 🤷
+  tests: tests/resolver.test.ts (S10.16 describe block)
+  status: ✅
 - **S10.17** Substitution resolving to an array participates in array concat (`${arr} [x]`) — §Array and object concatenation (L387)
   tests: tests/resolver.test.ts:284
   status: ✅
@@ -364,8 +374,14 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
   tests: tests/resolver.test.ts:213
   status: ✅
 - **S13a.3** Self-ref before any prior value → undefined → error — §Self-Referential (L767)
-  tests: —
-  status: 🤷
+  tests: tests/resolver.test.ts (S13a.3 describe block)
+  status: ⚠️
+  notes: `a = ${a}` (no prior value) raises `ResolveError("circular substitution: a")`.
+  An error is raised (correct), but spec L767-773 says this case should be treated as
+  "undefined" (i.e. a missing-substitution error), not an "intractable cycle" error.
+  The distinction matters for error messages and for `${?a}` handling (which the impl
+  already handles correctly via separate detection). Behavior (error) is correct;
+  error classification is off-spec.
 - **S13a.4** Optional self-ref `${?foo}` disappears silently — §Self-Referential (L776)
   tests: tests/resolver.test.ts:291
   status: ✅
@@ -385,8 +401,15 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
   tests: tests/resolver.test.ts:148
   status: ✅
 - **S13a.10** Substitution memoized by instance, not by path — §Self-Referential (L885)
-  tests: — (not externally observable — internal memoization semantics)
-  status: 🤷
+  out-of-scope: Internal resolver implementation detail. Two `${b}` substitutions at
+  different file positions naturally see the same lookup result (the final merged config)
+  regardless of whether memoization is keyed by instance or by path, because the config
+  is non-self-referential in any valid observable test. The spec rule constrains resolver
+  internals to prevent observable differences in self-referential edge cases, but no
+  black-box input/output test can distinguish "memoized by instance" from "resolved
+  independently" via the public API. See resolver.test.ts comment at S13a.10 for details.
+  tests: — (internal memoization semantics — not externally observable)
+  status: ➖
 - **S13a.11** Object can refer to its own descendant (`bar : { foo : 42, baz : ${bar.foo} }`) — §Self-Referential (L806)
   tests: tests/resolver.test.ts:227
   status: ✅
@@ -455,8 +478,8 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
   tests: tests/parser.test.ts:439
   status: ✅
 - **S14a.7** Whitespace allowed between `include` and resource name (incl. newlines) — §Include syntax (L952)
-  tests: tests/lightbend/testdata/test03.conf (fixture)
-  status: 🤷
+  tests: tests/lightbend/testdata/test03.conf (fixture); tests/resolver.test.ts (S14a.7 describe block)
+  status: ✅
 - **S14a.8** No value concatenation on include argument — §Include syntax (L957)
   tests: tests/parser.test.ts:447
   status: ✅
@@ -467,8 +490,8 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
   tests: tests/parser.test.ts:282
   status: ✅
 - **S14a.11** `"include"` (quoted) is just a normal key — §Include syntax (L977)
-  tests: —
-  status: 🤷
+  tests: tests/config.test.ts (S14a.11 describe block)
+  status: ✅
 
 ### S14b. Include semantics: merging
 
@@ -629,17 +652,33 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
 ## S18. Units format
 
 - **S18.1** Number value taken as default unit — §Units format (L1279)
-  tests: —
-  status: 🤷
+  tests: tests/config.test.ts (S18.1 describe block)
+  status: ❌
+  notes: `getDuration()` on a bare number value (e.g. `timeout = 5000`) throws
+  "invalid duration". `parseDuration` extracts all digits, leaving `unit = ""`, and
+  `DURATION_UNITS[""]` is `undefined` → `NaN` → error. Spec L1279: "if the value is a
+  number, it is taken to be a number in the default unit." Fix: add an early-exit in
+  `parseDuration` that returns `num / divisor` when `unit` is the empty string.
+  Tests pinned with `it.fails`.
 - **S18.2** String parsed as: optional ws + number + ws + unit + ws — §Units format (L1281-1294)
   tests: tests/config.test.ts:239
   status: ✅
 - **S18.3** Unit name letters-only (Unicode L* / `isLetter`) — §Units format (L1287)
-  tests: —
-  status: 🤷
+  tests: tests/config.test.ts (S18.3 describe block)
+  status: ✅
+  notes: Effectively enforced via the unit-name map lookup in `parseDuration`/`parseBytes`.
+  Unknown units (including those with digits or hyphens) produce `NaN` → `ConfigError`.
+  No explicit letter-only character check runs, but the outcome is conformant for all
+  tested inputs. ⚠️ would apply only if a non-letter unit string happened to match a
+  map key — which is structurally impossible given the map's contents.
 - **S18.4** String with no unit → interpreted with default unit — §Units format (L1290)
-  tests: —
-  status: 🤷
+  tests: tests/config.test.ts (S18.4 describe block)
+  status: ❌
+  notes: `getDuration()` on a string with no unit suffix (e.g. `timeout = "5000"`) throws
+  "invalid duration". Same root cause as S18.1: `unit = ""` → not in `DURATION_UNITS`
+  → `NaN` → error. Spec L1290: "If a string value has no unit name, then it should be
+  interpreted with the default unit." Fix is the same as S18.1: handle empty-unit case
+  in `parseDuration`. Tests pinned with `it.fails`.
 
 ## S19. Duration format
 
@@ -665,8 +704,13 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
   tests: tests/config.test.ts:254
   status: ✅
 - **S19.8** Duration unit names are case sensitive (lowercase only) — §Duration format (L1304)
-  tests: —
-  status: 🤷
+  tests: tests/config.test.ts (S19.8 describe block)
+  status: ❌
+  notes: `parseDuration` applies `.toLowerCase()` to the unit string before lookup, making
+  unit names case-insensitive. Probe: `"5 MS"` → 5, `"5 Seconds"` → 5000, `"5 DAYS"` →
+  432000000. Spec L1304: "The supported unit strings for duration are case sensitive and must
+  be lowercase." Fix: remove the `.toLowerCase()` call in `parseDuration` and rely on the
+  exact map keys. Tests pinned with `it.fails`.
 
 ## S20. Period format
 
@@ -712,11 +756,17 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
   tests: tests/config.test.ts:157
   status: ✅
 - **S22.2** Intermediate non-object hides earlier object across files — §Config object merging (L1406)
-  tests: —
-  status: 🤷
+  tests: tests/config.test.ts (S22.2 describe block)
+  status: ❌
+  notes: `deepMergeHocon` always recursively merges objects regardless of intermediate
+  non-object values. Probe: `c1({a:{x:1}}).withFallback(c2({a:42})).withFallback(c3({a:{y:2}}))`
+  → `{a:{x:1,y:2}}`. Expected per spec L1410-1417: `{a:{x:1}}` (the non-object `42` in c2
+  prevents c1's `{x:1}` from merging with c3's `{y:2}`). Fix requires `withFallback` /
+  `deepMergeHocon` to track value-sequence history per key, not just the current types.
+  Tests pinned with `it.fails`.
 - **S22.3** Setting key to null clears earlier object value — §Config object merging (L1436)
-  tests: —
-  status: 🤷
+  tests: tests/config.test.ts (S22.3 describe block)
+  status: ✅
 
 ## S23. Java properties mapping
 
@@ -724,14 +774,20 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
   tests: tests/properties.test.ts:30
   status: ✅
 - **S23.2** Empty path elements (leading/trailing) preserved — §Java properties (L1456)
-  tests: —
-  status: 🤷
+  tests: tests/properties.test.ts (S23.2 describe block)
+  status: ✅
 - **S23.3** Properties values are always strings — §Java properties (L1471)
   tests: tests/properties.test.ts:37; tests/parse.test.ts:386
   status: ✅
 - **S23.4** Object wins over string on conflicting key — §Java properties (L1485)
-  tests: —
-  status: 🤷
+  tests: tests/properties.test.ts (S23.4 describe block)
+  status: ❌
+  notes: `setNested` in `properties.ts` overwrites an existing object value with a string
+  when the string key appears after the dotted key. Probe: `"a.b=world\na=hello"` →
+  `{a:"hello"}`. Spec L1485: "the object must always win." Fix: add a guard in `setNested`
+  that skips assignment when the existing value at the last segment is already an object.
+  The reverse order (string first, dotted key second) already works correctly.
+  Tests pinned with `it.fails`.
 - **S23.5** Multi-line values (backslash continuation) — §Note on Java properties similarity (L1587)
   out-of-scope: declared in each implementation's README — the `.properties` reader supports only basic `key=value` syntax to avoid pulling a full Java properties parser into a non-JVM library.
   tests: —
@@ -765,8 +821,8 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
   tests: tests/resolver.test.ts:130; tests/parse.test.ts:35
   status: ✅
 - **S26.2** Empty env var preserved as empty string (not undefined) — §Substitution fallback (L1558)
-  tests: —
-  status: 🤷
+  tests: tests/config.test.ts (S26.2 describe block)
+  status: ✅
 - **S26.3** Env var SecurityException → treated as not present — §Substitution fallback (L1560)
   out-of-scope: `SecurityException` is a JVM-specific exception type; non-JVM runtimes have no equivalent guard at this layer.
   tests: —

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -17,10 +17,15 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
 - **S1.1** Files must be valid UTF-8 — §Unchanged from JSON (L117)
   out-of-scope: The public `parse()` API accepts a JS `string`, which is already a decoded
   Unicode sequence — Node.js (and browsers) perform UTF-8 decoding at the I/O boundary before
-  the string reaches the parser. `parseFile()` uses `fs.readFileSync(path, 'utf-8')`, which
-  rejects invalid UTF-8 bytes at the OS/Node layer. The HOCON parser itself therefore cannot
-  observe raw byte sequences and has no mechanism to reject invalid UTF-8. UTF-8 validity is
-  structurally enforced at the I/O layer, not the parse layer, in all JS runtimes.
+  the string reaches the parser. `parseFile()` uses `fs.readFileSync(path, 'utf-8')`. Note
+  that Node's default UTF-8 decoder is **non-fatal**: invalid byte sequences are silently
+  replaced with U+FFFD (REPLACEMENT CHARACTER), not thrown. Strict rejection of invalid
+  UTF-8 would require a custom decoder (e.g. `TextDecoder` with `{fatal: true}`) at the I/O
+  layer. The HOCON parser itself cannot observe raw byte sequences and has no mechanism to
+  detect or reject invalid UTF-8 — what reaches the parser layer is always a valid JS string.
+  S1.1 is therefore structurally inapplicable to the parser layer in JS runtimes; honoring
+  it is the caller's responsibility (provide bytes pre-validated, or wrap I/O with a strict
+  decoder). xx.hocon conformance fixtures cannot test this case via the public API.
   tests: tests/config.test.ts (S1.1 describe block — sanity checks multi-byte chars accepted)
   status: ➖
 - **S1.2.1** Quoted strings accept valid JSON escape sequences (`\" \\ \/ \b \f \n \r \t`) — §Unchanged from JSON (L118)

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -590,3 +590,217 @@ describe('S17.8 - array to other type must error', () => {
     expect(() => c.getConfig('val')).toThrow(ConfigError)
   })
 })
+
+// ---------------------------------------------------------------------------
+// Phase 5 spec debt tests
+// ---------------------------------------------------------------------------
+
+// S1.1 — files must be valid UTF-8 (HOCON spec L117)
+// The parse() API takes a JS string, which is already a decoded Unicode sequence
+// (Node.js decodes bytes to strings at the I/O boundary). The parser therefore
+// cannot observe raw byte sequences and has no mechanism to reject invalid UTF-8.
+// UTF-8 validation is the responsibility of the I/O layer (e.g. fs.readFileSync
+// with 'utf-8' encoding, which is what parseFile() uses). Status: ➖
+// Sanity check: multi-byte UTF-8 characters in values and keys parse correctly.
+describe('S1.1 - UTF-8 handling (HOCON spec L117)', () => {
+  it('S1.1: multi-byte UTF-8 characters are accepted in string values', () => {
+    const c = parse('key = "héllo wörld"')
+    expect(c.getString('key')).toBe('héllo wörld')
+  })
+
+  it('S1.1: multi-byte UTF-8 characters are accepted in unquoted values', () => {
+    // Japanese characters in an unquoted string
+    const c = parse('lang = こんにちは')
+    expect(c.getString('lang')).toBe('こんにちは')
+  })
+})
+
+// S3.1 — empty file is invalid (HOCON spec L130)
+// Probe (2026-05-13): parse('') returns an empty Config without throwing.
+// Spec L130: "Empty files are invalid documents."
+describe('S3.1 - empty file is invalid (HOCON spec L130)', () => {
+  it.fails('S3.1: parse("") should throw — empty file is invalid per spec L130', () => {
+    // Currently returns an empty Config; spec requires an error.
+    expect(() => parse('')).toThrow()
+  })
+
+  it.fails('S3.1: parse("   \\n  ") (whitespace-only) should throw — same rule', () => {
+    // Whitespace-only file has no root value, same as empty.
+    expect(() => parse('   \n  ')).toThrow()
+  })
+})
+
+// S14a.11 — quoted "include" is just a normal key (HOCON spec L977)
+describe('S14a.11 - quoted "include" is a normal key (HOCON spec L977)', () => {
+  it('S14a.11: "include" = 42 creates a regular key named include', () => {
+    const c = parse('"include" = 42')
+    expect(c.getNumber('include')).toBe(42)
+  })
+
+  it('S14a.11: quoted "include" in an object does not trigger include semantics', () => {
+    const c = parse('{ "include" = "hello" }')
+    expect(c.getString('include')).toBe('hello')
+  })
+})
+
+// S18.1 — number value taken as default unit (HOCON spec L1279)
+// Probe (2026-05-13): getDuration on a number-typed value throws "invalid duration".
+// parseDuration extracts digits → unit="" → DURATION_UNITS[""] is undefined → NaN → error.
+// Spec L1279: "if the value is a number, it is taken to be a number in the default unit."
+describe('S18.1 - bare number is in default unit (HOCON spec L1279)', () => {
+  it.fails('S18.1: getDuration() on a bare number treats it as milliseconds (default unit)', () => {
+    const c = parse('timeout = 5000')
+    // 5000 bare number → 5000 ms
+    expect(c.getDuration('timeout')).toBe(5000)
+  })
+
+  it.fails('S18.1: getDuration() on a bare number with explicit "ms" output unit', () => {
+    const c = parse('timeout = 5000')
+    expect(c.getDuration('timeout', 'ms')).toBe(5000)
+  })
+
+  it.fails('S18.1: getDuration() on a bare number with "s" output unit gives seconds', () => {
+    const c = parse('timeout = 5000')
+    // 5000 ms → 5 s
+    expect(c.getDuration('timeout', 's')).toBe(5)
+  })
+})
+
+// S18.3 — unit name consists only of letters (Unicode L* / Java isLetter) (HOCON spec L1287)
+// Probe (2026-05-13): "5 ms" → 5 (OK); "5 ms2" throws; "5 m-s" throws.
+// Effectively passing because parseDuration does a map lookup — unknown unit = NaN = error.
+describe('S18.3 - unit name must be letters-only (HOCON spec L1287)', () => {
+  it('S18.3: "5 ms" is accepted (valid letter-only unit)', () => {
+    const c = parse('a = "5 ms"')
+    expect(c.getDuration('a')).toBe(5)
+  })
+
+  it('S18.3: "5 ms2" is rejected (digit in unit name)', () => {
+    const c = parse('b = "5 ms2"')
+    expect(() => c.getDuration('b')).toThrow(ConfigError)
+  })
+
+  it('S18.3: "5 m-s" is rejected (hyphen in unit name)', () => {
+    const c = parse('c = "5 m-s"')
+    expect(() => c.getDuration('c')).toThrow(ConfigError)
+  })
+})
+
+// S18.4 — string with no unit uses default unit (HOCON spec L1290)
+// Probe (2026-05-13): getDuration on "5000" (string, no unit) throws "invalid duration".
+// parseDuration: unit="" → DURATION_UNITS[""] undefined → NaN → error.
+// Spec L1290: "If a string value has no unit name, then it should be interpreted with the
+// default unit, as if it were a number."
+describe('S18.4 - string with no unit uses default unit (HOCON spec L1290)', () => {
+  it.fails('S18.4: getDuration() on string "5000" (no unit) treats it as milliseconds', () => {
+    const c = parse('timeout = "5000"')
+    expect(c.getDuration('timeout')).toBe(5000)
+  })
+
+  it.fails('S18.4: getDuration() on string "30" (no unit) with "s" output gives 0.03', () => {
+    const c = parse('delay = "30"')
+    // 30 ms → 0.03 s
+    expect(c.getDuration('delay', 's')).toBeCloseTo(0.03)
+  })
+})
+
+// S19.8 — duration unit names are case sensitive, lowercase only (HOCON spec L1304)
+// Probe (2026-05-13): "5 MS" → 5, "5 Seconds" → 5000, "5 DAYS" → 432000000.
+// parseDuration applies .toLowerCase() to the unit before lookup, making it case-insensitive.
+// Spec L1304: "The supported unit strings for duration are case sensitive and must be lowercase."
+describe('S19.8 - duration unit names are case-sensitive lowercase (HOCON spec L1304)', () => {
+  it.fails('S19.8: "5 MS" should be rejected — uppercase unit is invalid per spec', () => {
+    // Currently parseDuration lowercases → "ms" → 5 ms. Should reject.
+    const c = parse('a = "5 MS"')
+    expect(() => c.getDuration('a')).toThrow(ConfigError)
+  })
+
+  it.fails('S19.8: "5 Seconds" should be rejected — mixed-case unit is invalid per spec', () => {
+    const c = parse('b = "5 Seconds"')
+    expect(() => c.getDuration('b')).toThrow(ConfigError)
+  })
+
+  it.fails('S19.8: "5 DAYS" should be rejected — uppercase unit is invalid per spec', () => {
+    const c = parse('c = "5 DAYS"')
+    expect(() => c.getDuration('c')).toThrow(ConfigError)
+  })
+
+  it('S19.8: "5 ms" (lowercase) is accepted', () => {
+    const c = parse('a = "5 ms"')
+    expect(c.getDuration('a')).toBe(5)
+  })
+
+  it('S19.8: "5 seconds" (lowercase) is accepted', () => {
+    const c = parse('b = "5 seconds"')
+    expect(c.getDuration('b')).toBe(5000)
+  })
+})
+
+// S22.2 — intermediate non-object value hides earlier object across files/merges (HOCON spec L1406)
+// Probe (2026-05-13): c1({a:{x:1}}).withFallback(c2({a:42})).withFallback(c3({a:{y:2}}))
+// → {"a":{"x":1,"y":2}}. Expected per spec: {"a":{"x":1}}.
+// deepMergeHocon always merges objects regardless of intermediate non-object values.
+describe('S22.2 - intermediate non-object hides earlier object in merge (HOCON spec L1406)', () => {
+  it.fails('S22.2: non-object in middle of fallback chain prevents object merge (spec L1406)', () => {
+    // Spec example (L1410-1417):
+    //   first priority: { a: { x: 1 } }
+    //   fallback:       { a: 42 }       ← non-object "breaks" the chain
+    //   another fallback: { a: { y: 2 } }
+    // Pair (fallback, another-fallback): 42 vs {y:2} → 42 wins (non-obj beats obj)
+    // Pair (first, fallback-result=42): {x:1} vs 42 → {x:1} wins (obj over scalar, no merge)
+    // Result: { a: { x: 1 } }
+    const c1 = parse('a { x = 1 }')
+    const c2 = parse('a = 42')
+    const c3 = parse('a { y = 2 }')
+    // Currently produces {"a":{"x":1,"y":2}} — incorrectly merges all three.
+    expect(c1.withFallback(c2).withFallback(c3).toObject()).toEqual({ a: { x: 1 } })
+  })
+
+  it('S22.2: two adjacent objects do merge correctly', () => {
+    // Control: without a non-object interruption, two objects should merge.
+    const c1 = parse('a { x = 1 }')
+    const c2 = parse('a { y = 2 }')
+    expect(c1.withFallback(c2).toObject()).toEqual({ a: { x: 1, y: 2 } })
+  })
+
+  it('S22.2: non-object higher-priority wins over lower-priority object', () => {
+    // c1 wins (scalar 42 > object fallback) — this sub-rule already works
+    const c1 = parse('a = 42')
+    const c2 = parse('a { x = 1 }')
+    expect(c1.withFallback(c2).toObject()).toEqual({ a: 42 })
+  })
+})
+
+// S22.3 — setting key to null clears earlier object value (HOCON spec L1436)
+// Probe (2026-05-13): parse('a=null').withFallback(parse('a{x:1}')) → a=null ✅
+describe('S22.3 - null clears earlier object value in fallback (HOCON spec L1436)', () => {
+  it('S22.3: null in higher-priority config clears object in fallback', () => {
+    const c1 = parse('a = null')
+    const c2 = parse('a { x = 1 }')
+    // null (c1) has higher priority; it wins over the object in the fallback (c2).
+    expect(c1.withFallback(c2).get('a')).toBeNull()
+  })
+
+  it('S22.3: object in higher-priority config wins over null fallback', () => {
+    const c1 = parse('a { x = 1 }')
+    const c2 = parse('a = null')
+    // Object (c1) has higher priority; null fallback is just ignored.
+    expect(c1.withFallback(c2).toObject()).toEqual({ a: { x: 1 } })
+  })
+})
+
+// S26.2 — empty env var preserved as empty string (HOCON spec L1558)
+// Probe (2026-05-13): resolveStr('a = ${EMPTY_VAR}', { EMPTY_VAR: '' }) →
+// { kind: 'scalar', raw: '', valueType: 'string' } ✅
+describe('S26.2 - empty env var preserved as empty string (HOCON spec L1558)', () => {
+  it('S26.2: empty-string env var resolves to empty string, not undefined', () => {
+    const c = parse('a = ${EMPTY_VAR}', { env: { EMPTY_VAR: '' } })
+    expect(c.getString('a')).toBe('')
+  })
+
+  it('S26.2: empty-string env var does not cause required substitution error', () => {
+    // An empty string is a valid value — the field must exist after resolution.
+    const c = parse('a = ${EMPTY_VAR}', { env: { EMPTY_VAR: '' } })
+    expect(c.has('a')).toBe(true)
+  })
+})

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -598,9 +598,13 @@ describe('S17.8 - array to other type must error', () => {
 // S1.1 — files must be valid UTF-8 (HOCON spec L117)
 // The parse() API takes a JS string, which is already a decoded Unicode sequence
 // (Node.js decodes bytes to strings at the I/O boundary). The parser therefore
-// cannot observe raw byte sequences and has no mechanism to reject invalid UTF-8.
-// UTF-8 validation is the responsibility of the I/O layer (e.g. fs.readFileSync
-// with 'utf-8' encoding, which is what parseFile() uses). Status: ➖
+// cannot observe raw byte sequences and has no mechanism to detect or reject
+// invalid UTF-8. parseFile() uses fs.readFileSync(path, 'utf-8'), and Node's
+// default UTF-8 decoder is non-fatal: invalid byte sequences are silently
+// replaced with U+FFFD (REPLACEMENT CHARACTER), not thrown. Strict UTF-8
+// rejection would require a custom decoder (e.g. TextDecoder with
+// {fatal: true}) at the I/O layer. The parser layer cannot enforce S1.1 by
+// design — what reaches it is always a valid JS string. Status: ➖
 // Sanity check: multi-byte UTF-8 characters in values and keys parse correctly.
 describe('S1.1 - UTF-8 handling (HOCON spec L117)', () => {
   it('S1.1: multi-byte UTF-8 characters are accepted in string values', () => {

--- a/tests/properties.test.ts
+++ b/tests/properties.test.ts
@@ -44,3 +44,51 @@ describe('parseProperties', () => {
     expect(({} as Record<string, unknown>).polluted).toBeUndefined()
   })
 })
+
+// ---------------------------------------------------------------------------
+// Phase 5 spec debt tests
+// ---------------------------------------------------------------------------
+
+// S23.2 — empty path elements (leading/trailing dot) preserved (HOCON spec L1456)
+// Probe (2026-05-13):
+//   "a."  → { a: { '': 'hello' } }  ✅  trailing empty segment preserved
+//   "."   → { '': { '': 'hello' } } ✅  both segments empty
+//   ".a"  → { '': { a: 'hello' } }  ✅  leading empty segment preserved
+describe('S23.2 - empty path elements preserved in properties (HOCON spec L1456)', () => {
+  it('S23.2: trailing dot in key creates an empty last path segment', () => {
+    // spec L1457: a. is a path with two elements, "a" and empty string
+    const result = parseProperties('a.=hello')
+    expect(result).toEqual({ a: { '': 'hello' } })
+  })
+
+  it('S23.2: a single dot is a path with two empty elements', () => {
+    // spec L1457: "." is a path with two elements, both empty string
+    const result = parseProperties('.=hello')
+    expect(result).toEqual({ '': { '': 'hello' } })
+  })
+
+  it('S23.2: leading dot in key creates an empty first path segment', () => {
+    const result = parseProperties('.a=hello')
+    expect(result).toEqual({ '': { a: 'hello' } })
+  })
+})
+
+// S23.4 — object wins over string on conflicting key (HOCON spec L1485)
+// Probe (2026-05-13):
+//   "a=hello\na.b=world" → { a: { b: 'world' } }  ✅ (string overwritten by object expansion)
+//   "a.b=world\na=hello" → { a: 'hello' }          ❌ (string overwrites object — spec: object must win)
+describe('S23.4 - object wins over string on conflicting key in properties (HOCON spec L1485)', () => {
+  it('S23.4: string key followed by dotted key → object wins (string overwritten)', () => {
+    // a=hello, then a.b=world: setNested sees a is a string, replaces it with object
+    const result = parseProperties('a=hello\na.b=world')
+    expect(result).toEqual({ a: { b: 'world' } })
+  })
+
+  it.fails('S23.4: dotted key followed by string key → object must still win (spec L1485)', () => {
+    // a.b=world creates { a: { b: 'world' } }, then a=hello overwrites a with a string.
+    // Spec L1485: "the object must always win in this case."
+    // Currently: { a: 'hello' } — string wins. Bug: setNested does not protect existing objects.
+    const result = parseProperties('a.b=world\na=hello')
+    expect(result).toEqual({ a: { b: 'world' } })
+  })
+})

--- a/tests/resolver.test.ts
+++ b/tests/resolver.test.ts
@@ -802,11 +802,17 @@ describe('spec compliance Phase 3 — substitution & include (resolver-level)', 
 describe('S6.5 - "newline" means 0x000A (LF) only (HOCON spec L183)', () => {
   it('S6.5: CR alone (0x0D) does not act as a field separator', () => {
     // If CR were treated as newline, "x = 1\ry = 2" would produce two fields.
-    // Spec: newline = LF only, so CR is whitespace absorbed into the value.
+    // Spec: newline = LF only, so CR is whitespace absorbed into x's unquoted value
+    // and the entire `1\ry = 2` becomes a single string value (with CR normalized
+    // to a space per unquoted-string whitespace rules).
     const v = resolveStr('x = 1\ry = 2')
     const fields = obj(v)
     // Only one field 'x'; 'y' is not a separate top-level key.
     expect(fields.has('y')).toBe(false)
+    // And x's value is the absorbed-into-one-line string, proving CR was treated
+    // as whitespace rather than dropped or causing truncation. This guards against
+    // a false positive where 'y' could be absent for an unrelated reason.
+    expect(fields.get('x')).toEqual({ kind: 'scalar', raw: '1 y = 2', valueType: 'string' })
   })
 
   it('S6.5: LF (0x0A) acts as the field separator', () => {

--- a/tests/resolver.test.ts
+++ b/tests/resolver.test.ts
@@ -791,3 +791,145 @@ describe('spec compliance Phase 3 — substitution & include (resolver-level)', 
     ).toThrow()
   })
 })
+
+// ---------------------------------------------------------------------------
+// Phase 5 spec debt tests
+// ---------------------------------------------------------------------------
+
+// S6.5 — "newline" means specifically 0x000A (LF) (HOCON spec L183)
+// Probe (2026-05-13): 'x = 1\ry = 2' → x = "1\ry = 2" (CR absorbed into unquoted value).
+// CR (0x0D) is not treated as the field separator; only LF (0x0A) is.
+describe('S6.5 - "newline" means 0x000A (LF) only (HOCON spec L183)', () => {
+  it('S6.5: CR alone (0x0D) does not act as a field separator', () => {
+    // If CR were treated as newline, "x = 1\ry = 2" would produce two fields.
+    // Spec: newline = LF only, so CR is whitespace absorbed into the value.
+    const v = resolveStr('x = 1\ry = 2')
+    const fields = obj(v)
+    // Only one field 'x'; 'y' is not a separate top-level key.
+    expect(fields.has('y')).toBe(false)
+  })
+
+  it('S6.5: LF (0x0A) acts as the field separator', () => {
+    const v = resolveStr('x = 1\ny = 2')
+    expect(obj(v).get('x')).toEqual({ kind: 'scalar', raw: '1', valueType: 'number' })
+    expect(obj(v).get('y')).toEqual({ kind: 'scalar', raw: '2', valueType: 'number' })
+  })
+})
+
+// S7.6 — intermediate non-object value breaks merge with later object (HOCON spec L207)
+// Probe (2026-05-13): foo={a:42}, foo=null, foo={b:43} → result has only b=43 ✅
+describe('S7.6 - intermediate non-object breaks object merge (HOCON spec L207)', () => {
+  it('S7.6: intermediate null prevents merge; final object stands alone', () => {
+    // Spec L207-238 example:
+    //   foo : { "a" : 42 }
+    //   foo : null          ← non-object interrupts chain
+    //   foo : { "b" : 43 }
+    // Result: { foo: { b: 43 } } — the two objects never merge.
+    const v = resolveStr('foo = { a: 42 }\nfoo = null\nfoo = { b: 43 }')
+    const foo = obj(v).get('foo')
+    if (foo?.kind !== 'object') throw new Error('expected object')
+    expect(foo.fields.has('a')).toBe(false)
+    expect(foo.fields.get('b')).toEqual({ kind: 'scalar', raw: '43', valueType: 'number' })
+  })
+
+  it('S7.6: intermediate non-null scalar also prevents merge', () => {
+    const v = resolveStr('foo = { a: 42 }\nfoo = 99\nfoo = { b: 43 }')
+    const foo = obj(v).get('foo')
+    if (foo?.kind !== 'object') throw new Error('expected object')
+    expect(foo.fields.has('a')).toBe(false)
+    expect(foo.fields.get('b')).toEqual({ kind: 'scalar', raw: '43', valueType: 'number' })
+  })
+})
+
+// S10.9 — true/false stringify to "true"/"false" in concat (HOCON spec L363)
+// Probe (2026-05-13): 'x = true foo' → "true foo" ✅
+describe('S10.9 - true/false stringify in value concat (HOCON spec L363)', () => {
+  it('S10.9: "true" keyword stringifies to "true" in concatenation', () => {
+    const v = resolveStr('x = true foo')
+    expect(obj(v).get('x')).toEqual({ kind: 'scalar', raw: 'true foo', valueType: 'string' })
+  })
+
+  it('S10.9: "false" keyword stringifies to "false" in concatenation', () => {
+    const v = resolveStr('x = false bar')
+    expect(obj(v).get('x')).toEqual({ kind: 'scalar', raw: 'false bar', valueType: 'string' })
+  })
+})
+
+// S10.10 — null stringifies to "null" in concat (HOCON spec L364)
+// Probe (2026-05-13): 'x = null foo' → "null foo" ✅
+describe('S10.10 - null stringifies to "null" in value concat (HOCON spec L364)', () => {
+  it('S10.10: "null" keyword stringifies to "null" in concatenation', () => {
+    const v = resolveStr('x = null foo')
+    expect(obj(v).get('x')).toEqual({ kind: 'scalar', raw: 'null foo', valueType: 'string' })
+  })
+
+  it('S10.10: "null" alone is not stringified (type preserved as null)', () => {
+    // Single non-string value is NOT converted (spec L376)
+    const v = resolveStr('x = null')
+    expect(obj(v).get('x')).toEqual({ kind: 'scalar', raw: 'null', valueType: 'null' })
+  })
+})
+
+// S10.16 — non-newline whitespace in arrays produces concat, not separate elements (HOCON spec L447)
+// Probe (2026-05-13): '[ 1 2 3 4 ]' → ["1 2 3 4"] (one string element) ✅
+describe('S10.16 - non-newline whitespace in arrays makes concat, not elements (HOCON spec L447)', () => {
+  it('S10.16: [1 2 3 4] is one concatenated string element, not four integers', () => {
+    const v = resolveStr('a = [ 1 2 3 4 ]')
+    const a = obj(v).get('a')
+    if (a?.kind !== 'array') throw new Error('expected array')
+    // spec: "this is an array with one element, the string '1 2 3 4'"
+    expect(a.items).toHaveLength(1)
+    expect(a.items[0]).toEqual({ kind: 'scalar', raw: '1 2 3 4', valueType: 'string' })
+  })
+
+  it('S10.16: elements separated by newlines are distinct', () => {
+    const v = resolveStr('a = [\n1\n2\n3\n4\n]')
+    const a = obj(v).get('a')
+    if (a?.kind !== 'array') throw new Error('expected array')
+    expect(a.items).toHaveLength(4)
+  })
+})
+
+// S14a.7 — whitespace (including newlines) allowed between `include` and resource name
+// (HOCON spec L952)
+// Probe (2026-05-13): include\n"file.conf" parses and resolves correctly ✅
+describe('S14a.7 - whitespace/newlines allowed between include and resource name (HOCON spec L952)', () => {
+  it('S14a.7: newline between include keyword and quoted filename is accepted', () => {
+    const v = resolveStr('include\n"inc.conf"', {}, { '/inc.conf': 'x = 42' })
+    expect(obj(v).get('x')).toEqual({ kind: 'scalar', raw: '42', valueType: 'number' })
+  })
+
+  it('S14a.7: multiple spaces between include keyword and quoted filename is accepted', () => {
+    const v = resolveStr('include   "inc.conf"', {}, { '/inc.conf': 'y = 7' })
+    expect(obj(v).get('y')).toEqual({ kind: 'scalar', raw: '7', valueType: 'number' })
+  })
+})
+
+// S13a.10 — substitution memoized by instance, not by path (HOCON spec L885)
+// This is an internal resolver implementation detail. Two ${b} substitutions at
+// different positions in the file resolve using the same lookup document (the final
+// merged config), so both naturally see the same result. No externally observable
+// difference exists between "memoized by instance" and "resolved independently" when
+// the config is non-self-referential. Status: ➖ (not externally observable via the
+// black-box public API; structural reason: the spec rule constrains resolver internals,
+// not the observable output for any valid input program).
+
+// S13a.3 — self-ref before any prior value → error (HOCON spec L767)
+// Probe (2026-05-13): resolveStr('a = ${a}') throws ResolveError "circular substitution: a".
+// Spec L767-773: error should be treated as "undefined" (missing subst) rather than
+// "intractable cycle". Both lead to an error, but the error message differs.
+// Classification: ⚠️ — error is raised (correct), but as a cycle error rather than a
+// missing-substitution error; the spec wants "undefined" semantics for this case.
+describe('S13a.3 - self-ref with no prior value → error (HOCON spec L767)', () => {
+  it('S13a.3: a = ${a} with no prior value for a raises an error', () => {
+    // Spec: treated as "undefined" — same outcome as required substitution not found.
+    // Impl raises ResolveError("circular substitution: a") instead of a missing-path error,
+    // but an error IS raised either way. ⚠️ wrong error message, correct behavior.
+    expect(() => resolveStr('a = ${a}')).toThrow(ResolveError)
+  })
+
+  it('S13a.3: a = ${a} is distinct from a two-step cycle (both error, but different cause)', () => {
+    // Two-step cycle — also an error, per S13a.8
+    expect(() => resolveStr('a = ${b}\nb = ${a}')).toThrow(ResolveError)
+  })
+})


### PR DESCRIPTION
## Summary

Probed and reclassified all 20 remaining 🤷 (unverified) spec items for ts.hocon. No src/ changes — test debt only.

## Per-item classification

| Item | Status | Notes |
|------|--------|-------|
| S1.1 | ➖ | JS string API; UTF-8 validation is I/O layer concern |
| S3.1 | ❌ | `parse('')` returns empty Config; spec requires error |
| S6.5 | ✅ | CR not treated as LF field separator |
| S7.6 | ✅ | Intermediate null/scalar breaks object merge |
| S10.9 | ✅ | `true`/`false` stringify to `"true"`/`"false"` in concat |
| S10.10 | ✅ | `null` stringifies to `"null"` in concat |
| S10.16 | ✅ | Non-newline whitespace in arrays produces concat |
| S13a.3 | ⚠️ | Error raised, but as "cycle" not "undefined" per spec L767 |
| S13a.10 | ➖ | Internal memoization detail — not observable via public API |
| S14a.7 | ✅ | Newlines between `include` and filename accepted |
| S14a.11 | ✅ | Quoted `"include"` is a normal key |
| S18.1 | ❌ | Bare number not treated as default unit in `getDuration()` |
| S18.3 | ✅ | Non-letter unit names rejected (via map lookup) |
| S18.4 | ❌ | String with no unit suffix not accepted as default-unit value |
| S19.8 | ❌ | `parseDuration` lowercases unit → uppercase accepted; should reject |
| S22.2 | ❌ | `deepMergeHocon` ignores non-object interruption in fallback chain |
| S22.3 | ✅ | `null` in higher-priority config clears lower-priority object |
| S23.2 | ✅ | Leading/trailing dots in property keys preserved as empty segments |
| S23.4 | ❌ | String overwrites object when string key appears after dotted key |
| S26.2 | ✅ | Empty env var preserved as empty string, not undefined |

## New compliance rate

| Metric | Before | After |
|--------|--------|-------|
| spec-total | 68.7% | **74.2%** |
| in-scope | 76.3% | **83.3%** |
| Remaining 🤷 | 20 | **0** |

OOS count increased from 21 → 23 (S1.1, S13a.10 newly classified ➖). Main thread should re-roll-up `xx.hocon/docs/compliance-matrix.md` after merge.

## Methodology

Per Phase 4 retrospective rules: probe before pinning, tight pins, no false positives. Each item has a date-stamped probe observation in the test comment.

## ❌ bugs deferred to Phase 6

- **S3.1**: `parse('')` should throw — guard needed in `parse()` or `parseTokens()`
- **S18.1 / S18.4**: `parseDuration` doesn't handle empty unit → bare numbers and unit-less strings fail
- **S19.8**: `parseDuration` applies `.toLowerCase()` — remove to enforce case-sensitivity
- **S22.2**: `deepMergeHocon` needs value-sequence history per key to detect non-object interruption
- **S23.4**: `setNested` in `properties.ts` needs guard to prevent string overwriting existing object

## Multi-agent review summary

- Claude (design/logic): PASS. Two Minor findings, neither requiring fixes: (1) S3.1 `it.fails` uses broad `toThrow()` which is correct pattern for "spec says throw but impl doesn't"; (2) S13a.3 second test tests S13a.8 behavior but is accurately described. No Critical or Important findings.
- Codex (security/performance): Read full diff and source files; confirmed test-only patch with no security or performance concerns. No Critical or Important findings.

**Critical fixed:** 0 | **Important fixed:** 0 | **Minor deferred:** 2 (acceptable per review)