### PR TITLE
fix(s15): numericObjectToArray + accessor + pairwise-fold concat (closes #87)

### DIFF
--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -246,7 +246,7 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
   status: ❌ (see #77) — resolver silently wraps scalar + array into flat array instead of erroring
 - **S10.14** Whitespace around obj/array substitutions is ignored — §Concatenation with whitespace (L440)
   tests: tests/resolver.test.ts:653,666
-  status: ⚠️ (see #78) — works for object substs; whitespace not stripped for array substs (included as extra element)
+  status: ✅ — fixed alongside S15 concat work; `resolveConcat` array-concat branch now filters parser-inserted separator whitespace to match the existing object-concat behavior.
 - **S10.15** Quoted whitespace between obj/array substitutions is an error — §Concatenation with whitespace (L442)
   tests: tests/resolver.test.ts:181
   status: ✅
@@ -356,8 +356,8 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
   tests: tests/resolver.test.ts:737
   status: ✅
 - **S13.14** Optional undefined in obj/array concat → empty obj/array — §Substitutions (L637)
-  tests: tests/resolver.test.ts:745 (it.fails — array variant); tests/resolver.test.ts:756 (object variant ✅)
-  status: ⚠️ (see #83) — object concat works correctly; array concat leaks whitespace scalars as extra elements
+  tests: tests/resolver.test.ts:745 (array variant); tests/resolver.test.ts:756 (object variant)
+  status: ✅ — fixed alongside S15 concat work; missing optional substitution no longer leaves a whitespace artefact in the array result.
 - **S13.15** `foo : ${?bar}${?baz}` skipped only when BOTH undefined — §Substitutions (L640)
   tests: tests/resolver.test.ts:274
   status: ✅
@@ -592,33 +592,33 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
 ## S15. Numerically-indexed objects to arrays
 
 - **S15.1** `{"0":"a","1":"b"}` → `["a","b"]` when array context — §Conversion (L1191)
-  tests: tests/config.test.ts:440
-  status: ❌
-  `getList()` throws `ConfigError: expected array` instead of converting the numerically-indexed object. Pin asserts via `.fails` that the expected `["a","b"]` shape currently does not materialize. See issue #87.
+  tests: tests/config.test.ts:440 (Phase 4 spec form, now passing); tests/numeric-array.test.ts (helper unit tests); tests/s15-numeric-obj-array.test.ts (xx.hocon na01 fixture)
+  status: ✅
+  `getList()` invokes `numericObjectToArray` (`src/value/numeric-array.ts`) before the type check, converting numeric-keyed objects to arrays per spec.
 - **S15.2** Conversion is lazy (only on type-required access) — §Conversion (L1204)
-  tests: tests/config.test.ts:449
-  status: ✅ (incidental)
-  `get()` and `getConfig()` on a numeric-keyed object return the object unchanged. Currently passes trivially because no conversion exists at all; **must be re-validated after #87 lands** to confirm laziness is enforced by an explicit `coerceList`-time guard rather than by the absence of conversion.
+  tests: tests/config.test.ts:449; tests/s15-numeric-obj-array.test.ts (xx.hocon na02 fixture)
+  status: ✅
+  `get()`/`getConfig()` do not invoke `numericObjectToArray`; only list-typed accessors trigger conversion. Explicit guard, not incidental.
 - **S15.3** Conversion in concatenation when list expected — §Conversion (L1210)
-  tests: tests/config.test.ts:457 (pin); tests/config.test.ts:469 (.fails spec assertion)
-  status: ❌
-  real concat context `arr = [a] ${obj}` (with `obj = {"0":"x","1":"y"}`) produces a 3-element array `["a", " ", {0:"x",1:"y"}]` — whitespace artefact + un-converted object. Spec L1210 requires conversion + flatten to `["a","x","y"]`. Pin asserts the un-converted last element so a future #87 fix flips it. See issue #87.
+  tests: tests/config.test.ts:455 (Phase 4 spec form, now passing); tests/s15-numeric-obj-array.test.ts (xx.hocon na03a/b/c/d fixtures including the NORMATIVE multi-piece left-to-right concat)
+  status: ✅
+  Resolver array-concat branch in `src/internal/resolver/substitution-resolver.ts:resolveConcat` filters separator whitespace (matching object-concat behavior) and invokes `numericObjectToArray` on object elements, spreading the resulting items.
 - **S15.4** Empty object NOT converted — §Conversion (L1212)
-  tests: tests/config.test.ts:478
-  status: ✅ (incidental)
-  `getList()` on `{}` correctly throws `ConfigError`. Currently passes trivially because no conversion runs at all; **must be re-validated after #87 lands** to confirm the implementation has an explicit empty-object guard before the conversion path.
+  tests: tests/config.test.ts:461; tests/s15-numeric-obj-array.test.ts (xx.hocon na04 fixture)
+  status: ✅
+  `numericObjectToArray` returns `null` on empty objects; `getList` then throws `ConfigError`. Explicit empty-guard, not incidental.
 - **S15.5** Non-integer keys ignored during conversion — §Conversion (L1214)
-  tests: tests/config.test.ts:485
-  status: ❌
-  `getList()` throws before any conversion logic runs; the non-integer-key ignore rule cannot be exercised until S15.1 is fixed. See issue #87.
+  tests: tests/config.test.ts:467; tests/s15-numeric-obj-array.test.ts (xx.hocon na05 fixture)
+  status: ✅
+  Pre-filter regex `^(0|[1-9][0-9]*)$` in `numericObjectToArray` rejects non-integer keys before parsing.
 - **S15.6** Missing indices compacted in resulting array — §Conversion (L1216)
-  tests: tests/config.test.ts:491
-  status: ❌
-  Same root cause as S15.1 — `getList()` does not perform object-to-array conversion at all. See issue #87.
+  tests: tests/config.test.ts:473; tests/s15-numeric-obj-array.test.ts (xx.hocon na06 fixture)
+  status: ✅
+  After eligibility filtering and integer parsing, entries are sorted by integer ascending and projected to a value array — gaps eliminated.
 - **S15.7** Sorted by integer key value — §Conversion (L1216)
-  tests: tests/config.test.ts:497
-  status: ❌
-  Same root cause as S15.1. See issue #87.
+  tests: tests/config.test.ts:479; tests/s15-numeric-obj-array.test.ts (xx.hocon na07 fixture)
+  status: ✅
+  Same sort step as S15.6.
 
 ## S16. MIME Type
 

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -602,7 +602,7 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
 - **S15.3** Conversion in concatenation when list expected — §Conversion (L1210)
   tests: tests/config.test.ts:454 (Phase 4 spec form, now passing); tests/s15-numeric-obj-array.test.ts (xx.hocon na03a/b/c/d/e fixtures including the NORMATIVE multi-piece left-to-right pairwise fold)
   status: ✅
-  Resolver array-concat branch in `src/internal/resolver/substitution-resolver.ts:resolveConcat` uses a true pairwise left-to-right fold (per spec §"Multi-piece concat") — adjacent Objects are merged first via S10.3, then `numericObjectToArray` is invoked when the partner is an Array. Verified by `na03e-multi-piece-overlap.conf` (overlapping numeric keys).
+  `src/internal/resolver/substitution-resolver.ts:resolveConcat` performs a true left-to-right pairwise fold (per spec §"Multi-piece concat") over non-separator resolved values — adjacent Objects are merged first via S10.3, then `numericObjectToArray` is invoked when the partner is an Array. Verified by `na03e-multi-piece-overlap.conf` (overlapping numeric keys). Note: the function no longer has a distinct "array-concat branch"; all type-pair dispatch happens inside the fold's `joinPair` helper.
 - **S15.4** Empty object NOT converted — §Conversion (L1212)
   tests: tests/config.test.ts:460; tests/s15-numeric-obj-array.test.ts (xx.hocon na04 fixture)
   status: ✅

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -356,7 +356,7 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
   tests: tests/resolver.test.ts:737
   status: ✅
 - **S13.14** Optional undefined in obj/array concat → empty obj/array — §Substitutions (L637)
-  tests: tests/resolver.test.ts:745 (array variant); tests/resolver.test.ts:756 (object variant)
+  tests: tests/resolver.test.ts:753 (array variant); tests/resolver.test.ts:764 (object variant)
   status: ✅ — fixed alongside S15 concat work; missing optional substitution no longer leaves a whitespace artefact in the array result.
 - **S13.15** `foo : ${?bar}${?baz}` skipped only when BOTH undefined — §Substitutions (L640)
   tests: tests/resolver.test.ts:274
@@ -596,27 +596,27 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
   status: ✅
   `getList()` invokes `numericObjectToArray` (`src/value/numeric-array.ts`) before the type check, converting numeric-keyed objects to arrays per spec.
 - **S15.2** Conversion is lazy (only on type-required access) — §Conversion (L1204)
-  tests: tests/config.test.ts:449; tests/s15-numeric-obj-array.test.ts (xx.hocon na02 fixture)
+  tests: tests/config.test.ts:447; tests/s15-numeric-obj-array.test.ts (xx.hocon na02 fixture)
   status: ✅
   `get()`/`getConfig()` do not invoke `numericObjectToArray`; only list-typed accessors trigger conversion. Explicit guard, not incidental.
 - **S15.3** Conversion in concatenation when list expected — §Conversion (L1210)
-  tests: tests/config.test.ts:455 (Phase 4 spec form, now passing); tests/s15-numeric-obj-array.test.ts (xx.hocon na03a/b/c/d fixtures including the NORMATIVE multi-piece left-to-right concat)
+  tests: tests/config.test.ts:454 (Phase 4 spec form, now passing); tests/s15-numeric-obj-array.test.ts (xx.hocon na03a/b/c/d/e fixtures including the NORMATIVE multi-piece left-to-right pairwise fold)
   status: ✅
-  Resolver array-concat branch in `src/internal/resolver/substitution-resolver.ts:resolveConcat` filters separator whitespace (matching object-concat behavior) and invokes `numericObjectToArray` on object elements, spreading the resulting items.
+  Resolver array-concat branch in `src/internal/resolver/substitution-resolver.ts:resolveConcat` uses a true pairwise left-to-right fold (per spec §"Multi-piece concat") — adjacent Objects are merged first via S10.3, then `numericObjectToArray` is invoked when the partner is an Array. Verified by `na03e-multi-piece-overlap.conf` (overlapping numeric keys).
 - **S15.4** Empty object NOT converted — §Conversion (L1212)
-  tests: tests/config.test.ts:461; tests/s15-numeric-obj-array.test.ts (xx.hocon na04 fixture)
+  tests: tests/config.test.ts:460; tests/s15-numeric-obj-array.test.ts (xx.hocon na04 fixture)
   status: ✅
   `numericObjectToArray` returns `null` on empty objects; `getList` then throws `ConfigError`. Explicit empty-guard, not incidental.
 - **S15.5** Non-integer keys ignored during conversion — §Conversion (L1214)
-  tests: tests/config.test.ts:467; tests/s15-numeric-obj-array.test.ts (xx.hocon na05 fixture)
+  tests: tests/config.test.ts:466; tests/s15-numeric-obj-array.test.ts (xx.hocon na05 fixture)
   status: ✅
   Pre-filter regex `^(0|[1-9][0-9]*)$` in `numericObjectToArray` rejects non-integer keys before parsing.
 - **S15.6** Missing indices compacted in resulting array — §Conversion (L1216)
-  tests: tests/config.test.ts:473; tests/s15-numeric-obj-array.test.ts (xx.hocon na06 fixture)
+  tests: tests/config.test.ts:472; tests/s15-numeric-obj-array.test.ts (xx.hocon na06 fixture)
   status: ✅
   After eligibility filtering and integer parsing, entries are sorted by integer ascending and projected to a value array — gaps eliminated.
 - **S15.7** Sorted by integer key value — §Conversion (L1216)
-  tests: tests/config.test.ts:479; tests/s15-numeric-obj-array.test.ts (xx.hocon na07 fixture)
+  tests: tests/config.test.ts:478; tests/s15-numeric-obj-array.test.ts (xx.hocon na07 fixture)
   status: ✅
   Same sort step as S15.6.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import { coerceBoolean, coerceNumber, parseBytes, parseDuration } from './coerce.js'
 import type { ByteUnit, DurationUnit } from './coerce.js'
 import { ConfigError } from './errors.js'
+import { numericObjectToArray } from './value/numeric-array.js'
 import type { HoconValue, ScalarValueType } from './value.js'
 
 export class Config {
@@ -61,6 +62,12 @@ export class Config {
   getList(path: string): unknown[] {
     const v = this.lookupNode(path)
     if (v === undefined) throw new ConfigError(`path not found: ${path}`, path)
+    // S15: if the value is a numerically-keyed object, convert to array before type check.
+    // Empty objects and objects with no eligible integer keys return null → fall through to error.
+    if (v.kind === 'object') {
+      const converted = numericObjectToArray(v)
+      if (converted !== null) return converted.map(hoconToJs)
+    }
     if (v.kind !== 'array') throw new ConfigError(`expected array at ${path}`, path)
     return v.items.map(hoconToJs)
   }

--- a/src/internal/resolver/substitution-resolver.ts
+++ b/src/internal/resolver/substitution-resolver.ts
@@ -255,7 +255,15 @@ export class SubstitutionResolver {
     // NOT user-authored values like '' or ' ' which should prevent object merging.
     const nonSep = resolved.filter((v) => !separatorValues.has(v))
 
-    if (nonSep.length === 0) return resolved[0] as HoconValue
+    if (nonSep.length === 0) {
+      // All resolved values are parser-inserted separators (e.g. concat collapsed to
+      // whitespace tokens after optional substitutions resolved away). Concatenate the
+      // raw scalars rather than dropping all but the first separator value.
+      const str = resolved
+        .map((v) => (v.kind === 'scalar' ? v.raw : JSON.stringify(v)))
+        .join('')
+      return { kind: 'scalar', raw: str, valueType: 'string' }
+    }
 
     // True left-to-right pairwise fold per spec §"Multi-piece concat is left-to-right pairwise
     // (NORMATIVE)". This matches Lightbend ConfigConcatenation.consolidate semantics.
@@ -296,7 +304,18 @@ export class SubstitutionResolver {
       if (left.kind === 'array' && right.kind === 'array') {
         return { kind: 'array', items: [...left.items, ...right.items] }
       }
-      // String concat (scalars, or mixed scalar/other)
+      // Array + non-array (scalar/other) — preserve prior "array context wins" behavior:
+      // push the non-array element into the array. S10.13 (array+scalar → error) is a
+      // separate cluster (Phase 6 #?) and is out of scope here.
+      if (left.kind === 'array') {
+        return { kind: 'array', items: [...left.items, right] }
+      }
+      if (right.kind === 'array') {
+        return { kind: 'array', items: [left, ...right.items] }
+      }
+      // String concat (scalars, or scalar+object — the obj+scalar case keeps prior
+      // string-concat behavior since prior code reached string-concat too when no array
+      // was present).
       const leftStr = left.kind === 'scalar' ? left.raw : JSON.stringify(left)
       const rightStr = right.kind === 'scalar' ? right.raw : JSON.stringify(right)
       return { kind: 'scalar', raw: leftStr + rightStr, valueType: 'string' }

--- a/src/internal/resolver/substitution-resolver.ts
+++ b/src/internal/resolver/substitution-resolver.ts
@@ -249,58 +249,76 @@ export class SubstitutionResolver {
       .filter((v): v is HoconValue => v !== undefined)
 
     if (resolved.length === 0) return { kind: 'scalar', raw: 'null', valueType: 'null' }
-    if (resolved.length === 1) return resolved[0]!
+    if (resolved.length === 1) return resolved[0] as HoconValue
 
-    // Object concatenation: if all non-separator elements are objects, deep-merge them.
-    // Only filter parser-inserted separator whitespace (tracked via separatorValues WeakSet),
+    // Filter parser-inserted separator whitespace (tracked via separatorValues WeakSet),
     // NOT user-authored values like '' or ' ' which should prevent object merging.
     const nonSep = resolved.filter((v) => !separatorValues.has(v))
-    if (nonSep.length > 0 && nonSep.every((v) => v.kind === 'object')) {
-      const merged = new Map<string, HoconValue>()
-      for (const v of nonSep) {
-        if (v.kind === 'object') {
-          for (const [k, val] of v.fields) {
-            const existing = merged.get(k)
-            if (existing?.kind === 'object' && val.kind === 'object') {
-              merged.set(k, deepMergeHoconValues(existing, val))
-            } else {
-              merged.set(k, val)
-            }
-          }
-        }
+
+    if (nonSep.length === 0) return resolved[0] as HoconValue
+
+    // True left-to-right pairwise fold per spec §"Multi-piece concat is left-to-right pairwise
+    // (NORMATIVE)". This matches Lightbend ConfigConcatenation.consolidate semantics.
+    //
+    // join_pair handles each type-pair:
+    //   Object + Object  → deep object-merge (S10.3)
+    //   Array  + Object  → numericObjectToArray on right, then array-concat (S15.3)
+    //   Object + Array   → numericObjectToArray on left, then array-concat (S15.3)
+    //   Array  + Array   → array-concat
+    //   others           → string concat (fallthrough)
+    //
+    // Critically, Object + Object produces an object (not an array), so overlapping numeric
+    // keys in adjacent objects are merged before the object side meets an array partner.
+    // A single-pass "classify first, then iterate" loop gets this wrong for overlapping keys.
+    const joinPair = (left: HoconValue, right: HoconValue): HoconValue => {
+      if (left.kind === 'object' && right.kind === 'object') {
+        // S10.3: both objects — deep-merge (later value wins on duplicate keys)
+        return deepMergeHoconValues(left, right)
       }
-      return { kind: 'object', fields: merged }
+      if (left.kind === 'array' && right.kind === 'object') {
+        // S15.3: list + object — attempt numeric conversion on the object side
+        const converted = numericObjectToArray(right)
+        if (converted !== null) {
+          return { kind: 'array', items: [...left.items, ...converted] }
+        }
+        // No eligible keys — treat as array+object mix (S10.4 path: push object as element)
+        return { kind: 'array', items: [...left.items, right] }
+      }
+      if (left.kind === 'object' && right.kind === 'array') {
+        // S15.3: object + list — attempt numeric conversion on the object side
+        const converted = numericObjectToArray(left)
+        if (converted !== null) {
+          return { kind: 'array', items: [...converted, ...right.items] }
+        }
+        // No eligible keys — treat as object+array mix (S10.4 path: push object as element)
+        return { kind: 'array', items: [left, ...right.items] }
+      }
+      if (left.kind === 'array' && right.kind === 'array') {
+        return { kind: 'array', items: [...left.items, ...right.items] }
+      }
+      // String concat (scalars, or mixed scalar/other)
+      const leftStr = left.kind === 'scalar' ? left.raw : JSON.stringify(left)
+      const rightStr = right.kind === 'scalar' ? right.raw : JSON.stringify(right)
+      return { kind: 'scalar', raw: leftStr + rightStr, valueType: 'string' }
     }
 
-    // Array concatenation: if any non-separator element is an array, treat all as array elements.
-    // Filter parser-inserted separator whitespace first (same rule as object concat above).
-    const nonSepForArray = resolved.filter((v) => !separatorValues.has(v))
-    if (nonSepForArray.some((v) => v.kind === 'array')) {
-      const items: HoconValue[] = []
-      for (const v of nonSepForArray) {
-        if (v.kind === 'array') {
-          items.push(...v.items)
-        } else if (v.kind === 'object') {
-          // S15: attempt numeric-object-to-array conversion when mixing objects into array concat.
-          const converted = numericObjectToArray(v)
-          if (converted !== null) {
-            items.push(...converted)
-          } else {
-            // No eligible keys — push the object as-is (silent S10.4 mix, out of scope).
-            items.push(v)
-          }
-        } else {
-          items.push(v)
-        }
-      }
-      return { kind: 'array', items }
+    // Pairwise left-to-right reduce over non-separator elements.
+    // For the string-concat case we must include separator whitespace tokens (they are
+    // user-meaningful in string context), so fall back to the full `resolved` list when the
+    // fold result is a scalar to preserve whitespace joining.
+    const [head, ...tail] = nonSep
+    const folded = tail.reduce(joinPair, head as HoconValue)
+
+    // If the result is scalar and there were separator tokens, re-run as plain string concat
+    // over all resolved values so whitespace is preserved (scalars are concatenated verbatim).
+    if (folded.kind === 'scalar') {
+      const str = resolved
+        .map((v) => (v.kind === 'scalar' ? v.raw : JSON.stringify(v)))
+        .join('')
+      return { kind: 'scalar', raw: str, valueType: 'string' }
     }
 
-    // String concatenation
-    const str = resolved
-      .map((v) => (v.kind === 'scalar' ? v.raw : JSON.stringify(v)))
-      .join('')
-    return { kind: 'scalar', raw: str, valueType: 'string' }
+    return folded
   }
 
   private resolveAppend(a: AppendPlaceholder, scope: ResObj): HoconValue {

--- a/src/internal/resolver/substitution-resolver.ts
+++ b/src/internal/resolver/substitution-resolver.ts
@@ -1,4 +1,5 @@
 import { ResolveError } from '../../errors.js'
+import { numericObjectToArray } from '../../value/numeric-array.js'
 import type { HoconValue } from '../../value.js'
 import type { Segment } from '../lexer/token.js'
 import {
@@ -271,12 +272,26 @@ export class SubstitutionResolver {
       return { kind: 'object', fields: merged }
     }
 
-    // Array concatenation: if any element is an array, treat all as array elements
-    if (resolved.some((v) => v.kind === 'array')) {
+    // Array concatenation: if any non-separator element is an array, treat all as array elements.
+    // Filter parser-inserted separator whitespace first (same rule as object concat above).
+    const nonSepForArray = resolved.filter((v) => !separatorValues.has(v))
+    if (nonSepForArray.some((v) => v.kind === 'array')) {
       const items: HoconValue[] = []
-      for (const v of resolved) {
-        if (v.kind === 'array') items.push(...v.items)
-        else items.push(v)
+      for (const v of nonSepForArray) {
+        if (v.kind === 'array') {
+          items.push(...v.items)
+        } else if (v.kind === 'object') {
+          // S15: attempt numeric-object-to-array conversion when mixing objects into array concat.
+          const converted = numericObjectToArray(v)
+          if (converted !== null) {
+            items.push(...converted)
+          } else {
+            // No eligible keys — push the object as-is (silent S10.4 mix, out of scope).
+            items.push(v)
+          }
+        } else {
+          items.push(v)
+        }
       }
       return { kind: 'array', items }
     }

--- a/src/value/numeric-array.ts
+++ b/src/value/numeric-array.ts
@@ -1,0 +1,54 @@
+// src/value/numeric-array.ts
+//
+// S15 — Numerically-indexed object → array conversion helper.
+// Spec: docs/superpowers/specs/2026-05-16-s15-numeric-obj-array-design.md
+// Issue: https://github.com/o3co/ts.hocon/issues/87
+//
+// This module is intentionally NOT exported from the public API (src/index.ts).
+// It is a private helper shared between the accessor call-site (Config.getList)
+// and the resolver concat call-site (SubstitutionResolver.resolveConcat).
+
+import type { HoconValue } from '../value.js'
+
+/**
+ * Attempt to convert a numerically-keyed HOCON object to an array.
+ *
+ * Contract (per spec §"Function contract"):
+ *   - If `value` is not an object        → returns null
+ *   - If `value` is an empty object      → returns null  (S15.4: empty NOT converted)
+ *   - If no key parses as non-neg int    → returns null
+ *   - Otherwise                          → returns values sorted by parsed key (ascending)
+ *
+ * Integer key parse rule (per spec §"Integer key parse rule"):
+ *   Pre-filter: ^(0|[1-9][0-9]*)$  — rejects "+1", "-0", "00", " 1", "", hex, decimal, etc.
+ *   Then: parse to integer and verify in i32 range [0, 2147483647].
+ *
+ * Conversion is non-recursive: only top-level keys are examined.
+ * The returned array is a new HoconValue — the original object is NOT mutated.
+ */
+export function numericObjectToArray(value: HoconValue): HoconValue[] | null {
+  if (value.kind !== 'object') return null
+  if (value.fields.size === 0) return null
+
+  // Pre-filter pattern: canonical decimal non-negative integers only.
+  // Rejects: "+1", "-0", "-1", "00", "01", " 1", "1 ", "0x1", "1e2", "1.0", ""
+  const canonicalInt = /^(0|[1-9][0-9]*)$/
+
+  const eligible: Array<{ n: number; v: HoconValue }> = []
+
+  for (const [key, val] of value.fields) {
+    if (!canonicalInt.test(key)) continue
+    // Parse to number. The pre-filter guarantees no sign, no leading zeros, decimal only.
+    // We still need a native parse for the in-range check.
+    const n = Number(key)
+    // i32 max: 2147483647
+    if (!Number.isInteger(n) || n > 2_147_483_647) continue
+    eligible.push({ n, v: val })
+  }
+
+  if (eligible.length === 0) return null
+
+  // Sort ascending by parsed key value, project to value array.
+  eligible.sort((a, b) => a.n - b.n)
+  return eligible.map((e) => e.v)
+}

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -437,64 +437,45 @@ describe('getBytes', () => {
 // Issue #87: getList() does not perform object-to-array conversion
 describe('S15 - numerically-indexed object to array', () => {
   // S15.1: basic conversion when array type is requested
-  it.fails('S15.1: getList() converts {"0":"a","1":"b"} to ["a","b"]', () => {
+  it('S15.1: getList() converts {"0":"a","1":"b"} to ["a","b"]', () => {
     const c = parse('items = {"0":"a","1":"b"}')
     expect(c.getList('items')).toEqual(['a', 'b'])
   })
 
-  // S15.2: conversion is lazy — object is still accessible as object before type-coercion.
-  // Trivially passes today because no conversion exists; once #87 lands, this must
-  // continue passing to confirm the implementation is genuinely lazy (does not eagerly
-  // convert during parse). Re-validate after #87.
+  // S15.2: conversion is lazy — object is still accessible as object via untyped/object accessors.
+  // Explicit guard that get/getConfig do NOT trigger conversion.
   it('S15.2: get() and getConfig() on numeric-keyed object return object (lazy, not eager)', () => {
     const c = parse('items = {"0":"a","1":"b"}')
-    // As a plain get(), it returns the object (no eager conversion)
     expect(c.get('items')).toEqual({ '0': 'a', '1': 'b' })
-    // getConfig() also works — object not auto-converted
     expect(c.getConfig('items').getString('0')).toBe('a')
   })
 
   // S15.3: conversion in concatenation when list expected (spec L1210).
-  // Probe (2026-05-13) shows `arr = [a] ${obj}` parses to a 3-element array
-  // ["a", " ", {"0":"x","1":"y"}] — whitespace artefact + un-converted object.
-  // Spec requires conversion + flatten to ["a","x","y"]. Pin asserts the un-converted
-  // last element so a future #87 fix flips it; .fails version asserts the spec shape.
-  it('S15.3: [a] ${obj} concat currently includes un-converted object as last element', () => {
-    const c = parse('obj = {"0":"x","1":"y"}\narr = [a] ${obj}')
-    const items = c.getList('arr') as unknown[]
-    expect(items.length).toBe(3)
-    // Last element is the un-converted object, not the flattened "x"/"y" strings.
-    expect(typeof items[items.length - 1]).toBe('object')
-    expect(items[items.length - 1]).not.toBeNull()
-  })
-
-  it.fails('S15.3: [a] ${obj} should produce ["a","x","y"] after conversion+flatten (spec L1210, see #87)', () => {
+  it('S15.3: [a] ${obj} produces ["a","x","y"] after conversion+flatten', () => {
     const c = parse('obj = {"0":"x","1":"y"}\narr = [a] ${obj}')
     expect(c.getList('arr')).toEqual(['a', 'x', 'y'])
   })
 
-  // S15.4: empty object must NOT be converted. Trivially passes today because no
-  // conversion exists at all; once #87 lands, this must continue passing to confirm
-  // the implementation has an explicit empty-object guard. Re-validate after #87.
-  it('S15.4: getList() on empty object still throws (empty object not converted)', () => {
+  // S15.4: empty object must NOT be converted. Explicit empty-object guard.
+  it('S15.4: getList() on empty object throws (empty object not converted)', () => {
     const c = parse('items = {}')
     expect(() => c.getList('items')).toThrow(ConfigError)
   })
 
   // S15.5: non-integer keys ignored during conversion
-  it.fails('S15.5: getList() ignores non-integer keys when converting {"0":"a","foo":"b","1":"c"}', () => {
+  it('S15.5: getList() ignores non-integer keys when converting {"0":"a","foo":"b","1":"c"}', () => {
     const c = parse('items = {"0":"a","foo":"b","1":"c"}')
     expect(c.getList('items')).toEqual(['a', 'c'])
   })
 
   // S15.6: missing indices compacted
-  it.fails('S15.6: getList() on {"0":"a","2":"c"} compacts missing index → ["a","c"]', () => {
+  it('S15.6: getList() on {"0":"a","2":"c"} compacts missing index → ["a","c"]', () => {
     const c = parse('items = {"0":"a","2":"c"}')
     expect(c.getList('items')).toEqual(['a', 'c'])
   })
 
   // S15.7: sorted by integer key value
-  it.fails('S15.7: getList() on {"1":"b","0":"a"} produces ["a","b"] (sorted by key int)', () => {
+  it('S15.7: getList() on {"1":"b","0":"a"} produces ["a","b"] (sorted by key int)', () => {
     const c = parse('items = {"1":"b","0":"a"}')
     expect(c.getList('items')).toEqual(['a', 'b'])
   })

--- a/tests/lightbend/testdata/numeric-obj-array/na01-basic.conf
+++ b/tests/lightbend/testdata/numeric-obj-array/na01-basic.conf
@@ -1,0 +1,3 @@
+# S15.1: numerically-keyed object eligible for array conversion when array context is requested.
+# Impl test: getList("items") should return ["a", "b"].
+items = {"0":"a","1":"b"}

--- a/tests/lightbend/testdata/numeric-obj-array/na02-lazy-getobject.conf
+++ b/tests/lightbend/testdata/numeric-obj-array/na02-lazy-getobject.conf
@@ -1,0 +1,3 @@
+# S15.2: same source as na01 but asserts laziness — get/getObject return the object as-is,
+# no eager conversion at parse/resolve time. Conversion only fires from list-typed accessors.
+items = {"0":"a","1":"b"}

--- a/tests/lightbend/testdata/numeric-obj-array/na03a-concat-left-list.conf
+++ b/tests/lightbend/testdata/numeric-obj-array/na03a-concat-left-list.conf
@@ -1,0 +1,5 @@
+# S15.3 + concat-time conversion (left-literal-array case).
+# Pairwise join (left=Array, right=Object) → numericObjectToArray(right) → array-array concat.
+# Expected: arr = ["a", "x", "y"].
+obj = {"0":"x","1":"y"}
+arr = [a] ${obj}

--- a/tests/lightbend/testdata/numeric-obj-array/na03b-concat-right-list.conf
+++ b/tests/lightbend/testdata/numeric-obj-array/na03b-concat-right-list.conf
@@ -1,0 +1,5 @@
+# S15.3 + concat-time conversion (right-literal-array case, symmetric to na03a).
+# Pairwise join (left=Object, right=Array) → numericObjectToArray(left) → array-array concat.
+# Expected: arr = ["x", "y", "a"].
+obj = {"0":"x","1":"y"}
+arr = ${obj} [a]

--- a/tests/lightbend/testdata/numeric-obj-array/na03c-concat-two-objs.conf
+++ b/tests/lightbend/testdata/numeric-obj-array/na03c-concat-two-objs.conf
@@ -1,0 +1,6 @@
+# Spec §"Two-object concat is NOT array-converted": both sides Object → S10.3 object merge,
+# no concat-time conversion. Subsequent getList on `arr` would trigger accessor-side conversion.
+# Expected resolved tree: arr = {"0":"x","1":"y","2":"z","3":"w"}.
+obj1 = {"0":"x","1":"y"}
+obj2 = {"2":"z","3":"w"}
+arr = ${obj1} ${obj2}

--- a/tests/lightbend/testdata/numeric-obj-array/na03d-concat-multi-piece.conf
+++ b/tests/lightbend/testdata/numeric-obj-array/na03d-concat-multi-piece.conf
@@ -1,0 +1,7 @@
+# Spec §"Multi-piece concat is left-to-right pairwise (NORMATIVE)".
+# Fold order: join(obj1, obj2) → object-merge {0:x,1:y,2:z,3:w}; join(merged, [a]) →
+# numericObjectToArray triggers (list partner) → array-array concat.
+# Expected: arr = ["x", "y", "z", "w", "a"].
+obj1 = {"0":"x","1":"y"}
+obj2 = {"2":"z","3":"w"}
+arr = ${obj1} ${obj2} [a]

--- a/tests/lightbend/testdata/numeric-obj-array/na03e-multi-piece-overlap.conf
+++ b/tests/lightbend/testdata/numeric-obj-array/na03e-multi-piece-overlap.conf
@@ -1,0 +1,14 @@
+# Spec §"Multi-piece concat is left-to-right pairwise (NORMATIVE)" — overlapping-keys variant.
+# Pairwise fold: join(obj1, obj2) → object-merge per S10.3 → {0:z, 1:y} (later "0" wins).
+# Then join(merged, [a]) → numericObjectToArray triggers (list partner) → array-array concat.
+# Expected: arr = ["z", "y", "a"].
+#
+# This fixture distinguishes a true left-to-right pairwise fold from a single-pass loop that
+# converts each Object element independently. The disjoint-keys fixture (na03d) cannot detect
+# the divergence — both algorithms produce the same answer when keys do not overlap.
+#
+# Multi-reviewer code review (2026-05-16) caught all 3 impls (ts/rs/go) initially shipping
+# the single-pass loop variant; this fixture is the regression guard added in followup.
+obj1 = {"0":"x","1":"y"}
+obj2 = {"0":"z"}
+arr = ${obj1} ${obj2} [a]

--- a/tests/lightbend/testdata/numeric-obj-array/na04-empty.conf
+++ b/tests/lightbend/testdata/numeric-obj-array/na04-empty.conf
@@ -1,0 +1,3 @@
+# S15.4: empty object explicitly NOT converted, even when array is requested.
+# Impl test: getList("items") raises a type-mismatch error.
+items = {}

--- a/tests/lightbend/testdata/numeric-obj-array/na05-non-int-keys.conf
+++ b/tests/lightbend/testdata/numeric-obj-array/na05-non-int-keys.conf
@@ -1,0 +1,3 @@
+# S15.5: non-integer keys ignored during conversion. Eligible keys: "0", "1".
+# Impl test: getList("items") returns ["a", "c"] (not "b").
+items = {"0":"a","foo":"b","1":"c"}

--- a/tests/lightbend/testdata/numeric-obj-array/na06-gaps.conf
+++ b/tests/lightbend/testdata/numeric-obj-array/na06-gaps.conf
@@ -1,0 +1,3 @@
+# S15.6: missing indices compacted in resulting array (gap between "0" and "2").
+# Impl test: getList("items") returns ["a", "c"] (no undefined slot for index 1).
+items = {"0":"a","2":"c"}

--- a/tests/lightbend/testdata/numeric-obj-array/na07-sort.conf
+++ b/tests/lightbend/testdata/numeric-obj-array/na07-sort.conf
@@ -1,0 +1,3 @@
+# S15.7: result sorted by integer key value, regardless of declaration order.
+# Impl test: getList("items") returns ["a", "b"].
+items = {"1":"b","0":"a"}

--- a/tests/lightbend/testdata/numeric-obj-array/na08-leading-zero.conf
+++ b/tests/lightbend/testdata/numeric-obj-array/na08-leading-zero.conf
@@ -1,0 +1,5 @@
+# E2 (extra-spec): leading zeros rejected. "00" is non-canonical → ineligible.
+# Eligible key: "0" only. Impl test: getList("items") returns ["b"].
+# Lightbend behaviour: HashMap collision (both "00" and "0" parse to 0); winning value depends
+# on iteration order — non-deterministic. Documented in expected/.../na08-leading-zero.divergence.md.
+items = {"00":"a","0":"b"}

--- a/tests/lightbend/testdata/numeric-obj-array/na09-negative.conf
+++ b/tests/lightbend/testdata/numeric-obj-array/na09-negative.conf
@@ -1,0 +1,3 @@
+# Spec §"Integer key parse rule": negative integers ineligible (Lightbend-aligned).
+# Eligible key: "0" only. Impl test: getList("items") returns ["b"].
+items = {"-1":"a","0":"b"}

--- a/tests/lightbend/testdata/numeric-obj-array/na10a-plus-sign.conf
+++ b/tests/lightbend/testdata/numeric-obj-array/na10a-plus-sign.conf
@@ -1,0 +1,4 @@
+# E3 (extra-spec): leading + rejected. "+1" is non-canonical → ineligible.
+# Eligible key: "0" only. Impl test: getList("items") returns ["b"].
+# Lightbend behaviour: accepts "+1" as 1; result ["b","a"]. Documented in expected/.../na10a-plus-sign.divergence.md.
+items = {"+1":"a","0":"b"}

--- a/tests/lightbend/testdata/numeric-obj-array/na10b-minus-zero.conf
+++ b/tests/lightbend/testdata/numeric-obj-array/na10b-minus-zero.conf
@@ -1,0 +1,5 @@
+# E4 (extra-spec): leading sign char on zero rejected. "-0" is non-canonical → ineligible.
+# Eligible key: "0" only. Impl test: getList("items") returns ["b"].
+# Lightbend behaviour: HashMap collision ("-0" and "0" both parse to 0); non-deterministic
+# winner. Documented in expected/.../na10b-minus-zero.divergence.md.
+items = {"-0":"a","0":"b"}

--- a/tests/lightbend/testdata/numeric-obj-array/na11-overflow.conf
+++ b/tests/lightbend/testdata/numeric-obj-array/na11-overflow.conf
@@ -1,0 +1,3 @@
+# Spec §"Integer key parse rule" range: "99999999999" exceeds i32 range, rejected.
+# Eligible key: "0" only. Impl test: getList("items") returns ["b"].
+items = {"99999999999":"a","0":"b"}

--- a/tests/lightbend/testdata/numeric-obj-array/na12-no-eligible.conf
+++ b/tests/lightbend/testdata/numeric-obj-array/na12-no-eligible.conf
@@ -1,0 +1,3 @@
+# No keys parse as non-negative integers → numericObjectToArray returns None.
+# Impl test: getList("items") raises a type-mismatch error (no conversion possible).
+items = {"foo":"a","bar":"b"}

--- a/tests/numeric-array.test.ts
+++ b/tests/numeric-array.test.ts
@@ -1,0 +1,190 @@
+// tests/numeric-array.test.ts
+//
+// Unit tests for the numericObjectToArray helper (S15 spec compliance).
+// Spec: docs/superpowers/specs/2026-05-16-s15-numeric-obj-array-design.md §"Integer key parse rule"
+import { describe, it, expect } from 'vitest'
+import type { HoconValue } from '../src/value.js'
+import { numericObjectToArray } from '../src/value/numeric-array.js'
+
+function str(raw: string): HoconValue {
+  return { kind: 'scalar', raw, valueType: 'string' }
+}
+
+function obj(entries: Record<string, HoconValue>): HoconValue {
+  return { kind: 'object', fields: new Map(Object.entries(entries)) }
+}
+
+function arr(...items: HoconValue[]): HoconValue {
+  return { kind: 'array', items }
+}
+
+// ---------------------------------------------------------------------------
+// Non-object inputs → null
+// ---------------------------------------------------------------------------
+describe('numericObjectToArray — non-object inputs', () => {
+  it('returns null for scalar value', () => {
+    expect(numericObjectToArray(str('hello'))).toBeNull()
+  })
+
+  it('returns null for array value', () => {
+    expect(numericObjectToArray(arr(str('a')))).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Empty object → null (S15.4)
+// ---------------------------------------------------------------------------
+describe('numericObjectToArray — empty object', () => {
+  it('returns null for empty object (S15.4: empty NOT converted)', () => {
+    expect(numericObjectToArray(obj({}))).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Integer key eligibility table (spec §"Integer key parse rule")
+// ---------------------------------------------------------------------------
+describe('numericObjectToArray — key eligibility', () => {
+  // Eligible keys
+  it('"0" is eligible', () => {
+    const result = numericObjectToArray(obj({ '0': str('a') }))
+    expect(result).not.toBeNull()
+    expect(result).toHaveLength(1)
+  })
+
+  it('"1" is eligible', () => {
+    const result = numericObjectToArray(obj({ '1': str('a') }))
+    expect(result).not.toBeNull()
+    expect(result).toHaveLength(1)
+  })
+
+  it('"42" is eligible', () => {
+    const result = numericObjectToArray(obj({ '42': str('a') }))
+    expect(result).not.toBeNull()
+    expect(result).toHaveLength(1)
+  })
+
+  it('"2147483647" (i32 max) is eligible', () => {
+    const result = numericObjectToArray(obj({ '2147483647': str('a') }))
+    expect(result).not.toBeNull()
+    expect(result).toHaveLength(1)
+  })
+
+  // Rejected: leading sign
+  it('"+1" is rejected (E3: leading + sign)', () => {
+    expect(numericObjectToArray(obj({ '+1': str('a') }))).toBeNull()
+  })
+
+  it('"-0" is rejected (E4: leading - sign on zero)', () => {
+    expect(numericObjectToArray(obj({ '-0': str('a') }))).toBeNull()
+  })
+
+  it('"-1" is rejected (negative integer)', () => {
+    expect(numericObjectToArray(obj({ '-1': str('a') }))).toBeNull()
+  })
+
+  // Rejected: leading zeros
+  it('"00" is rejected (E2: leading zero)', () => {
+    expect(numericObjectToArray(obj({ '00': str('a') }))).toBeNull()
+  })
+
+  it('"01" is rejected (leading zero)', () => {
+    expect(numericObjectToArray(obj({ '01': str('a') }))).toBeNull()
+  })
+
+  it('"007" is rejected (leading zeros)', () => {
+    expect(numericObjectToArray(obj({ '007': str('a') }))).toBeNull()
+  })
+
+  // Rejected: whitespace
+  it('" 1" (leading space) is rejected', () => {
+    expect(numericObjectToArray(obj({ ' 1': str('a') }))).toBeNull()
+  })
+
+  it('"1 " (trailing space) is rejected', () => {
+    expect(numericObjectToArray(obj({ '1 ': str('a') }))).toBeNull()
+  })
+
+  // Rejected: empty
+  it('"" (empty key) is rejected', () => {
+    expect(numericObjectToArray(obj({ '': str('a') }))).toBeNull()
+  })
+
+  // Rejected: overflow (i32 max + 1)
+  it('"2147483648" is rejected (i32 overflow)', () => {
+    expect(numericObjectToArray(obj({ '2147483648': str('a') }))).toBeNull()
+  })
+
+  it('"99999999999" is rejected (large overflow)', () => {
+    expect(numericObjectToArray(obj({ '99999999999': str('a') }))).toBeNull()
+  })
+
+  // Rejected: non-decimal forms
+  it('"0x1" is rejected (hex)', () => {
+    expect(numericObjectToArray(obj({ '0x1': str('a') }))).toBeNull()
+  })
+
+  it('"1e2" is rejected (scientific notation)', () => {
+    expect(numericObjectToArray(obj({ '1e2': str('a') }))).toBeNull()
+  })
+
+  it('"1.0" is rejected (decimal point)', () => {
+    expect(numericObjectToArray(obj({ '1.0': str('a') }))).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Sort & compaction (S15.6, S15.7)
+// ---------------------------------------------------------------------------
+describe('numericObjectToArray — sort and compaction', () => {
+  it('S15.7: sorts {"1":"b","0":"a"} → ["a","b"]', () => {
+    const result = numericObjectToArray(obj({ '1': str('b'), '0': str('a') }))
+    expect(result).not.toBeNull()
+    expect(result!.map((v) => (v as { raw: string }).raw)).toEqual(['a', 'b'])
+  })
+
+  it('S15.6: compacts {"0":"a","2":"c"} → ["a","c"] (no undefined slot)', () => {
+    const result = numericObjectToArray(obj({ '0': str('a'), '2': str('c') }))
+    expect(result).not.toBeNull()
+    expect(result!.map((v) => (v as { raw: string }).raw)).toEqual(['a', 'c'])
+  })
+
+  it('S15.5: ignores non-int keys {"0":"a","foo":"b","1":"c"} → ["a","c"]', () => {
+    const result = numericObjectToArray(obj({ '0': str('a'), 'foo': str('b'), '1': str('c') }))
+    expect(result).not.toBeNull()
+    expect(result!.map((v) => (v as { raw: string }).raw)).toEqual(['a', 'c'])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// No eligible keys → null (all keys ineligible)
+// ---------------------------------------------------------------------------
+describe('numericObjectToArray — all keys ineligible', () => {
+  it('{"foo":"a","bar":"b"} → null (no integer keys)', () => {
+    expect(numericObjectToArray(obj({ 'foo': str('a'), 'bar': str('b') }))).toBeNull()
+  })
+
+  it('{"+1":"a"} → null (all keys rejected by pre-filter)', () => {
+    expect(numericObjectToArray(obj({ '+1': str('a') }))).toBeNull()
+  })
+
+  it('{"00":"a","01":"b"} → null (all leading-zero forms rejected)', () => {
+    expect(numericObjectToArray(obj({ '00': str('a'), '01': str('b') }))).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Non-recursive: nested objects not converted
+// ---------------------------------------------------------------------------
+describe('numericObjectToArray — non-recursive', () => {
+  it('nested numeric-keyed object is NOT converted (laziness)', () => {
+    // outer = {"0": {"0":"x","1":"y"}}
+    // numericObjectToArray on outer should return [inner_object], not [["x","y"]]
+    const inner = obj({ '0': str('x'), '1': str('y') })
+    const outer = obj({ '0': inner })
+    const result = numericObjectToArray(outer)
+    expect(result).not.toBeNull()
+    expect(result).toHaveLength(1)
+    // The inner element should be the object itself, not a converted array
+    expect(result![0]).toBe(inner)
+  })
+})

--- a/tests/resolver.test.ts
+++ b/tests/resolver.test.ts
@@ -648,9 +648,9 @@ describe('spec compliance Phase 2 — concatenation and += (resolver-level)', ()
 
   // --- S10.14: whitespace around obj/array substitutions is ignored --------
   // Note: s() builds "${name}" without a literal ${ in source to avoid linter warnings.
-  // PARTIAL VIOLATION: whitespace stripping works for object substs but not array substs;
-  // the whitespace separator scalar is included as an extra array element.
-  it.fails('S10.14: unquoted whitespace between two array substitutions is ignored (spec L440)', () => {
+  // Fixed alongside S15 concat work: resolveConcat now filters parser-inserted separator
+  // whitespace from the array-concat path (matching the existing object-concat filter).
+  it('S10.14: unquoted whitespace between two array substitutions is ignored (spec L440)', () => {
     // subst(a) subst(b) where both resolve to arrays → array concat, whitespace stripped
     const s = (name: string) => '$' + '{' + name + '}'
     const input = 'a=[1]\nb=[2]\nx = ' + s('a') + ' ' + s('b')
@@ -748,8 +748,9 @@ describe('spec compliance Phase 3 — substitution & include (resolver-level)', 
   })
 
   // --- S13.14: optional undefined in array concat → no extra elements --------
-  // VIOLATION: whitespace scalars between the arrays leak into the result as extra elements.
-  it.fails('S13.14: optional missing subst in array concat produces clean 2-element array (spec L637, see #83)', () => {
+  // Fixed alongside S15 concat work: array-concat now filters separator whitespace, so the
+  // missing optional substitution no longer leaves a whitespace artefact in the result.
+  it('S13.14: optional missing subst in array concat produces clean 2-element array (spec L637, see #83)', () => {
     const r = resolveStr('x = [1] ${?missing} [2]')
     const x = obj(r).get('x')
     expect(x?.kind).toBe('array')

--- a/tests/s15-numeric-obj-array.test.ts
+++ b/tests/s15-numeric-obj-array.test.ts
@@ -10,10 +10,11 @@
 import { describe, it, expect } from 'vitest'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { parse } from '../src/index.js'
 import { ConfigError } from '../src/errors.js'
 
-const confDir = new URL('./lightbend/testdata/numeric-obj-array', import.meta.url).pathname
+const confDir = fileURLToPath(new URL('./lightbend/testdata/numeric-obj-array', import.meta.url))
 
 function loadFixture(name: string): ReturnType<typeof parse> {
   const content = readFileSync(join(confDir, name), 'utf-8')
@@ -25,7 +26,7 @@ function loadFixture(name: string): ReturnType<typeof parse> {
 // the correct resolved tree, identical between Lightbend and o3co).
 // ---------------------------------------------------------------------------
 describe('S15 — numeric-obj-array parse-tree conformance', () => {
-  const expectedDir = new URL('./lightbend/testdata/expected/numeric-obj-array', import.meta.url).pathname
+  const expectedDir = fileURLToPath(new URL('./lightbend/testdata/expected/numeric-obj-array', import.meta.url))
 
   const fixtures = [
     'na01-basic',

--- a/tests/s15-numeric-obj-array.test.ts
+++ b/tests/s15-numeric-obj-array.test.ts
@@ -34,6 +34,7 @@ describe('S15 — numeric-obj-array parse-tree conformance', () => {
     'na03b-concat-right-list',
     'na03c-concat-two-objs',
     'na03d-concat-multi-piece',
+    'na03e-multi-piece-overlap',
     'na04-empty',
     'na05-non-int-keys',
     'na06-gaps',
@@ -172,5 +173,15 @@ describe('S15 — concat-side conversion (resolver pairwise join)', () => {
   it('na03d: ${obj1} ${obj2} [a] (multi-piece, left-to-right) produces ["x","y","z","w","a"]', () => {
     const c = loadFixture('na03d-concat-multi-piece.conf')
     expect(c.getList('arr')).toEqual(['x', 'y', 'z', 'w', 'a'])
+  })
+
+  // na03e: NORMATIVE overlapping keys — distinguishes pairwise fold from single-pass loop.
+  // obj1={"0":"x","1":"y"}, obj2={"0":"z"}
+  // join(obj1, obj2) → object-merge → {"0":"z","1":"y"} (later "0" wins)
+  // join(merged, [a]) → numericObjectToArray → ["z","y","a"]
+  // Single-pass loop (wrong) would produce ["x","y","z","a"].
+  it('na03e: ${obj1} ${obj2} [a] with overlapping keys produces ["z","y","a"] (pairwise fold)', () => {
+    const c = loadFixture('na03e-multi-piece-overlap.conf')
+    expect(c.getList('arr')).toEqual(['z', 'y', 'a'])
   })
 })

--- a/tests/s15-numeric-obj-array.test.ts
+++ b/tests/s15-numeric-obj-array.test.ts
@@ -1,0 +1,176 @@
+// tests/s15-numeric-obj-array.test.ts
+//
+// S15 — Numerically-indexed object → array conversion.
+// Issue #87: https://github.com/o3co/ts.hocon/issues/87
+//
+// Fixture-driven conformance tests against xx.hocon ground truth.
+// Accessor tests assert the o3co canonical result (per spec §"Integer key parse rule").
+// E-row fixtures (na08, na10a, na10b) diverge from Lightbend at accessor time — see
+// the corresponding .divergence.md files in tests/lightbend/testdata/expected/numeric-obj-array/.
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { parse } from '../src/index.js'
+import { ConfigError } from '../src/errors.js'
+
+const confDir = new URL('./lightbend/testdata/numeric-obj-array', import.meta.url).pathname
+
+function loadFixture(name: string): ReturnType<typeof parse> {
+  const content = readFileSync(join(confDir, name), 'utf-8')
+  return parse(content)
+}
+
+// ---------------------------------------------------------------------------
+// Parse-tree conformance (all 16 fixtures must parse without error and produce
+// the correct resolved tree, identical between Lightbend and o3co).
+// ---------------------------------------------------------------------------
+describe('S15 — numeric-obj-array parse-tree conformance', () => {
+  const expectedDir = new URL('./lightbend/testdata/expected/numeric-obj-array', import.meta.url).pathname
+
+  const fixtures = [
+    'na01-basic',
+    'na02-lazy-getobject',
+    'na03a-concat-left-list',
+    'na03b-concat-right-list',
+    'na03c-concat-two-objs',
+    'na03d-concat-multi-piece',
+    'na04-empty',
+    'na05-non-int-keys',
+    'na06-gaps',
+    'na07-sort',
+    'na08-leading-zero',
+    'na09-negative',
+    'na10a-plus-sign',
+    'na10b-minus-zero',
+    'na11-overflow',
+    'na12-no-eligible',
+  ]
+
+  for (const name of fixtures) {
+    it(`${name}: parse tree matches expected JSON`, () => {
+      const content = readFileSync(join(confDir, `${name}.conf`), 'utf-8')
+      const config = parse(content)
+      const expectedContent = readFileSync(join(expectedDir, `${name}-expected.json`), 'utf-8')
+      const expected = JSON.parse(expectedContent)
+      expect(config.toObject()).toEqual(expected)
+    })
+  }
+})
+
+// ---------------------------------------------------------------------------
+// Accessor-side conversion (na01, na04-na12): getList() must invoke
+// numericObjectToArray and return the o3co canonical result.
+// ---------------------------------------------------------------------------
+describe('S15 — accessor-side conversion (getList)', () => {
+  // na01: basic conversion
+  it('na01: getList("items") on {"0":"a","1":"b"} returns ["a","b"]', () => {
+    const c = loadFixture('na01-basic.conf')
+    expect(c.getList('items')).toEqual(['a', 'b'])
+  })
+
+  // na02: laziness — get() and getConfig() must NOT trigger conversion
+  it('na02: get("items") returns the object (no eager conversion)', () => {
+    const c = loadFixture('na02-lazy-getobject.conf')
+    expect(c.get('items')).toEqual({ '0': 'a', '1': 'b' })
+  })
+
+  it('na02: getConfig("items").getString("0") works (object access preserved)', () => {
+    const c = loadFixture('na02-lazy-getobject.conf')
+    expect(c.getConfig('items').getString('0')).toBe('a')
+  })
+
+  // na04: empty object NOT converted → type error
+  it('na04: getList("items") on {} throws (empty object not converted)', () => {
+    const c = loadFixture('na04-empty.conf')
+    expect(() => c.getList('items')).toThrow(ConfigError)
+  })
+
+  // na05: non-integer keys ignored
+  it('na05: getList("items") ignores "foo" key → ["a","c"]', () => {
+    const c = loadFixture('na05-non-int-keys.conf')
+    expect(c.getList('items')).toEqual(['a', 'c'])
+  })
+
+  // na06: gap compaction
+  it('na06: getList("items") compacts gap between "0" and "2" → ["a","c"]', () => {
+    const c = loadFixture('na06-gaps.conf')
+    expect(c.getList('items')).toEqual(['a', 'c'])
+  })
+
+  // na07: sort by integer key
+  it('na07: getList("items") sorts {"1":"b","0":"a"} → ["a","b"]', () => {
+    const c = loadFixture('na07-sort.conf')
+    expect(c.getList('items')).toEqual(['a', 'b'])
+  })
+
+  // na08: E2 — leading zero "00" rejected; only "0" eligible → ["b"]
+  it('na08: getList("items") rejects "00" key (E2 leading-zero rule) → ["b"]', () => {
+    const c = loadFixture('na08-leading-zero.conf')
+    expect(c.getList('items')).toEqual(['b'])
+  })
+
+  // na09: negative key ineligible; only "0" eligible → ["b"]
+  it('na09: getList("items") rejects "-1" key → ["b"]', () => {
+    const c = loadFixture('na09-negative.conf')
+    expect(c.getList('items')).toEqual(['b'])
+  })
+
+  // na10a: E3 — leading "+" rejected; only "0" eligible → ["b"]
+  it('na10a: getList("items") rejects "+1" key (E3 leading-sign rule) → ["b"]', () => {
+    const c = loadFixture('na10a-plus-sign.conf')
+    expect(c.getList('items')).toEqual(['b'])
+  })
+
+  // na10b: E4 — leading "-" on zero rejected; only "0" eligible → ["b"]
+  it('na10b: getList("items") rejects "-0" key (E4 minus-zero rule) → ["b"]', () => {
+    const c = loadFixture('na10b-minus-zero.conf')
+    expect(c.getList('items')).toEqual(['b'])
+  })
+
+  // na11: overflow (>i32) rejected; only "0" eligible → ["b"]
+  it('na11: getList("items") rejects "99999999999" (overflow) → ["b"]', () => {
+    const c = loadFixture('na11-overflow.conf')
+    expect(c.getList('items')).toEqual(['b'])
+  })
+
+  // na12: all keys ineligible → no conversion → type error
+  it('na12: getList("items") on {"foo":"a","bar":"b"} throws (no eligible keys)', () => {
+    const c = loadFixture('na12-no-eligible.conf')
+    expect(() => c.getList('items')).toThrow(ConfigError)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Concat-side conversion (na03a-na03d): resolver pairwise join must invoke
+// numericObjectToArray when one side is Array and the other is Object.
+// ---------------------------------------------------------------------------
+describe('S15 — concat-side conversion (resolver pairwise join)', () => {
+  // na03a: literal array on left, numeric-keyed object on right
+  it('na03a: [a] ${obj} produces ["a","x","y"]', () => {
+    const c = loadFixture('na03a-concat-left-list.conf')
+    expect(c.getList('arr')).toEqual(['a', 'x', 'y'])
+  })
+
+  // na03b: numeric-keyed object on left, literal array on right (symmetric)
+  it('na03b: ${obj} [a] produces ["x","y","a"]', () => {
+    const c = loadFixture('na03b-concat-right-list.conf')
+    expect(c.getList('arr')).toEqual(['x', 'y', 'a'])
+  })
+
+  // na03c: both sides are objects → S10.3 object merge (no concat-time conversion)
+  // Subsequent getList triggers accessor-side conversion.
+  it('na03c: ${obj1} ${obj2} merges to object; getList triggers accessor conversion → ["x","y","z","w"]', () => {
+    const c = loadFixture('na03c-concat-two-objs.conf')
+    // parse tree: arr is an object
+    expect(c.get('arr')).toEqual({ '0': 'x', '1': 'y', '2': 'z', '3': 'w' })
+    // accessor-side conversion fires when getList is called
+    expect(c.getList('arr')).toEqual(['x', 'y', 'z', 'w'])
+  })
+
+  // na03d: NORMATIVE multi-piece concat — left-to-right pairwise fold
+  // join(obj1, obj2) → merged object; join(merged, [a]) → numericObjectToArray → concat
+  it('na03d: ${obj1} ${obj2} [a] (multi-piece, left-to-right) produces ["x","y","z","w","a"]', () => {
+    const c = loadFixture('na03d-concat-multi-piece.conf')
+    expect(c.getList('arr')).toEqual(['x', 'y', 'z', 'w', 'a'])
+  })
+})


### PR DESCRIPTION
## Summary

Implements S15 numerically-indexed object → array conversion in ts.hocon (Phase 6 #2 of cross-impl HOCON spec compliance work). Closes #87.

- New helper `numericObjectToArray` at `src/value/numeric-array.ts` with canonical-text-strict pre-filter (rejects `+1`/`-0`/`00` per [extra-spec E2/E3/E4](https://github.com/o3co/xx.hocon/blob/main/docs/extra-spec-conventions.md)).
- `Config.getList` invokes the helper; `get`/`getConfig` stay lazy.
- Resolver array-concat refactored to true left-to-right **pairwise fold** (per [spec §"Multi-piece concat"](https://github.com/o3co/xx.hocon/blob/main/testdata/hocon/numeric-obj-array/na03e-multi-piece-overlap.conf)) — adjacent Objects merge first, then convert at list partner.
- 16 + 1 (na03e) xx.hocon fixtures synced; Phase-4 dual-form tests collapsed to spec-form.
- Side-effect fix: **S10.14** (whitespace around array substs ignored) and **S13.14** (optional missing in array concat) — both were `it.fails`-pinned bugs that the array-concat WS filter (required by S15.3) also resolves. Bundled in same PR.

Spec rows flipped: S15.1, S15.2, S15.3, S15.4, S15.5, S15.6, S15.7, S10.14, S13.14 → ✅.

## Multi-agent review history

Local `/multi-agent-review` ran on the initial implementation (commit `b301c11`). Codex + Claude (general-purpose Opus) both caught a critical bug: the initial single-pass loop variant of multi-piece concat produced wrong results for overlapping numeric keys. Fix commit `000bc5d` refactors to true pairwise fold per the NORMATIVE rule. New xx.hocon fixture `na03e-multi-piece-overlap.conf` (xx.hocon#11) pins Lightbend ground truth `["z","y","a"]` and is verified GREEN here.

## Test plan

- [x] `pnpm test --run`: 548 passed | 34 expected-fail (other Phase 6 work) | 1 skipped | 0 failures
- [x] na03e (`${obj1} ${obj2} [a]` with overlapping numeric keys) → `["z","y","a"]` confirmed
- [x] na03d (disjoint keys) → `["x","y","z","w","a"]` still passes (pairwise + single-pass coincide for disjoint case)
- [x] Phase-4 dual-form `_pin` tests removed; `_spec` form converted to `it()` and passes
- [ ] In-flight Phase-2 sibling PRs in rs.hocon and go.hocon converge on the same xx.hocon ground truth

## Related

- Phase 6 #2 cluster (cross-impl)
- Sibling PRs: rs.hocon#TBD, go.hocon#TBD
- xx.hocon ground truth: o3co/xx.hocon#10 (16 fixtures + E2/E3/E4) and o3co/xx.hocon#11 (na03e overlap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)