### PR TITLE
chore: bump CI Node matrix to 22/24/26 and Actions to Node 24 runtime

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,16 +37,16 @@ jobs:
             echo "Deploying docs for v$TAG"
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: steps.version.outputs.skip == 'false'
 
       - name: Set up pnpm
         if: steps.version.outputs.skip == 'false'
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Set up Node.js
         if: steps.version.outputs.skip == 'false'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "24"
           cache: pnpm

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,15 +12,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
-          node-version: "22"
+          node-version: "24"
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "24"
           cache: pnpm

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,20 +13,20 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ["20", "22"]
+        node: ["22", "24", "26"]
         os: [ubuntu-latest]
         include:
-          - node: "22"
+          - node: "24"
             os: macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node }}
           cache: pnpm
@@ -35,7 +35,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Cache expected JSON
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             tests/lightbend/testdata/expected
@@ -53,11 +53,11 @@ jobs:
         run: pnpm test
 
       - name: Test with coverage
-        if: matrix.node == '22' && matrix.os == 'ubuntu-latest'
+        if: matrix.node == '24' && matrix.os == 'ubuntu-latest'
         run: pnpm coverage
 
       - name: Upload coverage to Codecov
-        if: matrix.node == '22' && matrix.os == 'ubuntu-latest'
+        if: matrix.node == '24' && matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.ja.md
+++ b/README.ja.md
@@ -22,7 +22,7 @@
 npm install @o3co/ts.hocon
 ```
 
-Node.js 20 以上が必要です。
+Node.js 22 以上が必要です。
 
 ### 2. 使い方
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A [Lightbend HOCON](https://github.com/lightbend/config/blob/main/HOCON.md) pars
 npm install @o3co/ts.hocon
 ```
 
-Requires Node.js 20+.
+Requires Node.js 22+.
 
 ### 2. Use
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   },
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "homepage": "https://o3co.github.io/ts.hocon/",
   "bugs": "https://github.com/o3co/ts.hocon/issues",


### PR DESCRIPTION
## Summary

- **Node test matrix**: `["20", "22"]` → `["22", "24", "26"]`; macOS slot now on Node 24
- **Coverage gate**: condition updated from Node 22 → Node 24 (still hits exactly one cell)
- **lint.yml**: node-version 22 → 24 (current LTS)
- **Actions bumped to Node 24 runtime**:
  - `actions/checkout@v4 → v5`
  - `actions/setup-node@v4 → v5` (intentionally NOT v6 — v6 dropped `cache: pnpm`)
  - `actions/cache@v4 → v5`
  - `pnpm/action-setup@v4 → v6`
- **`engines.node`**: `">=20"` → `">=22"` (Node 20 reached EOL 2026-04)
- **README.md / README.ja.md**: documented Node requirement updated 20+ → 22+ (alignment)

Closes the org-wide "Actions Node.js 24 upgrade" deadline (2026-06-02) for this repo.

## Why

- Node 20 hit EOL in April 2026 — keeping it in the matrix and engines is misleading.
- GitHub deprecated Node 20 as Actions runtime; staying on `@v4` of checkout/setup-node/cache means deprecation warnings on every run.
- Node 26 (released 2026-04, current) is included to surface upstream regressions early; `fail-fast: false` is already set so a transient 26-only break does not block other cells.

## Version-selection notes

- `actions/setup-node@v6` was rejected: its release notes state "Limit automatic caching to npm" — `cache: pnpm` would break in v6. v5 already runs on Node 24, which satisfies the deprecation deadline.
- `actions/checkout@v6` was rejected for conservatism: v6 changed credential persistence ("Persist creds to a separate file") and `docs.yml` does `git push origin HEAD:gh-pages --force`. v5 keeps current behavior.

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm test` — 465 passed, 49 expected-fail, 1 skipped (no regressions from source change — there is none)
- [x] Verify CI cycle on this branch:
  - [ ] All 4 Node matrix cells (22 ubuntu, 24 ubuntu, 26 ubuntu, 24 macos) pass
  - [ ] Coverage uploads exactly once (gated on `matrix.node == '24' && matrix.os == 'ubuntu-latest'`)
  - [ ] No "duplicate cache" warning from setup-node v5 + explicit `cache: pnpm` + `packageManager` field interaction
- [ ] Engines bump (`>=20` → `>=22`) tracked for next release notes / CHANGELOG entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)