### PR TITLE
ci(release): add make testdata before Test — fixes v1.2.0 publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,13 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Fetch expected JSON
+        # xx.hocon ground-truth fixtures used by the conformance tests
+        # (e.g. tests/lightbend/testdata/expected/unquoted-starts/*.json).
+        # Without this step the test job fails with ENOENT before publish
+        # — see #98 release-time regression where v1.2.0 publish was blocked.
+        run: make testdata
+
       - name: Type check
         run: pnpm typecheck
 


### PR DESCRIPTION
## Summary

`.github/workflows/release.yml` was missing the `make testdata` step that `test.yml` runs before the Test step. xx.hocon ground-truth fixtures (e.g. `tests/lightbend/testdata/expected/unquoted-starts/*.json`) are fetched via that Makefile target and not checked into the repo. As a result the v1.2.0 tag push triggered the publish workflow but the Test step ENOENT'd before Publish — leaving v1.2.0 unpublished on npm.

## Recovery plan after this PR merges

1. Force-update the `v1.2.0` tag to the new develop HEAD (which includes this release.yml fix): `git tag -f v1.2.0` + `git push -f origin v1.2.0`
2. Publish workflow re-runs with the fix; npm publish should succeed
3. Verify: `npm view @o3co/ts.hocon versions` shows 1.2.0

## Test plan

- [x] Diff matches the existing `test.yml` step verbatim (same Makefile target, no extra config)
- [ ] After merge: monitor re-triggered release.yml run for green Test + Publish steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)