### PR TITLE
refactor(parser): use TokenKind type for skip() parameter

### DIFF
--- a/src/internal/parser/parser.ts
+++ b/src/internal/parser/parser.ts
@@ -1,7 +1,7 @@
 import { DECIMAL_NUMBER_RE } from '../../coerce.js'
 import { ParseError } from '../../errors.js'
 import type { ScalarValueType } from '../../value.js'
-import type { Token } from '../lexer/token.js'
+import type { Token, TokenKind } from '../lexer/token.js'
 import type { AstNode, AstField, Pos } from './ast.js'
 
 const EOF_TOKEN: Token = { kind: 'eof', value: '', line: 0, col: 0, isQuoted: false, precedingSpace: false, subst: undefined }
@@ -56,7 +56,7 @@ class Parser {
     if (this.pos < this.tokens.length) this.pos++
     return t ?? EOF_TOKEN
   }
-  private skip(...kinds: string[]): void {
+  private skip(...kinds: TokenKind[]): void {
     while (kinds.includes(this.peek().kind)) this.advance()
   }
 


### PR DESCRIPTION
## Summary

- Narrows `Parser.skip()` parameter from `...kinds: string[]` to `...kinds: TokenKind[]`
- Adds `TokenKind` to the existing type-only import from `../lexer/token.js`
- Pure type-only refactor — no behavior change

Closes #53 (P3, found by Copilot on PR #52)

## Why

Previously any string compiled, making token-kind typos undetectable at the call site. Now `tsc` enforces that callers pass valid `TokenKind` literals.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 465 passed, 49 expected-fail, 1 skipped (no regressions)
- [x] Audited all 14 call sites — all pass `'newline'` (valid `TokenKind`), no caller changes required
- [x] `skip` is private → no public API surface change

🤖 Generated with [Claude Code](https://claude.com/claude-code)