### PR TITLE
chore(release): cut v1.3.0 — spec-compliance bugfix release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [1.3.0] - 2026-05-21
 
 v1.3 is a spec-compliance bugfix release. The implementation has been corrected to match the HOCON spec and Lightbend typesafe-config reference behavior across several previously-divergent areas (concat type-checking, `include` key reservation, leading-`-` value-position lexing, leading-zero number canonicalization, single-letter byte units, empty-file rejection, `.properties` object-wins, duration/bytes default unit). The spec did not change; the parser was simply wrong in places.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.3.0] - 2026-05-21
+
+v1.3 is a spec-compliance bugfix release. The implementation has been corrected to match the HOCON spec and Lightbend typesafe-config reference behavior across several previously-divergent areas (concat type-checking, `include` key reservation, leading-`-` value-position lexing, leading-zero number canonicalization, single-letter byte units, empty-file rejection, `.properties` object-wins, duration/bytes default unit). The spec did not change; the parser was simply wrong in places.
+
+A subset of these fixes change observable runtime behavior. Configs that relied on the previously-incorrect lenience need updating — read the `### Breaking` and `### Fixed` sections below if your CI fails to upgrade cleanly. We elected MINOR (not MAJOR) because no API or architectural changes occurred; v2.0 is reserved for parser/lexer rewrites or similar structural shifts.
 
 ### Breaking
 


### PR DESCRIPTION
## Summary

CHANGELOG-only PR to cut **v1.3.0** — collected spec-compliance bugfixes from Phase 6 (#3b–#3h) + E8 amendment, framed as bugfix release (impl was wrong vs HOCON spec / Lightbend reference; spec itself unchanged).

- `[Unreleased]` → `[1.3.0] - 2026-05-21`
- Top-of-release paragraph framing this as bugfix release, explaining MINOR (not MAJOR) — no API/architectural change; v2.0 reserved for structural shifts (parser/lexer rewrites).

## After merge

`git tag v1.3.0` on develop after merge → `git push --tags` → `.github/workflows/release.yml` auto-publishes to npm.

## Test plan

- [x] No code change — only CHANGELOG text
- [x] Develop CI green on the underlying impl PRs (#108 E8, #106 Phase 6 #3h, etc.)
- [x] CHANGELOG MD024 warnings are pre-existing Keep-A-Changelog convention (per-release `### Breaking` / `### Fixed` headers repeat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)