### PR TITLE
fix(s8.6): gate parseSubstBody '-' check on segment start (refs #73)

### DIFF
--- a/src/internal/lexer/lexer.ts
+++ b/src/internal/lexer/lexer.ts
@@ -334,10 +334,14 @@ class Lexer {
       } else if (isUnquotedSubstChar(ch)) {
         // S8.6 (HOCON.md L270–276) also applies to unquoted path segments
         // inside ${...}: a segment beginning with '-' must be followed by a
-        // digit. Digit-leading segments are not policed here (consistent
-        // with the value-position rule and ts.hocon's unquoted-only token
-        // model — see docs/spec-compliance.md §S8.6).
-        if (ch === '-' && !isDecimalDigit(this.peek(1))) {
+        // digit. Gate on `!curStarted` so the check fires only at segment
+        // start — a `-` that follows a quoted fragment in the same segment
+        // (e.g. ${"a"-foo} resolving the key "a-foo" via quoted/unquoted
+        // concat) is not policed, mirroring how the existing ${"a"x} flow
+        // builds "ax". Digit-leading segments are not policed here either
+        // (consistent with the value-position rule and ts.hocon's unquoted-
+        // only token model — see docs/spec-compliance.md §S8.6).
+        if (ch === '-' && !curStarted && !isDecimalDigit(this.peek(1))) {
           const after = this.peek(1) === '' ? 'EOF' : JSON.stringify(this.peek(1))
           throw new ParseError(
             `unquoted path segment cannot begin with '-' unless followed by a digit (got '-' then ${after}, HOCON.md L270-276)`,

--- a/tests/s8-unquoted-starts.test.ts
+++ b/tests/s8-unquoted-starts.test.ts
@@ -109,4 +109,13 @@ describe('S8.6 — unquoted-starts conformance', () => {
   it('S8.6 in key path: a.-foo = 1 is rejected (segment-level rule)', () => {
     expect(() => parse('a.-foo = 1')).toThrow(ParseError)
   })
+
+  // Regression: the parseSubstBody S8.6 check must fire only at segment start
+  // (gated on `!curStarted`). Quoted+unquoted concat within a segment — e.g.
+  // ${"a"-foo} building key "a-foo" — must remain accepted. Mirrors the
+  // existing ${"a"x} → "ax" concat flow.
+  it('S8.6 in substitution: ${"a"-foo} (quoted+unquoted concat) is accepted', () => {
+    const input = '"a-foo" = 1\nx = ${"a"-foo}'
+    expect(() => parse(input)).not.toThrow()
+  })
 })


### PR DESCRIPTION
## Summary

Follow-up to PR #96 (squashed as 1d5f6b1). Multi-agent-review on rs.hocon's mirror PR caught a bug in the analogous `parseSubstBody` check: the `-` rejection fired for **every** unquoted fragment, not only at segment start. This wrongly rejected `${"a"-foo}` (quoted+unquoted concat forming key `"a-foo"`), mirroring the existing `${"a"x}` → `"ax"` pattern.

Fix: gate on `!curStarted` so the check fires only at segment start. The value-position check (main tokenize loop) and `parseKey` segment check were already correct — only `parseSubstBody` needed the gate.

## What changed

- `src/internal/lexer/lexer.ts` — `parseSubstBody` unquoted-segment-start check now gated on `!curStarted`. One additional predicate, no structural changes.
- `tests/s8-unquoted-starts.test.ts` — new regression: `${"a"-foo}` (quoted+unquoted concat) must lex+resolve to `"a-foo"`.

## Why this slipped past PR #96

The `${"a"-foo}` pattern isn't in the xx.hocon `unquoted-starts/` fixtures (those test value-position, not substitution mid-segment concat). PR #96's `${-foo}` regression test only exercised the segment-start case, not the mid-segment case. The bug was symmetric across ts.hocon and rs.hocon — Codex caught it during rs.hocon PR #86's review by tracing the `${"a"x}` pattern in the existing `subst-tokenize/st08-quoted-unquoted-concat.conf` fixture.

## Test plan

- [x] `pnpm test` — 566 passed, 35 expected fail, 1 skipped, 0 regressions (was 565/35/1 — net +1 passing test)
- [x] New regression test asserts `${"a"-foo}` does not throw
- [x] Existing `${-foo}` and `${a.-foo}` tests still throw correctly (gate re-fires after `.` because `parseSubstBody` resets `curStarted=false` in the DOT branch)

## Cross-impl

[rs.hocon PR #86](https://github.com/o3co/rs.hocon/pull/86) commit d31f02b applies the analogous fix to `parse_subst_body`.

Refs: #73, follow-up to #96.

🤖 Generated with [Claude Code](https://claude.com/claude-code)