### PR TITLE
chore(release): v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-05-18
+
 ### Notes
 
 - Substitution and top-level quoted strings continue to accept `\uXXXX` escapes producing surrogate code units (Java/Lightbend semantics). This intentionally diverges from rs.hocon, which rejects them because Rust's `char` cannot represent unpaired surrogates. See spec "Surrogate codepoint divergence" note.
 
 ### Changed
 
-- **BREAKING**: Minimum Node.js version raised from 18 to 20. Node 18 reached EOL on 2025-04-30.
+- **BREAKING**: Minimum Node.js version raised from 18 to 22 (`engines.node` is `">=22"`). Node 18 reached EOL on 2025-04-30; Node 20 reached EOL on 2026-04-30. npm install on Node ≤ 21 will emit `EBADENGINE` and refuse to install.
 - **BREAKING (S8.6)**: `a = -foo`, `a = -bar`, `a = -` and other `-`-not-followed-by-digit inputs are now lex errors. Per HOCON.md L270–276, a leading `-` must begin a number literal (i.e. be followed by a digit). Previously these were silently accepted as unquoted strings (`"-foo"`, `"-"`). Mitigation: quote the value (`a = "-foo"`). Note: this is intentionally stricter than Lightbend's reference implementation, which falls back to unquoted on number-parse failure. Digit-leading inputs (e.g. `123abc`, `01`, `1e+x`) are unaffected — ts.hocon's token model has no separate `number` kind, so the resolved value continues to match Lightbend's value-concat output for the common cases (see docs/spec-compliance.md §S8.6 for the remaining gaps tracked under #73).
 - Substitution body tokenization: `${...}` internals are now tokenized at lex time via `parseSubstBody`. `SubstPlaceholder.segments` is now `Segment[]` (each segment carries `text`, `line`, `col`). The `opt_subst` token kind has been removed — use `token.subst.optional` instead.
 - Key parser now handles mixed quoted/unquoted paths like `a."b.c".d` in both key position and substitution paths.


### PR DESCRIPTION
## Summary

ts.hocon v1.2.0 release. Two BREAKING changes + new substitution body tokenization + minor fixes.

## BREAKING changes

- **S8.6** — `a = -foo` / `a = -bar` / `a = -` no-digit hyphen rejected at lex time. Mitigation: quote (`a = "-foo"`).
- **engines** — Minimum Node.js raised from 18 to 22 (Node 18 EOL 2025-04-30, Node 20 EOL 2026-04-30). `npm install` on Node ≤ 21 emits `EBADENGINE`.

## Highlights

- Substitution body tokenization via `parseSubstBody` — `${...}` now matches Lightbend `PathParser` + `WhitespaceSaver` semantics
- Key parser handles mixed quoted/unquoted paths (`a."b.c".d`)
- Escape + whitespace concat inside `${...}` fixed (closes #58)
- Cross-impl compliance: 88.2% in-scope (S6.1/6.2/6.4 + S15.1–S15.7 + S8.6 partial cleared in Phase 6 #1/#2/#3c)

## Test plan

- [x] All Phase 6 #1/#2/#3c PRs merged to develop and passed CI individually
- [x] Tag-triggered npm publish workflow (`.github/workflows/release.yml`) will run on `v1.2.0` tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)