### PR TITLE
docs: fix codecov badge URL (main → develop)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/@o3co/ts.hocon.svg)](https://www.npmjs.com/package/@o3co/ts.hocon)
 [![CI](https://github.com/o3co/ts.hocon/actions/workflows/test.yml/badge.svg)](https://github.com/o3co/ts.hocon/actions/workflows/test.yml)
-[![codecov](https://codecov.io/gh/o3co/ts.hocon/branch/main/graph/badge.svg)](https://codecov.io/gh/o3co/ts.hocon)
+[![codecov](https://codecov.io/gh/o3co/ts.hocon/branch/develop/graph/badge.svg)](https://codecov.io/gh/o3co/ts.hocon)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
 [Lightbend HOCON](https://github.com/lightbend/config/blob/main/HOCON.md) 仕様の TypeScript パーサー。現在の準拠率は [仕様準拠](#仕様準拠) を参照。

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm](https://img.shields.io/npm/v/@o3co/ts.hocon.svg)](https://www.npmjs.com/package/@o3co/ts.hocon)
 [![CI](https://github.com/o3co/ts.hocon/actions/workflows/test.yml/badge.svg)](https://github.com/o3co/ts.hocon/actions/workflows/test.yml)
-[![codecov](https://codecov.io/gh/o3co/ts.hocon/branch/main/graph/badge.svg)](https://codecov.io/gh/o3co/ts.hocon)
+[![codecov](https://codecov.io/gh/o3co/ts.hocon/branch/develop/graph/badge.svg)](https://codecov.io/gh/o3co/ts.hocon)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
 
 A [Lightbend HOCON](https://github.com/lightbend/config/blob/main/HOCON.md) parser for TypeScript. See [Spec Compliance](#spec-compliance) for the current conformance rate.


### PR DESCRIPTION
## Summary

- README.md + README.ja.md の codecov badge URL を `branch/main` から `branch/develop` に修正
- このリポは default branch が `develop` で、`main` branch は存在しない

## Why

`https://codecov.io/gh/o3co/ts.hocon/branch/main/graph/badge.svg` を fetch すると codecov は存在しない branch のため fallback して **stale な 89%** を返していた (実際の develop coverage は ~97%)。badge は動いてるように見えて嘘の数値を表示するという最悪パターン。

`branch/develop` に修正後、empirically 97% を返すことを確認済。

## Cross-repo

同じ修正を [rs.hocon](https://github.com/o3co/rs.hocon) と [go.hocon](https://github.com/o3co/go.hocon) にも並列 PR で適用。

## Test plan

- [x] curl で新 URL が正しい値を返すことを確認
- [ ] CI green (markdown lint 等)

🤖 Generated with [Claude Code](https://claude.com/claude-code)