### PR TITLE
fix(lexer): expand whitespace recognition to HOCON spec set (S6.1/6.2/6.4)

### DIFF
--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -118,17 +118,17 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
 ## S6. Whitespace
 
 - **S6.1** Unicode Zs/Zl/Zp category characters are whitespace — §Whitespace (L170)
-  tests: tests/lexer.test.ts:286; tests/lexer.test.ts:293
-  status: ❌ ([#72](https://github.com/o3co/ts.hocon/issues/72)) — lexer only recognizes ASCII space/tab/CR; Unicode whitespace categories leak into unquoted runs
+  tests: tests/lexer.test.ts:296; tests/lexer.test.ts:303
+  status: ✅ (fixed by PR fix/s6-whitespace-expansion, issue #72 resolved)
 - **S6.2** Non-breaking spaces (0x00A0, 0x2007, 0x202F) are whitespace — §Whitespace (L171)
-  tests: tests/lexer.test.ts:310; tests/lexer.test.ts:317; tests/lexer.test.ts:323
-  status: ❌ ([#72](https://github.com/o3co/ts.hocon/issues/72)) — NBSP / figure space / narrow NBSP are not recognized as whitespace
+  tests: tests/lexer.test.ts:320; tests/lexer.test.ts:327; tests/lexer.test.ts:333
+  status: ✅ (fixed by PR fix/s6-whitespace-expansion, issue #72 resolved)
 - **S6.3** BOM (0xFEFF) treated as whitespace — §Whitespace (L173)
-  tests: tests/lexer.test.ts:161; tests/lightbend/testdata/bom.conf (fixture)
-  status: ✅
+  tests: tests/lexer.test.ts:161; tests/lexer.test.ts:166; tests/lightbend/testdata/bom.conf (fixture)
+  status: ✅ (broadened: BOM is now whitespace anywhere, not only at start-of-input; mid-stream test added)
 - **S6.4** ASCII control whitespace (tab, vtab, FF, CR, FS, GS, RS, US) — §Whitespace (L174)
-  tests: tests/lexer.test.ts:333; tests/lexer.test.ts:339; tests/lexer.test.ts:344; tests/lexer.test.ts:350; tests/lexer.test.ts:356
-  status: ⚠️ ([#72](https://github.com/o3co/ts.hocon/issues/72)) — 2 of 8 sub-rules pass: tab (0x09) and CR (0x0D) are recognized; vtab (0x0B), FF (0x0C), FS–US (0x1C–0x1F) are not. The ⚠️ glyph contributes 0.5 to the rate per legend; the actual sub-rule coverage is 25%
+  tests: tests/lexer.test.ts:343; tests/lexer.test.ts:349; tests/lexer.test.ts:354; tests/lexer.test.ts:360; tests/lexer.test.ts:366
+  status: ✅ (fixed by PR fix/s6-whitespace-expansion, issue #72 resolved — all 8 chars now recognized)
 - **S6.5** "newline" means specifically 0x000A (LF) — §Whitespace (L183)
   tests: tests/resolver.test.ts (S6.5 describe block)
   status: ✅

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -129,6 +129,10 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
 - **S6.4** ASCII control whitespace (tab, vtab, FF, CR, FS, GS, RS, US) — §Whitespace (L174)
   tests: tests/lexer.test.ts:343; tests/lexer.test.ts:349; tests/lexer.test.ts:354; tests/lexer.test.ts:360; tests/lexer.test.ts:366
   status: ✅ (fixed by PR fix/s6-whitespace-expansion, issue #72 resolved — all 8 chars now recognized)
+  note — CR inside `${...}`: the S6 GREEN commit changed CR (0x0D) inside a substitution body from
+  "unterminated substitution" error to "consumed as inter-segment whitespace". This is intentional per
+  spec §F (newline = LF only; CR is whitespace) and is 3-way-convergent across ts/rs/go.
+  Tests pinning this behavior: tests/lexer.test.ts:280 (NBSP), :287 (Zl), :294 (vtab), :301 (CR).
 - **S6.5** "newline" means specifically 0x000A (LF) — §Whitespace (L183)
   tests: tests/resolver.test.ts (S6.5 describe block)
   status: ✅

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -118,16 +118,16 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
 ## S6. Whitespace
 
 - **S6.1** Unicode Zs/Zl/Zp category characters are whitespace — §Whitespace (L170)
-  tests: tests/lexer.test.ts:296; tests/lexer.test.ts:303
+  tests: tests/lexer.test.ts:336; tests/lexer.test.ts:343
   status: ✅ (fixed by PR fix/s6-whitespace-expansion, issue #72 resolved)
 - **S6.2** Non-breaking spaces (0x00A0, 0x2007, 0x202F) are whitespace — §Whitespace (L171)
-  tests: tests/lexer.test.ts:320; tests/lexer.test.ts:327; tests/lexer.test.ts:333
+  tests: tests/lexer.test.ts:360; tests/lexer.test.ts:367; tests/lexer.test.ts:373
   status: ✅ (fixed by PR fix/s6-whitespace-expansion, issue #72 resolved)
 - **S6.3** BOM (0xFEFF) treated as whitespace — §Whitespace (L173)
   tests: tests/lexer.test.ts:161; tests/lexer.test.ts:166; tests/lightbend/testdata/bom.conf (fixture)
   status: ✅ (broadened: BOM is now whitespace anywhere, not only at start-of-input; mid-stream test added)
 - **S6.4** ASCII control whitespace (tab, vtab, FF, CR, FS, GS, RS, US) — §Whitespace (L174)
-  tests: tests/lexer.test.ts:343; tests/lexer.test.ts:349; tests/lexer.test.ts:354; tests/lexer.test.ts:360; tests/lexer.test.ts:366
+  tests: tests/lexer.test.ts:383; tests/lexer.test.ts:389; tests/lexer.test.ts:394; tests/lexer.test.ts:400; tests/lexer.test.ts:406
   status: ✅ (fixed by PR fix/s6-whitespace-expansion, issue #72 resolved — all 8 chars now recognized)
   note — CR inside `${...}`: the S6 GREEN commit changed CR (0x0D) inside a substitution body from
   "unterminated substitution" error to "consumed as inter-segment whitespace". This is intentional per

--- a/src/internal/lexer/lexer.ts
+++ b/src/internal/lexer/lexer.ts
@@ -1,6 +1,50 @@
 import { ParseError } from '../../errors.js'
 import type { Segment, SubstPayload, Token, TokenKind } from './token.js'
 
+/**
+ * Returns true if `ch` is a HOCON whitespace character per spec §Whitespace
+ * (HOCON.md L165-184). This is the canonical single-source predicate; all
+ * three lexer sites route through it.
+ *
+ * HOCON_WS = Java Character.isWhitespace set
+ *          ∪ { 0x00A0, 0x2007, 0x202F }   (NBSP variants Java excludes)
+ *          ∪ { 0xFEFF }                    (BOM)
+ *
+ * NOTE: 0x0A (LF) is included here but isHoconNewline takes priority in the
+ * main loop — the caller must check isHoconNewline BEFORE isHoconWhitespace.
+ * NOTE: Do NOT use regex /\s/ (misses 0x1C-0x1F) or stdlib unicode.IsSpace
+ * (includes NEL 0x0085 which HOCON does not list). Hardcode the set.
+ */
+function isHoconWhitespace(ch: string): boolean {
+  const cp = ch.codePointAt(0) ?? -1
+  // ASCII control whitespace: tab, LF, VT, FF, CR
+  if (cp === 0x09 || cp === 0x0A || cp === 0x0B || cp === 0x0C || cp === 0x0D) return true
+  // File/group/record/unit separators (0x1C-0x1F)
+  if (cp >= 0x1C && cp <= 0x1F) return true
+  // ASCII space, NBSP (0x00A0), BOM (0xFEFF) — fast path
+  if (cp === 0x20 || cp === 0xA0 || cp === 0xFEFF) return true
+  // Ogham space mark (Zs)
+  if (cp === 0x1680) return true
+  // En quad through hair space (Zs, 0x2000-0x200A)
+  if (cp >= 0x2000 && cp <= 0x200A) return true
+  // Line separator (Zl), paragraph separator (Zp), narrow no-break space (Zs),
+  // medium mathematical space (Zs)
+  if (cp === 0x2028 || cp === 0x2029 || cp === 0x202F || cp === 0x205F) return true
+  // Ideographic space (Zs)
+  if (cp === 0x3000) return true
+  return false
+}
+
+/**
+ * Returns true only for ASCII LF (0x0A), the sole HOCON newline character.
+ * Per HOCON.md L182-184: "newline refers only and specifically to ASCII
+ * newline 0x000A". Zl (0x2028) and Zp (0x2029) are whitespace, NOT newlines.
+ * Must be checked BEFORE isHoconWhitespace in the main lexer loop.
+ */
+function isHoconNewline(ch: string): boolean {
+  return ch === '\n'
+}
+
 const SINGLE_CHAR_TOKENS: Record<string, TokenKind> = {
   '{': 'lbrace',
   '}': 'rbrace',
@@ -26,18 +70,20 @@ class Lexer {
       const sl = this.line, sc = this.col
       const ch = this.peek()
 
-      // Whitespace (not newline)
-      if (ch === ' ' || ch === '\t' || ch === '\r') {
-        this.advance(); this.hadSpace = true; continue
-      }
-
-      // Newline
-      if (ch === '\n') {
+      // Newline — must be checked before isHoconWhitespace because
+      // isHoconWhitespace returns true for 0x0A (LF); if whitespace were
+      // checked first, LF would be silently consumed and no newline token emitted.
+      if (isHoconNewline(ch)) {
         this.advance()
         if (this.tokens[this.tokens.length - 1]?.kind !== 'newline') {
           this.push('newline', '\n', sl, sc)
         }
         continue
+      }
+
+      // Whitespace (not newline) — expanded to full HOCON_WS set per spec §Whitespace
+      if (isHoconWhitespace(ch)) {
+        this.advance(); this.hadSpace = true; continue
       }
 
       // Comments
@@ -295,12 +341,15 @@ class Lexer {
         curCol = 0
         lastDot = [startLine, dotCol]
         this.advance()
-      } else if (ch === ' ' || ch === '\t') {
-        // WS: buffer into pendingWs
+      } else if (isHoconNewline(ch)) {
+        // LF inside ${...} is an error: substitutions cannot span newlines
+        throw new ParseError('unterminated substitution', startLine, startCol)
+      } else if (isHoconWhitespace(ch)) {
+        // Non-newline HOCON whitespace (incl. NBSP, Zs/Zl/Zp, vtab, FS-US, BOM):
+        // buffer into pendingWs; col advances in this.advance() per §F.
+        // CR is whitespace, not newline — it is buffered here, not an error.
         pendingWs += ch
         this.advance()
-      } else if (ch === '\n' || ch === '\r') {
-        throw new ParseError('unterminated substitution', startLine, startCol)
       } else {
         throw new ParseError(`unexpected character in substitution path: ${JSON.stringify(ch)}`, startLine, this.col)
       }
@@ -328,19 +377,26 @@ export function tokenize(input: string): Token[] {
 
 /**
  * Returns true if `ch` is a valid unquoted character inside a `${...}` body.
- * Forbidden: whitespace, `"`, `\`, structural chars, operators, sigils.
+ * Forbidden: whitespace (full HOCON_WS set), `"`, `\`, structural chars,
+ * operators, sigils.
  */
 function isUnquotedSubstChar(ch: string): boolean {
-  return ch !== '' && !' \t\n\r"\\'
-    .includes(ch) && !'{}[]'.includes(ch) && !':=,+#`^?!@*&$.'.includes(ch)
+  if (ch === '' || isHoconWhitespace(ch)) return false
+  if ('"\\'.includes(ch)) return false
+  if ('{}[]'.includes(ch)) return false
+  if (':=,+#`^?!@*&$.'.includes(ch)) return false
+  return true
 }
 
 function isUnquotedStart(ch: string): boolean {
-  return ch !== '' && !'{}[],:=+#\n\r\t "$?!@*&^\\'.includes(ch)
+  if (ch === '' || isHoconWhitespace(ch)) return false
+  if ('{}[],:=+#"$?!@*&^\\'.includes(ch)) return false
+  return true
 }
 
 function isUnquotedContinue(ch: string, nextFn: () => string): boolean {
-  if (ch === '' || '{}[],:=\n\r\t #"$?!@*&^\\'.includes(ch) || ch === ' ') return false
+  if (ch === '' || isHoconWhitespace(ch)) return false
+  if ('{}[],:=#"$?!@*&^\\'.includes(ch)) return false
   if (ch === '+' && nextFn() === '=') return false
   if (ch === '/' && nextFn() === '/') return false
   return true

--- a/src/internal/lexer/lexer.ts
+++ b/src/internal/lexer/lexer.ts
@@ -4,7 +4,9 @@ import type { Segment, SubstPayload, Token, TokenKind } from './token.js'
 /**
  * Returns true if `ch` is a HOCON whitespace character per spec §Whitespace
  * (HOCON.md L165-184). This is the canonical single-source predicate; all
- * three lexer sites route through it.
+ * lexer call sites route through it: the main loop whitespace-skip, the
+ * substitution body inter-segment whitespace skip, `isUnquotedSubstChar`,
+ * `isUnquotedStart`, and `isUnquotedContinue`.
  *
  * HOCON_WS = Java Character.isWhitespace set
  *          ∪ { 0x00A0, 0x2007, 0x202F }   (NBSP variants Java excludes)

--- a/tests/lexer.test.ts
+++ b/tests/lexer.test.ts
@@ -341,19 +341,19 @@ describe('spec compliance Phase 1 — lexer-level', () => {
     expect(tokens.map(t => t.kind)).toEqual(['unquoted', 'unquoted'])
   })
 
-  it.fails('S6.4: vertical tab (0x0B) is whitespace', () => {
+  it('S6.4: vertical tab (0x0B) is whitespace', () => {
     const tokens = tokenize('a\x0Bb').filter(t => t.kind !== 'eof')
     expect(tokens.map(t => t.kind)).toEqual(['unquoted', 'unquoted'])
     expect(tokens[0].value).toBe('a')
   })
 
-  it.fails('S6.4: form feed (0x0C) is whitespace', () => {
+  it('S6.4: form feed (0x0C) is whitespace', () => {
     const tokens = tokenize('a\x0Cb').filter(t => t.kind !== 'eof')
     expect(tokens.map(t => t.kind)).toEqual(['unquoted', 'unquoted'])
     expect(tokens[0].value).toBe('a')
   })
 
-  it.fails('S6.4: file/group/record/unit separators (0x1C-0x1F) are whitespace', () => {
+  it('S6.4: file/group/record/unit separators (0x1C-0x1F) are whitespace', () => {
     for (const ch of ['\x1C', '\x1D', '\x1E', '\x1F']) {
       const tokens = tokenize(`a${ch}b`).filter(t => t.kind !== 'eof')
       expect(tokens.map(t => t.kind), `for char U+00${ch.charCodeAt(0).toString(16).toUpperCase()}`)

--- a/tests/lexer.test.ts
+++ b/tests/lexer.test.ts
@@ -371,6 +371,14 @@ describe('spec compliance Phase 1 — lexer-level', () => {
     }
   })
 
+  // Regression guard: LF must still emit a newline token after isHoconWhitespace
+  // predicate centralization. isHoconWhitespace returns true for 0x0A, so if the
+  // newline check runs AFTER the whitespace skip, LF would be silently consumed.
+  it('S6 LF still emits newline token (regression guard)', () => {
+    const tokens = tokenize('a\nb')
+    expect(tokens.some(t => t.kind === 'newline')).toBe(true)
+  })
+
   // --- S8.6: unquoted string cannot begin with 0-9 or - --------------------
   // Spec L270. Already-known violation tracked in docs/spec-compliance.md.
   // Tests go through full parse(), not just tokenize(), so a fix at either

--- a/tests/lexer.test.ts
+++ b/tests/lexer.test.ts
@@ -342,17 +342,9 @@ describe('spec compliance Phase 1 — lexer-level', () => {
 
   it('S6.1: line separator (U+2028, Zl) separates two unquoted tokens', () => {
     const tokens = tokenize('a b').filter(t => t.kind !== 'eof')
-    // Spec says U+2028 (Zl) is whitespace and should separate tokens.
-    // Currently ts.hocon folds it into the unquoted run, producing a single
-    // token "a<U+2028>b". When fixed via #72, expect the lexer to emit two
-    // unquoted tokens with values "a" and "b".
-    //
-    // NOTE on it.fails wrong-reason risk: a hypothetical fix that REJECTS
-    // U+2028 with a throw would also flip this test (it.fails counts a throw
-    // as "expected failure"). That fix would be spec-incorrect — see #72 for
-    // the spec-correct expectation. Reviewers of any #72 fix should verify
-    // the impl matches spec intent (whitespace) rather than just satisfying
-    // this pin.
+    // Spec L170: U+2028 (Zl, line separator) is Unicode whitespace and must
+    // separate tokens. Fixed by PR fix/s6-whitespace-expansion (#72): the
+    // lexer now recognises the full Zs/Zl/Zp Unicode whitespace set.
     expect(tokens.map(t => t.value)).toEqual(['a', 'b'])
   })
 

--- a/tests/lexer.test.ts
+++ b/tests/lexer.test.ts
@@ -163,6 +163,16 @@ describe('tokenize', () => {
     expect(tokens[0].value).toBe('foo')
   })
 
+  it('S6.3 BOM mid-stream is whitespace', () => {
+    // Per spec \u00A7Whitespace, BOM (U+FEFF) is whitespace anywhere, not just at
+    // start-of-input. A BOM embedded between two unquoted tokens acts as a
+    // separator. Broadened from "strip at start only" by S6 fix (#72).
+    const tokens = tokenize('foo\uFEFFbar').filter(t => t.kind !== 'eof')
+    expect(tokens.map(t => t.kind)).toEqual(['unquoted', 'unquoted'])
+    expect(tokens[0].value).toBe('foo')
+    expect(tokens[1].value).toBe('bar')
+  })
+
   it('stops unquoted scan at $ for concat', () => {
     const tokens = tokenize('foo${bar}')
     expect(tokens[0].kind).toBe('unquoted')

--- a/tests/lexer.test.ts
+++ b/tests/lexer.test.ts
@@ -267,6 +267,46 @@ describe('Segment positions', () => {
   })
 })
 
+describe('Subst body whitespace (S6 inside subst)', () => {
+  // NBSP, Zl, vtab, and CR inside ${...} are treated as inter-segment
+  // whitespace: buffered as pendingWs, not rejected as forbidden chars.
+  // Each case produces a single segment with the whitespace absorbed into
+  // the text, mirroring ASCII-space behavior (${foo bar} => one segment).
+  //
+  // Per spec F: CR is whitespace, not a newline. It must NOT trigger
+  // "unterminated substitution" (only LF does). Intentional and
+  // 3-way-convergent across ts/rs/go.
+
+  it('NBSP (\u00A0) inside subst body is inter-segment whitespace', () => {
+    // ${foo<NBSP>bar}: NBSP buffered as pendingWs, merged into one segment
+    const segs = substSegments('${foo\u00A0bar}')
+    expect(segs).toHaveLength(1)
+    expect(segs[0]?.text).toBe('foo\u00A0bar')
+  })
+
+  it('Zl (\u2028) inside subst body is inter-segment whitespace', () => {
+    // ${foo<Zl>bar}: line separator buffered as pendingWs
+    const segs = substSegments('${foo\u2028bar}')
+    expect(segs).toHaveLength(1)
+    expect(segs[0]?.text).toBe('foo\u2028bar')
+  })
+
+  it('vtab (\u000B) inside subst body is inter-segment whitespace', () => {
+    // ${foo<VT>bar}: vertical tab buffered as pendingWs
+    const segs = substSegments('${foo\u000Bbar}')
+    expect(segs).toHaveLength(1)
+    expect(segs[0]?.text).toBe('foo\u000Bbar')
+  })
+
+  it('CR (\u000D) inside subst body is whitespace, not an error (spec F)', () => {
+    // ${foo<CR>bar}: CR is whitespace (only LF = newline per spec F);
+    // must NOT throw "unterminated substitution".
+    const segs = substSegments('${foo\u000Dbar}')
+    expect(segs).toHaveLength(1)
+    expect(segs[0]?.text).toBe('foo\u000Dbar')
+  })
+})
+
 // -----------------------------------------------------------------------------
 // Spec compliance Phase 1 (issue #70): lexer-level rules.
 //

--- a/tests/lexer.test.ts
+++ b/tests/lexer.test.ts
@@ -307,20 +307,20 @@ describe('spec compliance Phase 1 — lexer-level', () => {
   })
 
   // --- S6.2: non-breaking spaces are whitespace ----------------------------
-  it.fails('S6.2: NBSP (U+00A0) separates tokens', () => {
+  it('S6.2: NBSP (U+00A0) separates tokens', () => {
     const tokens = tokenize('a b').filter(t => t.kind !== 'eof')
     expect(tokens.map(t => t.kind)).toEqual(['unquoted', 'unquoted'])
     expect(tokens[0].value).toBe('a')
     expect(tokens[1].value).toBe('b')
   })
 
-  it.fails('S6.2: figure space (U+2007) separates tokens', () => {
+  it('S6.2: figure space (U+2007) separates tokens', () => {
     const tokens = tokenize('a b').filter(t => t.kind !== 'eof')
     expect(tokens.map(t => t.kind)).toEqual(['unquoted', 'unquoted'])
     expect(tokens[0].value).toBe('a')
   })
 
-  it.fails('S6.2: narrow no-break space (U+202F) separates tokens', () => {
+  it('S6.2: narrow no-break space (U+202F) separates tokens', () => {
     const tokens = tokenize('a b').filter(t => t.kind !== 'eof')
     expect(tokens.map(t => t.kind)).toEqual(['unquoted', 'unquoted'])
     expect(tokens[0].value).toBe('a')

--- a/tests/lexer.test.ts
+++ b/tests/lexer.test.ts
@@ -283,14 +283,14 @@ describe('spec compliance Phase 1 — lexer-level', () => {
   // --- S6.1: Unicode Zs / Zl / Zp category characters are whitespace -------
   // Spec L170: lexer must treat any Unicode whitespace (Zs/Zl/Zp categories)
   // as separator. ts.hocon currently only handles ASCII space + tab + CR.
-  it.fails('S6.1: em space (U+2003, Zs) separates two unquoted tokens', () => {
+  it('S6.1: em space (U+2003, Zs) separates two unquoted tokens', () => {
     const tokens = tokenize('a b').filter(t => t.kind !== 'eof')
     expect(tokens.map(t => t.kind)).toEqual(['unquoted', 'unquoted'])
     expect(tokens[0].value).toBe('a')
     expect(tokens[1].value).toBe('b')
   })
 
-  it.fails('S6.1: line separator (U+2028, Zl) separates two unquoted tokens', () => {
+  it('S6.1: line separator (U+2028, Zl) separates two unquoted tokens', () => {
     const tokens = tokenize('a b').filter(t => t.kind !== 'eof')
     // Spec says U+2028 (Zl) is whitespace and should separate tokens.
     // Currently ts.hocon folds it into the unquoted run, producing a single


### PR DESCRIPTION
## Summary

Expand HOCON lexer whitespace recognition to match the [Lightbend HOCON.md §Whitespace](https://github.com/lightbend/config/blob/main/HOCON.md#whitespace) (L165–184). Part of [Phase 6 #1](https://github.com/o3co/xx.hocon/blob/develop/docs/compliance-matrix.md) of the cross-impl compliance program.

## Compliance lift (in-scope)

- S6.1 ❌ → ✅ — Unicode Zs/Zl/Zp category characters recognized as whitespace
- S6.2 ❌ → ✅ — Non-breaking spaces (U+00A0, U+2007, U+202F) recognized
- S6.4 ⚠️ → ✅ — All 8 non-newline ASCII control whitespace chars (U+0009, U+000B–U+000D, U+001C–U+001F) recognized
- S6.3 — broadened: BOM (U+FEFF) now whitespace anywhere, not only at start-of-input

Expected lift: **83.3% → ~84.6%** (closes [#72](https://github.com/o3co/ts.hocon/issues/72))

## Behavior changes (intentional, 3-way convergent across ts/rs/go)

1. **BOM mid-stream is whitespace** — was: stripped only at start-of-input. Spec L173 says BOM "must also be treated as whitespace" with no positional qualifier.
2. **CR (`\r`) inside `\${...}`** — was: "unterminated substitution" error alongside LF. Now consumed as inter-segment whitespace per spec L182–184 ("newline refers only and specifically to ASCII newline 0x000A"). LF still terminates substitution body as error.

## Implementation

- Added module-private `isHoconWhitespace(ch)` + `isHoconNewline(ch)` predicates matching the spec set exactly (hardcoded, not delegated to JS regex `\s` which misses U+001C–U+001F).
- Newline check runs before whitespace skip in the main lexer loop (spec §D invariant — LF must still emit \`newline\` token).
- All four call sites route through the new predicate: main loop, \`parseSubstBody\` whitespace skip, \`isUnquotedSubstChar\`, \`isUnquotedStart\` / \`isUnquotedContinue\`.

## Design references

- Cross-impl design spec + per-impl plan in xx.hocon \`.claude/superpowers/\` (Codex-reviewed, multi-agent-reviewed)
- Lightbend HOCON.md §Whitespace L165–184

## Test plan

- [x] RED commits demonstrate failure before predicate implementation (verified per-commit)
- [x] LF regression guard test confirms LF still emits \`newline\` token after predicate centralization
- [x] BOM mid-stream regression test (S6.3 broadening verification)
- [x] Subst body whitespace tests cover NBSP / Zl / vtab / CR inside \`\${...}\` (post-multi-agent-review fix)
- [x] \`make test\` green (479 passed | 41 expected fail | 1 skipped)