### PR TITLE
feat(e11): include package(...) — Node module resolution resolver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ docs/*
 
 # Hand-written docs to track
 !docs/spec-compliance.md
+!docs/proposals/
+!docs/proposals/*.md
 
 # Fetched testdata (from xx.hocon)
 tests/lightbend/testdata/expected/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.3.0] - 2026-05-21
+## [Unreleased]
 
-v1.3 is a spec-compliance bugfix release. The implementation has been corrected to match the HOCON spec and Lightbend typesafe-config reference behavior across several previously-divergent areas (concat type-checking, `include` key reservation, leading-`-` value-position lexing, leading-zero number canonicalization, single-letter byte units, empty-file rejection, `.properties` object-wins, duration/bytes default unit). The spec did not change; the parser was simply wrong in places.
+### Added
 
-A subset of these fixes change observable runtime behavior. Configs that relied on the previously-incorrect lenience need updating — read the `### Breaking` and `### Fixed` sections below if your CI fails to upgrade cleanly. We elected MINOR (not MAJOR) because no API or architectural changes occurred; v2.0 is reserved for parser/lexer rewrites or similar structural shifts.
+- **E11 — `include package("<id>", "<file>")` qualifier** (xx.hocon [#33](https://github.com/o3co/xx.hocon/issues/33), [#36](https://github.com/o3co/xx.hocon/pull/36); supersedes [#109](https://github.com/o3co/ts.hocon/issues/109)). A new include qualifier with **service-locator semantics** — looks up `.conf` files registered under a stable name via Node module resolution. **Not a Java classpath equivalent** (no auto-discovery, no auto `reference.conf` merge, no transitive auto-resolution). New public surface:
+  - `include package("github.com/myorg/pkg", "reference.conf")` syntax — two-arg form mandatory; one-arg + missing-comma rejected at parse time.
+  - `ParseOptions.packageResolver?: PackageResolver` — custom resolver callback. When provided, takes full control; `resolveFrom` is ignored. Use for Yarn Berry PnP, bundler contexts, edge runtimes, or test isolation.
+  - `ParseOptions.resolveFrom?: string | string[]` — override the starting directory(ies) for the default resolver's `require.resolve`. Default resolution order: `resolveFrom` > `baseDir` > `path.dirname(includingFile)` > `process.cwd()`.
+  - Exported `PackageResolver` type — `(identifier, file, includingFile, baseDir) => string`.
+  - Exported `PackageLookupError extends ResolveError` — thrown on registry/module miss.
+  - File argument validated **after HOCON string unescaping**: rejects empty, absolute, `..`, `./`, backslash, consecutive `/`.
+  - Yarn Berry PnP detected and rejected with a clear error (cross-impl decision X1).
+  - Cycle detection: `("package", id, file)` cycle-key integrated with existing include-cycle detection.
+
+### Changed
+
+- `IncludeQualifier` AST type refactored from a boolean `isFile` flag to a discriminated union (`kind: 'bare' | 'file' | 'url' | 'classpath' | 'package'`). Internal change; not part of the documented public AST surface.
 
 ## [1.3.0] - 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.3.0] - 2026-05-21
+
+v1.3 is a spec-compliance bugfix release. The implementation has been corrected to match the HOCON spec and Lightbend typesafe-config reference behavior across several previously-divergent areas (concat type-checking, `include` key reservation, leading-`-` value-position lexing, leading-zero number canonicalization, single-letter byte units, empty-file rejection, `.properties` object-wins, duration/bytes default unit). The spec did not change; the parser was simply wrong in places.
+
+A subset of these fixes change observable runtime behavior. Configs that relied on the previously-incorrect lenience need updating — read the `### Breaking` and `### Fixed` sections below if your CI fails to upgrade cleanly. We elected MINOR (not MAJOR) because no API or architectural changes occurred; v2.0 is reserved for parser/lexer rewrites or similar structural shifts.
 
 ## [1.3.0] - 2026-05-21
 

--- a/docs/proposals/E11-include-package-design.md
+++ b/docs/proposals/E11-include-package-design.md
@@ -1,9 +1,10 @@
 # E11 `include package(...)` — ts.hocon API Surface and Resolution Design
 
-**Status**: Design notes — NOT approved for implementation yet (★1 gate pending).
-**Branch**: `feat/include-package-design`
+**Status**: Approved 2026-05-21 (Yoshi ★1) and implemented on this branch.
+**Branch**: `feat/include-package-design` (design `9f25bbe` → impl `ebbfd6a` → tests `c7fcb0e` → multi-agent-review fixes `66738a4` → Copilot review-cycle fixes on top)
 **Spec**: `xx.hocon/docs/extra-spec-conventions.md § E11`
 **Tracking**: [xx.hocon#33](https://github.com/o3co/xx.hocon/issues/33)
+**PR**: [ts.hocon#112](https://github.com/o3co/ts.hocon/pull/112)
 
 ---
 

--- a/docs/proposals/E11-include-package-design.md
+++ b/docs/proposals/E11-include-package-design.md
@@ -1,0 +1,678 @@
+# E11 `include package(...)` — ts.hocon API Surface and Resolution Design
+
+**Status**: Design notes — NOT approved for implementation yet (★1 gate pending).
+**Branch**: `feat/include-package-design`
+**Spec**: `xx.hocon/docs/extra-spec-conventions.md § E11`
+**Tracking**: [xx.hocon#33](https://github.com/o3co/xx.hocon/issues/33)
+
+---
+
+## 1. Context
+
+E11 adds a new `include package("identifier", "file")` qualifier. ts.hocon's lookup
+mechanism is Node `require.resolve` — implicit, host-driven, no explicit registry. This
+document records the design decisions needed before implementation begins.
+
+---
+
+## 2. Decision 1 — Resolution starting-point default
+
+### Proposed call site
+
+```text
+require.resolve(identifier + "/" + file, { paths: [path.dirname(includingConfFile)] })
+```
+
+`includingConfFile` is the absolute path of the `.conf` file that contains the
+`include package(...)` directive, threaded into the resolver via `ResolveOptions.baseDir`.
+
+### Correctness analysis by package manager
+
+| Package manager | Layout | Does the call work? | Notes |
+| --- | --- | --- | --- |
+| npm flat | `node_modules/<id>/…` | Yes | Canonical case; `paths` array starts search from the `.conf` file's directory, resolves up through parent `node_modules` trees — standard Node resolution. |
+| pnpm with hoisted layout (`shamefully-hoist=true`) | Same as npm flat | Yes | Hoisted mode places deps in root `node_modules`; resolution identical to npm. |
+| pnpm default (symlink layout) | `node_modules/<id>` → `.pnpm/<id@ver>/node_modules/<id>` | Yes | `require.resolve` follows symlinks; the virtual-store target is a real directory. The `.conf` file path need not be inside the symlinked tree — `paths` is the starting scope, resolution still works. |
+| pnpm PnP (experimental) | Package zip files | **Untested** | pnpm PnP is rare and experimental; treat as unsupported with a clear error. |
+| Yarn Berry PnP | ZIP-based store (`__pnp_loader__` intercept) | **Problematic** | Yarn Berry's PnP runtime monkey-patches `Module._resolveFilename`. `require.resolve` may work if the consuming process loaded Yarn's runtime loader (`--loader`), but the file inside the ZIP cannot be read by `fs.readFileSync` after resolution. The resolved path is a ZIP entry path, not a real fs path. **Design conclusion**: detect PnP store paths (path contains `.yarn/cache` or `.pnp.cjs`), throw a clear error recommending Yarn's `module.createRequire` + PnP API, or requiring the package to export its conf content explicitly. |
+| Yarn Classic | `node_modules/<id>` | Yes | Same as npm flat. |
+
+### Pitfall: `baseDir` absent
+
+When `parse(input, {})` is called (no `baseDir`, no file path), `includingConfFile` is
+`undefined`. In this case `require.resolve` must be called with `paths: [process.cwd()]`
+as the fallback. This matches the existing behaviour of bare `include "..."` in ts.hocon
+(which resolves relative to `baseDir ?? process.cwd()`).
+
+### Pitfall: file reading after resolve
+
+`require.resolve` returns the absolute path to the resolved file. The actual file read
+then goes through the caller-supplied `readFile` / `readFileSync` option, which is correct
+for testability but means the file must be a real fs path. This is compatible with all
+non-PnP environments.
+
+---
+
+## 3. Decision 2 — Parser option API
+
+### Option A: `resolveFrom` (path or path[])
+
+```ts
+export type ParseOptions = {
+  // … existing fields …
+  /**
+   * Override the starting directory (or directories) used when resolving
+   * `include package("id", "file")` via Node module resolution.
+   *
+   * Default: path.dirname(includingConfFile) when known, process.cwd() otherwise.
+   *
+   * Useful for monorepos where the conf file lives outside the package tree,
+   * or for test fixtures that need a stable resolution root.
+   */
+  resolveFrom?: string | string[]
+}
+```
+
+### Option B: Full resolver callback
+
+```ts
+export type PackageResolver = (identifier: string, file: string, includingFile: string | undefined) => string
+// Returns the absolute path to the resolved file, or throws if not found.
+
+export type ParseOptions = {
+  // … existing fields …
+  /**
+   * Custom resolver for `include package("id", "file")`.
+   * Receives the identifier, file, and (if known) the absolute path of the
+   * including .conf file. Must return an absolute path or throw.
+   *
+   * When not provided, the default resolver uses Node's `require.resolve`.
+   */
+  packageResolver?: PackageResolver
+}
+```
+
+### Decision
+
+Provide **both**, with Option B being the escape hatch. Rationale:
+
+1. `resolveFrom` covers the common monorepo / test-fixture override case with minimal API
+   surface (a string is easy to reason about and document).
+2. `packageResolver` is needed for: Yarn PnP environments, bundler contexts where
+   `require.resolve` is replaced, edge runtimes, and advanced test isolation. Without it,
+   those users have no recourse.
+3. Both options can coexist: if `packageResolver` is provided it takes full control;
+   `resolveFrom` modifies the default resolver only.
+4. The callback signature `(identifier, file, includingFile) => string` is enough
+   information for any resolution strategy without over-engineering. The return type is a
+   plain path string — keeping file-reading in ts.hocon's existing `readFile` / `readFileSync`
+   path, which preserves the existing test-hook surface.
+
+**Interface shape** (internal type, not public-exported initially — see §9):
+
+```ts
+// internal/resolver/types.ts additions
+export type PackageResolver = (
+  identifier: string,
+  file: string,
+  includingFile: string | undefined,
+) => string   // must return absolute path or throw
+
+export type ResolveOptions = {
+  env: Record<string, string>
+  baseDir: string | undefined
+  readFileSync: (filePath: string) => string
+  readFile?: (filePath: string) => Promise<string>
+  includeStack?: string[]    // existing — now extended with package cycle keys
+  // NEW:
+  resolveFrom?: string | string[]
+  packageResolver?: PackageResolver
+}
+```
+
+`ParseOptions` mirrors these two new fields into the public API surface (src/parse.ts).
+
+---
+
+## 4. Decision 3 — Sync vs async
+
+### Existing parse paths
+
+| Entry point | Sync | Async |
+| --- | --- | --- |
+| `parse()` | Yes (uses `readFileSync`) | — |
+| `parseAsync()` | — | Yes (uses `readFile`) |
+| `parseFile()` | Yes | — |
+| `parseFileAsync()` | Yes (fallback `readFileSync`) + | Yes (primary `readFile`) |
+
+### `package(...)` in sync path
+
+`require.resolve()` is **synchronous**. File reading uses `readFileSync`. No async
+primitives needed. The sync path is fully compatible without additional design.
+
+### `package(...)` in async path
+
+`require.resolve()` is still sync (no `require.resolve`-as-promise exists in Node).
+The resolution step is sync; only the file read is async. The `packageResolver` callback
+(Option B above) also returns `string` synchronously (not `Promise<string>`), keeping the
+pattern consistent. If a custom resolver needs to do async work (e.g., hitting a network
+registry), the caller must pre-resolve and pass a sync wrapper or use `packageResolver`
+with a pre-built cache. This tradeoff is acceptable: module resolution is by definition a
+local-filesystem-and-manifest operation in all supported environments.
+
+**Conclusion**: `PackageResolver` returns `string` (sync). Both `load` and `loadAsync`
+in `IncludeLoader` call the same sync resolution step, then branch on
+`readFileSync` vs `readFile` for the content fetch.
+
+---
+
+## 5. Decision 4 — ESM vs CJS resolution
+
+### Runtime landscape (Node ≥ 22, per `engines` field in package.json)
+
+- **CJS context**: `require.resolve(id, { paths })` — available, synchronous, correct.
+- **ESM context (`import.meta.resolve`)**: Node 20.6+ stabilized. Node 22 fully supports it.
+  However `import.meta.resolve` is async in some contexts, does not accept a `paths`
+  override option, and resolves relative to the calling module's URL (not a configurable
+  starting path). This makes it unsuitable as the primary mechanism.
+- **Mixed CJS/ESM**: ts.hocon publishes both `./dist/index.cjs` and `./dist/index.js`
+  (ESM) per the `exports` map. The dist bundle is produced by `tsup`.
+
+### ESM/CJS decision
+
+Use **CJS `require.resolve`** as the default, detected via a guard:
+
+```ts
+function defaultPackageResolver(
+  identifier: string,
+  file: string,
+  includingFile: string | undefined,
+  resolveFrom?: string | string[],
+): string {
+  if (typeof require === 'undefined' || typeof require.resolve === 'undefined') {
+    throw new ResolveError(
+      `include package("${identifier}", "${file}") requires Node.js CommonJS require.resolve, ` +
+      `which is not available in this environment (ESM-only, bundler, or edge runtime). ` +
+      `Provide a custom packageResolver option.`,
+      identifier, 0, 0,
+    )
+  }
+  const from = resolveFrom
+    ? (Array.isArray(resolveFrom) ? resolveFrom : [resolveFrom])
+    : (includingFile ? [nodePath.dirname(includingFile)] : [process.cwd()])
+  try {
+    return require.resolve(`${identifier}/${file}`, { paths: from })
+  } catch {
+    throw new ResolveError(
+      `include package("${identifier}", "${file}"): module not found via require.resolve ` +
+      `(starting from: ${from.join(', ')})`,
+      identifier, 0, 0,
+    )
+  }
+}
+```
+
+**ESM interop note**: when ts.hocon's ESM build is loaded in a pure ESM Node process,
+`require` is not defined natively. However, callers can create a CJS-compatible `require`
+via `import { createRequire } from 'module'; const require = createRequire(import.meta.url)`.
+The design provides the `packageResolver` escape hatch specifically for this and for
+Yarn PnP / bundler cases — the default resolver fails loudly with an actionable error
+rather than silently.
+
+**`import.meta.resolve` path**: not used in the default resolver. It could be wrapped in
+a future opt-in via a helper export (`createImportMetaResolver(import.meta)`), but that
+is out of scope for this design (ESM-only consolidation is listed as a non-goal in E11).
+
+---
+
+## 6. Decision 5 — Caching
+
+### Options
+
+| Level | Pros | Cons |
+| --- | --- | --- |
+| **None** | Simple, no state, no stale-file risk | Re-reads same file if `include package` appears N times |
+| Per-parser-call | Warm within a single `parse()` invocation | Requires threading cache through `ResolveOptions`; adds complexity |
+| Per-process (`Map` module-level) | Fastest across calls | Test isolation problem (shared mutable state) |
+
+### Caching decision
+
+**None** for V1. Rationale:
+
+1. `require.resolve` is fast (filesystem metadata, no file read). The expensive part is
+   file reading + tokenize + parse of the included content; these happen once per
+   `include package(...)` occurrence in the source document, not per package identifier.
+2. A per-process cache would require `ResetPackageCache()` for test isolation (the
+   go.hocon pattern). ts.hocon explicitly avoids a global registry (E11 spec decision 3,
+   ts.hocon column), so adding a global cache would partially contradict that stance.
+3. HOCON includes are typically few in number; the performance impact of re-resolution is
+   negligible in practice.
+4. A caching layer can be added by the caller via a memoized `packageResolver` callback.
+
+---
+
+## 7. Decision 6 — Bundler / edge runtime detection
+
+### When `require.resolve` is unavailable
+
+Contexts: webpack (replaces `require.resolve` with its own module graph), esbuild
+(similar), Cloudflare Workers (no `require`), Deno (no `require`), browser bundles.
+
+### Detection strategy
+
+The guard in `defaultPackageResolver` (§Decision 4) checks:
+
+```ts
+typeof require === 'undefined' || typeof require.resolve === 'undefined'
+```
+
+This fires in pure ESM node processes and in most bundlers (webpack re-defines `require`
+but `require.resolve` may throw or return incorrect paths inside a bundle).
+
+A secondary heuristic for webpack-inside-Node: `typeof __webpack_require__ !== 'undefined'`.
+Add this to the guard condition.
+
+### Error message
+
+The error must:
+
+1. Identify the qualifier that triggered it: `include package("id", "file")`
+2. Explain why it failed: `require.resolve` not available
+3. Give an actionable resolution: "Provide a custom packageResolver option, or pre-bundle
+   the package content and pass it via a pre-populated custom resolver."
+
+Bundler users are expected to provide a `packageResolver` that uses the bundler's own
+asset/import mechanism (e.g., webpack's `require.context`, Vite's `import.meta.glob`).
+This is intentional: bundler integration cannot be made automatic without coupling
+ts.hocon to specific bundler APIs.
+
+---
+
+## 8. Decision 7 — File arg validation (E11 decision 6)
+
+### Validation rules (from E11 spec)
+
+- non-empty
+- forward-slash separators only (no `\`)
+- no leading `/`
+- no `.` or `..` segments
+- no consecutive `//`
+- no percent-decoding applied
+
+### Where to validate
+
+**Recommended: include resolver layer** (`IncludeLoader.loadPackage`), not the parser or tokenizer.
+
+Rationale:
+
+- The parser already treats `package("id", "file")` as an opaque pair of HOCON strings.
+  Inserting validation at the AST level would require the parser to understand E11
+  semantics, which it should not.
+- The tokenizer has no access to the `file` argument's semantic meaning; it merely
+  tokenizes the quoted strings.
+- The resolver layer is the right point because it is the first consumer that understands
+  what `("identifier", "file")` means in context. Validation at this layer is consistent
+  with how existing qualifiers' path constraints are enforced (e.g., `file()` implicitly
+  resolves only to filesystem paths; bare include rejects missing files at resolution
+  time).
+- Validation runs before `require.resolve` is called, giving a clean parse-time error
+  rather than a confusing `MODULE_NOT_FOUND` from Node.
+
+### Validation logic shape
+
+```ts
+// internal/resolver/include-loader.ts (in loadPackage / loadPackageAsync)
+function validatePackageFile(file: string, identifier: string): void {
+  if (file.length === 0)
+    throw new ResolveError(`include package("${identifier}", ...): file argument must be non-empty`, ...)
+  if (file.includes('\\'))
+    throw new ResolveError(`include package: backslash not allowed in file arg (use forward slash): "${file}"`, ...)
+  if (file.startsWith('/'))
+    throw new ResolveError(`include package: absolute path not allowed in file arg: "${file}"`, ...)
+  if (/(?:^|\/)\.\.?(?:\/|$)/.test(file))
+    throw new ResolveError(`include package: path traversal (. or ..) not allowed in file arg: "${file}"`, ...)
+  if (file.includes('//'))
+    throw new ResolveError(`include package: consecutive slashes not allowed in file arg: "${file}"`, ...)
+}
+```
+
+Note: the regex `/(?:^|\/)\.\.?(?:\/|$)/` rejects both `.` and `..` as path segments
+while allowing filenames that contain dots (e.g., `reference.conf` is valid).
+
+---
+
+## 9. Decision 8 — Cycle detection
+
+### Where existing cycle detection lives
+
+In `IncludeLoader.load` / `loadAsync` (src/internal/resolver/include-loader.ts, lines
+47–49 and 90–92):
+
+```ts
+if (includeStack.includes(absPath)) {
+  throw new ResolveError(`circular include: ${absPath}`, absPath, 0, 0)
+}
+```
+
+`includeStack` is a `string[]` in `ResolveOptions`, threaded through each recursive
+`loadSingle` / `loadSingleAsync` call with a spread-copy (`[...includeStack, candidate]`).
+
+### Adding `("package", identifier, file)` cycle key
+
+The cycle key for a `package(...)` include must distinguish it from `file(...)` includes.
+The spec mandates: `("package", <identifier>, <file>)`.
+
+Serialize as a single string key to slot into the existing `string[]`:
+
+```ts
+const cycleKey = `\0package\0${identifier}\0${file}`
+// \0 (NUL) is not valid in fs paths or in HOCON string values, so it is a safe separator.
+```
+
+Usage:
+
+```ts
+loadPackage(identifier: string, file: string, required: boolean): ResObj {
+  const { includeStack = [] } = this.opts
+  const cycleKey = `\0package\0${identifier}\0${file}`
+
+  if (includeStack.includes(cycleKey)) {
+    throw new ResolveError(
+      `circular include: package("${identifier}", "${file}")`,
+      identifier, 0, 0,
+    )
+  }
+  if (includeStack.length >= 50) {
+    throw new ResolveError(`include depth limit exceeded (max 50)`, identifier, 0, 0)
+  }
+
+  // … validate file arg, resolve path, read content, parse …
+
+  return this.onBuildResObj(ast, {
+    ...this.opts,
+    baseDir: nodePath.dirname(resolvedPath),
+    includeStack: [...includeStack, cycleKey],
+  })
+}
+```
+
+The `\0package\0` prefix ensures no collision with filesystem paths (which cannot
+contain NUL) while keeping the existing `includeStack: string[]` type unchanged.
+
+---
+
+## 10. AST changes required
+
+The current `AstNode` include variant:
+
+```ts
+{ kind: 'include'; path: string; required: boolean; isFile?: boolean; pos: Pos }
+```
+
+Must be extended to carry package qualifier data. Two approaches:
+
+### Option A: Add optional fields
+
+```ts
+{ kind: 'include'; path: string; required: boolean; isFile?: boolean;
+  isPackage?: boolean; packageIdentifier?: string; pos: Pos }
+```
+
+Drawback: `path` is overloaded (file path vs. package file arg); `isPackage + packageIdentifier`
+are awkward.
+
+### Option B: Discriminated qualifier union (recommended)
+
+```ts
+type IncludeQualifier =
+  | { kind: 'bare' }
+  | { kind: 'file' }
+  | { kind: 'package'; identifier: string }
+
+{ kind: 'include'; qualifier: IncludeQualifier; path: string; required: boolean; pos: Pos }
+```
+
+`path` becomes: bare/file → file path string; package → the `<file>` argument. The
+`identifier` lives in the qualifier discriminant. This is a **breaking change** to the
+internal AST type but `AstNode` is not part of the public API surface (it is in
+`src/internal/`).
+
+### AST design decision
+
+Option B. Rationale: it makes the qualifier explicit in the type system, avoids boolean
+flag accumulation (`isFile`, `isPackage`, future `isUrl`...), and is correct at the
+type level. Since `AstNode` is internal-only, the refactor scope is bounded to
+`parser.ts`, `structure-builder.ts`, and `include-loader.ts`.
+
+---
+
+## 11. Public API surface changes
+
+### `ParseOptions` (src/parse.ts) — additive, non-breaking
+
+```ts
+export type ParseOptions = {
+  baseDir?: string
+  env?: Record<string, string>
+  readFile?: (filePath: string) => Promise<string>
+  readFileSync?: (filePath: string) => string
+  // NEW — E11:
+  resolveFrom?: string | string[]
+  packageResolver?: (identifier: string, file: string, includingFile: string | undefined) => string
+}
+```
+
+### `PackageResolver` type — whether to export
+
+The `PackageResolver` callback type is used in `ParseOptions`. It SHOULD be exported from
+`src/index.ts` so callers can type their custom resolver without re-declaring the type.
+
+Per the Design Principles self-check (CLAUDE.md): exporting this type is correct because
+it is a public contract — callers who implement `packageResolver` need this type. The name
+`PackageResolver` describes the layer's responsibility (resolving package references),
+not the implementation (`require.resolve`). It will remain meaningful if the default
+mechanism changes.
+
+**Proposed exports addition** (src/index.ts):
+
+```ts
+export type { PackageResolver } from './parse.js'
+// (defined in parse.ts, re-exported from internal/resolver/types.ts or parse.ts directly)
+```
+
+---
+
+## 12. Open questions for ★1
+
+The following items require Yoshi's decision before implementation begins:
+
+1. **`PackageResolver` type name and export location**: export from `src/index.ts` as `PackageResolver`?
+   Or keep it inline in `ParseOptions` without a named type? Named type is better for callers but
+   adds one more public identifier. (Design recommendation: export it.)
+
+2. **AST refactor scope**: the Option B discriminated qualifier union (§10) changes the internal
+   `AstNode` include variant. This is a parser-layer refactor. Yoshi to confirm this is in scope
+   for the same PR as the E11 feature, or whether the AST refactor should be a preparatory PR first.
+
+3. **`resolveFrom` vs `packageResolver` precedence**: if both are provided, `packageResolver`
+   wins (takes full control, `resolveFrom` is ignored). This is the proposed precedence. Confirm.
+
+4. **Yarn Berry PnP stance**: detected PnP paths produce a clear error pointing to `packageResolver`.
+   Is this the right stance, or should ts.hocon attempt to support PnP natively via
+   `import { PnpApi } from 'pnpapi'`? (Recommendation: fail with clear error + docs; PnP
+   support is out of scope for V1.)
+
+5. **Error type**: should `include package` lookup failure throw `ResolveError` (existing) or a
+   new `PackageLookupError extends ResolveError`? A distinct subclass makes it programmatically
+   catchable by library users who want to handle "missing package" differently from other resolve
+   failures. (Recommendation: new subclass; low implementation cost, high caller value.)
+
+---
+
+## 13. Implementation pipeline (informational — NOT yet approved)
+
+When ★1 is approved, the implementation order should be:
+
+1. AST refactor (`AstNode` include qualifier union) — isolated, no behavior change.
+2. Parser: recognize `package(...)` qualifier, emit `{ kind: 'include', qualifier: { kind: 'package', identifier }, path: file }` AST node. Validate two-arg form (reject one-arg).
+3. `IncludeLoader`: add `loadPackage` / `loadPackageAsync` methods. Wire file-arg validation (§8) and cycle detection (§9). Add default resolver (§5).
+4. `StructureBuilder`: route `qualifier.kind === 'package'` to `loadPackage`.
+5. `ParseOptions` / `ResolveOptions`: add `resolveFrom` + `packageResolver`.
+6. Export `PackageResolver` from `src/index.ts`.
+7. Tests: ipk01–ipk14 fixtures per E11 spec.
+
+---
+
+---
+
+## 14. Codex review findings and dispositions
+
+Codex review run 2026-05-21 (`design-review-include-package-ts`). Five issues found and addressed below.
+
+### Issue 1 — Missing identifier non-empty check (must-fix, applied)
+
+**Finding**: The design defined `validatePackageFile` but had no corresponding identifier validation.
+E11 decision 1 says parsers MUST enforce a non-empty identifier (the only shape constraint at the
+parser layer).
+
+**Resolution**: Add `validatePackageIdentifier` alongside `validatePackageFile`:
+
+```ts
+function validatePackageIdentifier(identifier: string): void {
+  if (identifier.length === 0)
+    throw new ParseError('include package: identifier argument must be non-empty', 0, 0)
+}
+```
+
+Both validators run at the start of `loadPackage` before `require.resolve` is called. This ensures
+the error is a parse-phase `ParseError`, not a confusing `MODULE_NOT_FOUND`.
+
+### Issue 2 — Validation placement: resolver layer must throw ParseError (must-fix, clarified)
+
+**Finding**: The design said "resolver layer" and used `ResolveError`, but E11 decision 6 says file-arg
+violations are parse errors. Contradicts the spec's error phase.
+
+**Resolution**: `validatePackageFile` and `validatePackageIdentifier` MUST throw `ParseError`, not
+`ResolveError`. The `IncludeLoader` already imports from `errors.ts`; adding `ParseError` to that
+import is the only change required. The layer boundary is resolver, but the error class is parser.
+This is consistent with how the existing parser throws `ParseError` for structural issues (e.g., bad
+qualifier syntax) while the resolver throws `ResolveError` for semantic issues (e.g., file not found).
+Decision 6 violations are structural (bad qualifier argument shape), so `ParseError` is correct.
+
+Updated error class table:
+
+| Violation | Error class |
+| --- | --- |
+| One-arg form `package("x")` | `ParseError` (parser — bad syntax) |
+| Non-empty identifier check | `ParseError` (resolver entry, but ParseError class) |
+| File arg validation (decision 6) | `ParseError` (resolver entry, but ParseError class) |
+| Lookup failure (decision 4) | `ResolveError` |
+| Cycle detection (decision 8) | `ResolveError` |
+| Bundler/edge runtime no-`require` | `ResolveError` |
+
+### Issue 3 — Case-sensitive equality vs macOS/Windows FS (documented limitation + mitigation)
+
+**Finding**: Node `require.resolve` resolves on the host filesystem, which is case-insensitive
+by default on macOS (HFS+ / APFS case-insensitive) and Windows (NTFS). This means
+`Reference.conf` can satisfy `reference.conf` in practice, violating E11 decision 5 (`ipk07`).
+
+**Resolution**: This is a structural limitation of delegating to `require.resolve` — it cannot
+be fully mitigated without a post-resolution case-comparison step. Design decision:
+
+1. **Post-resolution case check**: after `require.resolve` returns a path, extract the basename
+   and compare it byte-exactly to the `file` argument's last segment.
+
+   ```ts
+   const resolved = require.resolve(...)
+   const resolvedBasename = nodePath.basename(resolved)
+   const expectedBasename = file.split('/').at(-1)!
+   if (resolvedBasename !== expectedBasename) {
+     throw new ResolveError(
+       `include package("${identifier}", "${file}"): case mismatch — resolved "${resolvedBasename}" ` +
+       `but expected "${expectedBasename}" (decision 5: case-sensitive)`,
+       identifier, 0, 0,
+     )
+   }
+   ```
+
+   This catches the most common case (wrong capitalization of the file name). The intermediate
+   directory segments cannot be post-checked from the resolved path without parsing the entire
+   `node_modules` tree — this is an accepted residual limitation.
+
+2. **Documentation**: add a note in `ParseOptions.packageResolver` JSDoc that on macOS/Windows,
+   the default resolver may resolve case-insensitively for intermediate path segments. Callers
+   who need strict cross-platform enforcement should use a `packageResolver` that performs
+   their own case check.
+
+3. **`ipk07` fixture**: the fixture must be run in CI on a case-sensitive filesystem
+   (Linux) to be a meaningful conformance test. Add a comment to the fixture file noting
+   this requirement.
+
+### Issue 4 — NUL cycle-key collision (must-fix, applied)
+
+**Finding**: HOCON strings CAN contain NUL via `" "` — the claim "NUL not valid in HOCON"
+is incorrect. Different `(identifier, file)` pairs containing NUL could produce identical cycle keys.
+
+**Resolution**: Use `JSON.stringify` for the cycle key:
+
+```ts
+const cycleKey = JSON.stringify(['package', identifier, file])
+// e.g. '["package","github.com/o3co/auth","reference.conf"]'
+```
+
+`JSON.stringify` produces an unambiguous, collision-free encoding of the `(identifier, file)`
+pair regardless of embedded NUL, quotes, or other special characters. The resulting key string
+cannot appear as a filesystem path (it starts with `[`), so no collision with file-include
+stack entries.
+
+### Issue 5 — ESM default resolver: concrete wiring plan (must-fix, design updated)
+
+**Finding**: The ESM build (`./dist/index.js`) has no native `require`. Using ambient `typeof
+require` will always be undefined in ESM contexts, making `package(...)` unusable from the ESM
+entry point without a user-supplied `packageResolver`.
+
+**Resolution**: The `defaultPackageResolver` in the distributed code must use `createRequire`:
+
+```ts
+// At module load time (top of the default-resolver module or include-loader):
+import { createRequire } from 'node:module'
+const _require = createRequire(import.meta.url)   // works in both CJS and ESM
+
+function defaultPackageResolver(
+  identifier: string,
+  file: string,
+  includingFile: string | undefined,
+  resolveFrom?: string | string[],
+): string {
+  // _require is always defined here (createRequire works in Node ≥ 12, both CJS + ESM)
+  const from = resolveFrom
+    ? (Array.isArray(resolveFrom) ? resolveFrom : [resolveFrom])
+    : (includingFile ? [nodePath.dirname(includingFile)] : [process.cwd()])
+  try {
+    return _require.resolve(`${identifier}/${file}`, { paths: from })
+  } catch {
+    throw new ResolveError(
+      `include package("${identifier}", "${file}"): module not found ` +
+      `(starting from: ${from.join(', ')})`,
+      identifier, 0, 0,
+    )
+  }
+}
+```
+
+`createRequire(import.meta.url)` is available in Node ≥ 12 (well within the `engines: node >= 22`
+requirement) and works identically in CJS and ESM contexts. This eliminates the ambient-`require`
+detection guard entirely — no `typeof require === 'undefined'` needed. The only remaining runtime
+check is for non-Node environments (edge runtimes, browsers) where `createRequire` itself may not
+be importable; that case is caught at import time, not at call time, and the bundler/edge detection
+heuristic in §Decision 6 is still valid for those cases.
+
+**Revised bundler detection**: since `createRequire` is imported from `node:module`, bundlers that
+tree-shake or stub `node:module` will produce an import error at bundle time (not a silent runtime
+failure). This is actually better behavior than the ambient-`require` guard — it fails loud and
+early at bundle stage rather than silently at runtime.
+
+---
+
+*Document created 2026-05-21 by design-notes agent on branch `feat/include-package-design`.*
+*Codex review applied 2026-05-21 — all 5 issues addressed.*

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -23,6 +23,26 @@ export class ResolveError extends Error {
   }
 }
 
+/**
+ * Thrown when `include package("id", "file")` resolution fails because the
+ * package cannot be located via `require.resolve` or a custom `packageResolver`.
+ * Extends `ResolveError` so callers who catch `ResolveError` still handle it,
+ * while callers who need to distinguish a missing-package error can use:
+ *   `if (err instanceof PackageLookupError) { ... }`
+ */
+export class PackageLookupError extends ResolveError {
+  constructor(
+    message: string,
+    public readonly identifier: string,
+    public readonly packageFile: string,
+    line: number,
+    col: number,
+  ) {
+    super(message, `${identifier}/${packageFile}`, line, col)
+    this.name = 'PackageLookupError'
+  }
+}
+
 export class ConfigError extends Error {
   constructor(
     message: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export type { ByteUnit, DurationUnit } from './coerce.js'
 export { Config } from './config.js'
-export { ConfigError, ParseError, ResolveError } from './errors.js'
+export { ConfigError, PackageLookupError, ParseError, ResolveError } from './errors.js'
 export { parse, parseAsync, parseFile, parseFileAsync } from './parse.js'
 export type { ParseOptions } from './parse.js'
+export type { PackageResolver } from './internal/resolver/types.js'
 export type { HoconValue, ScalarValueType } from './value.js'

--- a/src/internal/parser/ast.ts
+++ b/src/internal/parser/ast.ts
@@ -3,13 +3,24 @@ import type { Segment } from '../lexer/token.js'
 
 export type Pos = { line: number; col: number; file?: string }
 
+/**
+ * Discriminated union of include qualifiers.
+ * - `bare`: `include "path"` — resolves relative to including file's directory
+ * - `file`: `include file("path")` — resolves relative to CWD (or as absolute)
+ * - `package`: `include package("id", "file")` — resolves via Node module resolution
+ */
+export type IncludeQualifier =
+  | { kind: 'bare' }
+  | { kind: 'file' }
+  | { kind: 'package'; identifier: string }
+
 export type AstNode =
   | { kind: 'object'; fields: AstField[]; pos: Pos }
   | { kind: 'array'; items: AstNode[]; pos: Pos }
   | { kind: 'scalar'; raw: string; valueType: ScalarValueType; pos: Pos; _separator?: boolean }
   | { kind: 'concat'; nodes: AstNode[]; pos: Pos }
   | { kind: 'subst'; segments: Segment[]; optional: boolean; listSuffix: boolean; pos: Pos }
-  | { kind: 'include'; path: string; required: boolean; isFile?: boolean; pos: Pos }
+  | { kind: 'include'; qualifier: IncludeQualifier; path: string; required: boolean; pos: Pos }
 
 // key が空配列のとき include ディレクティブを表す（value は include ノード）
 export type AstField = {

--- a/src/internal/parser/parser.ts
+++ b/src/internal/parser/parser.ts
@@ -2,7 +2,7 @@ import { DECIMAL_NUMBER_RE } from '../../coerce.js'
 import { ParseError } from '../../errors.js'
 import type { ScalarValueType } from '../../value.js'
 import type { Token, TokenKind } from '../lexer/token.js'
-import type { AstNode, AstField, Pos } from './ast.js'
+import type { AstNode, AstField, IncludeQualifier, Pos } from './ast.js'
 
 const EOF_TOKEN: Token = { kind: 'eof', value: '', line: 0, col: 0, isQuoted: false, precedingSpace: false, subst: undefined }
 
@@ -215,15 +215,13 @@ class Parser {
     const p = this.currentPos()
     this.skip('newline')
     const t = this.peek()
-    let path: string
-    let required = false
-    let isFile = false
 
+    // ---- required(...) wrapper ----
     if (t.kind === 'unquoted' && (t.value === 'required(' || t.value === 'required' ||
         t.value.startsWith('required('))) {
-      // include required("path") or include required(file("path"))
+      // include required("path") or include required(file("path")) or include required(package("id","file"))
       // The lexer may produce "required(" or "required(file(" as a single unquoted token
-      // depending on whether there is whitespace before "file(".
+      // depending on whether there is whitespace before the inner qualifier.
 
       // Reject bare `required` without a following `(`: e.g. `include required "file.conf"`
       if (t.value === 'required') {
@@ -233,62 +231,139 @@ class Parser {
         }
       }
 
-      required = true
       this.advance()
 
-      // Check for unsupported url/classpath forms inside required():
-      // Case 1 (no space): lexer produced a single token like "required(url(" or "required(classpath("
+      // innerPrefix is the content after "required(" when the lexer bundles them
       const innerPrefix = t.value.startsWith('required(') ? t.value.slice('required('.length) : ''
       if (innerPrefix.startsWith('url') || innerPrefix.startsWith('classpath')) {
         throw new ParseError('include url(...) and classpath(...) are not supported', t.line, t.col)
       }
-      // Detect file() inside required(): "required(file(" as single token or "file(" as next token
-      if (innerPrefix.startsWith('file')) {
-        isFile = true
-      }
-      // Case 2 (with space): next token starts with url/classpath/file
-      const next = this.peek()
-      if (next.kind === 'unquoted' && (next.value === 'url' || next.value.startsWith('url(') ||
-          next.value === 'classpath' || next.value.startsWith('classpath('))) {
-        throw new ParseError('include url(...) and classpath(...) are not supported', next.line, next.col)
-      }
-      if (next.kind === 'unquoted' && (next.value === 'file(' || next.value === 'file' || next.value.startsWith('file('))) {
-        isFile = true
+
+      const nextTok = this.peek()
+
+      if (innerPrefix.startsWith('package') ||
+          (nextTok.kind === 'unquoted' && (nextTok.value === 'package(' || nextTok.value.startsWith('package(')))) {
+        // required(package("id", "file"))
+        // When innerPrefix already contains "package(", the lexer bundled it into the
+        // required( token — so the current position is already at the first string arg.
+        // When it's a separate token, consumePackageToken=true advances past it first.
+        const consumePackageToken = !innerPrefix.startsWith('package')
+        const { qualifier, path } = this.parsePackageArgs(consumePackageToken)
+        return this.makeIncludeField(qualifier, path, true, p)
       }
 
-      // Skip tokens until we find the quoted path string
-      while (this.peek().kind !== 'string' && this.peek().kind !== 'eof') this.advance()
-      if (this.peek().kind === 'eof') throw new ParseError('expected include path', t.line, t.col)
-      path = this.advance().value
-      // Skip closing ) and anything else on this line (but stop at comma — next field)
-      while (this.peek().kind !== 'newline' && this.peek().kind !== 'rbrace' && this.peek().kind !== 'eof' && this.peek().kind !== 'comma') this.advance()
-    } else if (t.kind === 'string') {
-      // include "path"
-      path = this.advance().value
-    } else if (t.kind === 'unquoted' && (t.value === 'file(' || t.value === 'file')) {
-      // include file("path")
-      isFile = true
+      if (innerPrefix.startsWith('file') ||
+          (nextTok.kind === 'unquoted' && (nextTok.value === 'file(' || nextTok.value === 'file' || nextTok.value.startsWith('file(')))) {
+        // required(file("path"))
+        const path = this.parseQuotedPathSkipWrapper(t)
+        return this.makeIncludeField({ kind: 'file' }, path, true, p)
+      }
+
+      if (nextTok.kind === 'unquoted' && (nextTok.value === 'url' || nextTok.value.startsWith('url(') ||
+          nextTok.value === 'classpath' || nextTok.value.startsWith('classpath('))) {
+        throw new ParseError('include url(...) and classpath(...) are not supported', nextTok.line, nextTok.col)
+      }
+
+      // required("path") — bare with wrapper
+      const path = this.parseQuotedPathSkipWrapper(t)
+      return this.makeIncludeField({ kind: 'bare' }, path, true, p)
+    }
+
+    // ---- bare include "path" ----
+    if (t.kind === 'string') {
+      const path = this.advance().value
+      return this.makeIncludeField({ kind: 'bare' }, path, false, p)
+    }
+
+    // ---- file(...) qualifier ----
+    if (t.kind === 'unquoted' && (t.value === 'file(' || t.value === 'file')) {
       this.advance()
-      // Skip tokens until we find the quoted path string
-      while (this.peek().kind !== 'string' && this.peek().kind !== 'eof') this.advance()
-      if (this.peek().kind === 'eof') throw new ParseError('expected include path', t.line, t.col)
-      path = this.advance().value
-      // Skip closing ) and anything else on this line (but stop at comma — next field)
-      while (this.peek().kind !== 'newline' && this.peek().kind !== 'rbrace' && this.peek().kind !== 'eof' && this.peek().kind !== 'comma') this.advance()
-    } else if (t.kind === 'unquoted' && (t.value === 'url' || t.value.startsWith('url('))) {
-      throw new ParseError('include url(...) is not supported', t.line, t.col)
-    } else if (t.kind === 'unquoted' && (t.value === 'classpath' || t.value.startsWith('classpath('))) {
-      throw new ParseError('include classpath(...) is not supported', t.line, t.col)
-    } else {
-      throw new ParseError(`expected include path, got ${t.kind}`, t.line, t.col)
+      const path = this.parseQuotedPathSkipWrapper(t)
+      return this.makeIncludeField({ kind: 'file' }, path, false, p)
     }
 
-    return {
-      key: [],
-      value: { kind: 'include', path, required, ...(isFile ? { isFile: true } : {}), pos: p },
-      append: false,
-      pos: p,
+    // ---- package(...) qualifier ----
+    if (t.kind === 'unquoted' && (t.value === 'package(' || t.value.startsWith('package('))) {
+      const { qualifier, path } = this.parsePackageArgs()
+      return this.makeIncludeField(qualifier, path, false, p)
     }
+
+    if (t.kind === 'unquoted' && (t.value === 'url' || t.value.startsWith('url('))) {
+      throw new ParseError('include url(...) is not supported', t.line, t.col)
+    }
+    if (t.kind === 'unquoted' && (t.value === 'classpath' || t.value.startsWith('classpath('))) {
+      throw new ParseError('include classpath(...) is not supported', t.line, t.col)
+    }
+    throw new ParseError(`expected include path, got ${t.kind}`, t.line, t.col)
+  }
+
+  private makeIncludeField(qualifier: IncludeQualifier, path: string, required: boolean, pos: ReturnType<typeof this.currentPos>): AstField {
+    return { key: [], value: { kind: 'include', qualifier, path, required, pos }, append: false, pos }
+  }
+
+  /**
+   * Skip past any wrapper tokens (qualifier name, open paren) to find the first quoted
+   * string, consume it, then skip trailing tokens to end-of-statement. Returns the string value.
+   */
+  private parseQuotedPathSkipWrapper(errTok: Token): string {
+    while (this.peek().kind !== 'string' && this.peek().kind !== 'eof') this.advance()
+    if (this.peek().kind === 'eof') throw new ParseError('expected include path', errTok.line, errTok.col)
+    const path = this.advance().value
+    while (this.peek().kind !== 'newline' && this.peek().kind !== 'rbrace' && this.peek().kind !== 'eof' && this.peek().kind !== 'comma') this.advance()
+    return path
+  }
+
+  /**
+   * Parse the body of `package("identifier", "file")`.
+   *
+   * @param consumePackageToken - When true (default), the current token is `package(` and
+   *   must be consumed first. When false, the lexer already bundled `package(` into the
+   *   preceding token (e.g. `required(package("`), so we are already positioned at the
+   *   first string argument.
+   */
+  private parsePackageArgs(consumePackageToken = true): { qualifier: IncludeQualifier & { kind: 'package' }; path: string } {
+    const pkgTok = consumePackageToken ? this.advance() : this.peek()
+    this.skip('newline')
+
+    // First argument: quoted identifier
+    const idTok = this.peek()
+    if (idTok.kind !== 'string') {
+      throw new ParseError('include package: expected quoted identifier as first argument', pkgTok.line, pkgTok.col)
+    }
+    const identifier = this.advance().value
+
+    // Separator: comma between args
+    this.skip('newline')
+    if (this.peek().kind === 'comma') {
+      this.advance()
+    } else {
+      // No comma — check if we're at closing paren or EOF (one-arg form)
+      const after = this.peek()
+      if (after.kind !== 'string') {
+        throw new ParseError(
+          'include package: requires exactly two arguments (identifier, file) — one-arg form is not supported',
+          pkgTok.line, pkgTok.col,
+        )
+      }
+    }
+    this.skip('newline')
+
+    // Second argument: quoted file path
+    const fileTok = this.peek()
+    if (fileTok.kind !== 'string') {
+      throw new ParseError(
+        'include package: requires exactly two arguments (identifier, file) — one-arg form is not supported',
+        pkgTok.line, pkgTok.col,
+      )
+    }
+    const filePath = this.advance().value
+
+    // Skip closing ) and anything else to end-of-statement
+    while (this.peek().kind !== 'newline' && this.peek().kind !== 'rbrace' && this.peek().kind !== 'eof' && this.peek().kind !== 'comma') {
+      this.advance()
+    }
+
+    return { qualifier: { kind: 'package', identifier }, path: filePath }
   }
 
   private parseValue(): AstNode {
@@ -338,7 +413,10 @@ class Parser {
     }
 
     if (parts.length === 0) throw new ParseError('expected value', this.peek().line, this.peek().col)
-    if (parts.length === 1) return parts[0]!
+    if (parts.length === 1) {
+      // length === 1 guarantees parts[0] exists; the array access is safe
+      return parts[0] as AstNode
+    }
     return { kind: 'concat', nodes: parts, pos: p }
   }
 

--- a/src/internal/parser/parser.ts
+++ b/src/internal/parser/parser.ts
@@ -332,20 +332,18 @@ class Parser {
     }
     const identifier = this.advance().value
 
-    // Separator: comma between args
+    // Separator: comma between args is REQUIRED
     this.skip('newline')
-    if (this.peek().kind === 'comma') {
-      this.advance()
-    } else {
-      // No comma — check if we're at closing paren or EOF (one-arg form)
+    if (this.peek().kind !== 'comma') {
       const after = this.peek()
-      if (after.kind !== 'string') {
-        throw new ParseError(
-          'include package: requires exactly two arguments (identifier, file) — one-arg form is not supported',
-          pkgTok.line, pkgTok.col,
-        )
-      }
+      throw new ParseError(
+        after.kind === 'string'
+          ? 'include package: missing comma between identifier and file arguments'
+          : 'include package: requires exactly two arguments (identifier, file) — one-arg form is not supported',
+        pkgTok.line, pkgTok.col,
+      )
     }
+    this.advance() // consume comma
     this.skip('newline')
 
     // Second argument: quoted file path

--- a/src/internal/resolver/include-loader.ts
+++ b/src/internal/resolver/include-loader.ts
@@ -1,11 +1,13 @@
+import { createRequire } from 'node:module'
 import * as nodePath from 'node:path'
-import { ResolveError } from '../../errors.js'
+import { PackageLookupError, ParseError, ResolveError } from '../../errors.js'
+import { assertNonEmptyDocument } from '../parser/empty-check.js'
 import type { AstNode } from '../parser/ast.js'
 import { tokenize } from '../lexer/lexer.js'
 import { parseTokens } from '../parser/parser.js'
-import { assertNonEmptyDocument } from '../parser/empty-check.js'
 import { propertiesToHoconValue } from '../properties/properties.js'
 import {
+  type PackageResolver,
   type ResObj,
   type ResolveOptions,
   makeResObj,
@@ -15,6 +17,121 @@ import {
   hoconValueToResObj,
   isFileNotFoundError,
 } from './utils.js'
+
+// createRequire works in both CJS and ESM Node contexts (Node ≥ 12).
+// Using import.meta.url makes this module's directory the resolution anchor,
+// which is overridden per-call via the `paths` option.
+const _require = createRequire(import.meta.url)
+
+/**
+ * Detect Yarn Berry PnP store paths. PnP resolves to ZIP-internal paths that
+ * cannot be read by fs.readFileSync after resolution.
+ */
+function isPnpPath(p: string): boolean {
+  return p.includes('.yarn/cache') || p.includes('.pnp.cjs') || p.includes('.pnp.loader')
+}
+
+/**
+ * Validate the file argument of `package("id", "file")` per E11 decision 6.
+ * Runs on the post-HOCON-unescape string value.
+ * Throws `ParseError` on violation (structural constraint, not a resolution failure).
+ */
+function validatePackageFile(file: string, identifier: string): void {
+  if (file.length === 0) {
+    throw new ParseError(`include package("${identifier}", ...): file argument must be non-empty`, 0, 0)
+  }
+  if (file.includes('\\')) {
+    throw new ParseError(
+      `include package("${identifier}", "${file}"): backslash not allowed in file argument (use forward slash)`,
+      0, 0,
+    )
+  }
+  if (file.startsWith('/')) {
+    throw new ParseError(
+      `include package("${identifier}", "${file}"): absolute path not allowed in file argument`,
+      0, 0,
+    )
+  }
+  if (/(?:^|\/)\.\.?(?:\/|$)/u.test(file)) {
+    throw new ParseError(
+      `include package("${identifier}", "${file}"): path traversal (. or ..) not allowed in file argument`,
+      0, 0,
+    )
+  }
+  if (file.includes('//')) {
+    throw new ParseError(
+      `include package("${identifier}", "${file}"): consecutive slashes not allowed in file argument`,
+      0, 0,
+    )
+  }
+}
+
+/**
+ * Validate the identifier argument of `package("id", "file")` per E11 decision 1.
+ * Throws `ParseError` on violation.
+ */
+function validatePackageIdentifier(identifier: string): void {
+  if (identifier.length === 0) {
+    throw new ParseError('include package: identifier argument must be non-empty', 0, 0)
+  }
+}
+
+/**
+ * Default package resolver using Node's `require.resolve` via `createRequire`.
+ * Works in both CJS and ESM contexts. Throws `PackageLookupError` on miss.
+ */
+function defaultPackageResolver(
+  identifier: string,
+  file: string,
+  includingFile: string | undefined,
+  resolveFrom: string | string[] | undefined,
+): string {
+  const from = resolveFrom
+    ? (Array.isArray(resolveFrom) ? resolveFrom : [resolveFrom])
+    : (includingFile ? [nodePath.dirname(includingFile)] : [process.cwd()])
+
+  let resolved: string
+  try {
+    resolved = _require.resolve(`${identifier}/${file}`, { paths: from })
+  } catch {
+    throw new PackageLookupError(
+      `include package("${identifier}", "${file}"): module not found (starting from: ${from.join(', ')})`,
+      identifier,
+      file,
+      0,
+      0,
+    )
+  }
+
+  if (isPnpPath(resolved)) {
+    throw new ResolveError(
+      `include package("${identifier}", "${file}"): Yarn Berry PnP store paths are not supported. ` +
+      `Provide a custom packageResolver option to handle PnP resolution.`,
+      `${identifier}/${file}`,
+      0,
+      0,
+    )
+  }
+
+  // E11 decision 5: case-sensitive file basename check.
+  // On macOS/Windows (case-insensitive FS), require.resolve may return a path
+  // with different capitalisation. Check the resolved basename matches exactly.
+  const fileParts = file.split('/')
+  const expectedBasename = fileParts[fileParts.length - 1] ?? file
+  const resolvedBasename = nodePath.basename(resolved)
+  if (resolvedBasename !== expectedBasename) {
+    throw new PackageLookupError(
+      `include package("${identifier}", "${file}"): case mismatch — resolved "${resolvedBasename}" ` +
+      `but expected "${expectedBasename}" (E11 decision 5: case-sensitive)`,
+      identifier,
+      file,
+      0,
+      0,
+    )
+  }
+
+  return resolved
+}
 
 export class IncludeLoader {
   private opts: ResolveOptions
@@ -121,6 +238,96 @@ export class IncludeLoader {
       throw new ResolveError(`required include file not found: ${includePath}`, includePath, 0, 0)
     }
     return merged
+  }
+
+  /**
+   * Resolve and load `include package("identifier", "file")`.
+   * Validates the identifier and file arguments, resolves via the package resolver,
+   * performs cycle detection using a JSON-serialised cycle key, and parses the content.
+   */
+  // `required` is reserved for future optional-package semantics (E11 decision 7);
+  // currently all package lookup failures throw regardless of this flag.
+  loadPackage(identifier: string, file: string, _required: boolean): ResObj {
+    validatePackageIdentifier(identifier)
+    validatePackageFile(file, identifier)
+
+    const { includeStack = [], baseDir, resolveFrom, packageResolver, readFileSync } = this.opts
+    const cycleKey = JSON.stringify(['package', identifier, file])
+
+    if (includeStack.includes(cycleKey)) {
+      throw new ResolveError(
+        `circular include: package("${identifier}", "${file}")`,
+        `${identifier}/${file}`,
+        0, 0,
+      )
+    }
+    if (includeStack.length >= 50) {
+      throw new ResolveError(`include depth limit exceeded (max 50)`, `${identifier}/${file}`, 0, 0)
+    }
+
+    const resolver: PackageResolver = packageResolver ??
+      ((id, f, includingFile) => defaultPackageResolver(id, f, includingFile, resolveFrom))
+
+    const includingFile = baseDir ? nodePath.join(baseDir, '_placeholder') : undefined
+    const resolvedPath = resolver(identifier, file, includingFile)
+
+    const content = readFileSync(resolvedPath)
+    // Empty content is valid for package includes (ipk08): contributes {} to merge
+    if (content.trim().length === 0) return makeResObj()
+
+    const tokens = tokenize(content)
+    assertNonEmptyDocument(tokens, resolvedPath)
+    const ast = parseTokens(tokens)
+    return this.onBuildResObj(ast, {
+      ...this.opts,
+      baseDir: nodePath.dirname(resolvedPath),
+      includeStack: [...includeStack, cycleKey],
+    })
+  }
+
+  /**
+   * Async variant of `loadPackage`.
+   */
+  async loadPackageAsync(identifier: string, file: string, _required: boolean): Promise<ResObj> {
+    validatePackageIdentifier(identifier)
+    validatePackageFile(file, identifier)
+
+    const { includeStack = [], baseDir, resolveFrom, packageResolver, readFile, readFileSync } = this.opts
+    const cycleKey = JSON.stringify(['package', identifier, file])
+
+    if (includeStack.includes(cycleKey)) {
+      throw new ResolveError(
+        `circular include: package("${identifier}", "${file}")`,
+        `${identifier}/${file}`,
+        0, 0,
+      )
+    }
+    if (includeStack.length >= 50) {
+      throw new ResolveError(`include depth limit exceeded (max 50)`, `${identifier}/${file}`, 0, 0)
+    }
+
+    const resolver: PackageResolver = packageResolver ??
+      ((id, f, includingFile) => defaultPackageResolver(id, f, includingFile, resolveFrom))
+
+    const includingFile = baseDir ? nodePath.join(baseDir, '_placeholder') : undefined
+    const resolvedPath = resolver(identifier, file, includingFile)
+
+    const read = readFile
+      ? async (p: string) => readFile(p)
+      : async (p: string) => readFileSync(p)
+
+    const content = await read(resolvedPath)
+    // Empty content is valid for package includes (ipk08): contributes {} to merge
+    if (content.trim().length === 0) return makeResObj()
+
+    const tokens = tokenize(content)
+    assertNonEmptyDocument(tokens, resolvedPath)
+    const ast = parseTokens(tokens)
+    return this.onBuildResObjAsync(ast, {
+      ...this.opts,
+      baseDir: nodePath.dirname(resolvedPath),
+      includeStack: [...includeStack, cycleKey],
+    })
   }
 
   private loadSingle(candidate: string): ResObj | undefined {

--- a/src/internal/resolver/include-loader.ts
+++ b/src/internal/resolver/include-loader.ts
@@ -305,7 +305,7 @@ export class IncludeLoader {
     validatePackageIdentifier(identifier)
     validatePackageFile(file, identifier)
 
-    const { includeStack = [], resolveFrom, packageResolver, readFile, readFileSync } = this.opts
+    const { includeStack = [], baseDir, resolveFrom, packageResolver, readFile, readFileSync } = this.opts
     const cycleKey = JSON.stringify(['package', identifier, file])
 
     if (includeStack.includes(cycleKey)) {

--- a/src/internal/resolver/include-loader.ts
+++ b/src/internal/resolver/include-loader.ts
@@ -251,7 +251,7 @@ export class IncludeLoader {
     validatePackageIdentifier(identifier)
     validatePackageFile(file, identifier)
 
-    const { includeStack = [], baseDir, resolveFrom, packageResolver, readFileSync } = this.opts
+    const { includeStack = [], resolveFrom, packageResolver, readFileSync } = this.opts
     const cycleKey = JSON.stringify(['package', identifier, file])
 
     if (includeStack.includes(cycleKey)) {
@@ -268,12 +268,16 @@ export class IncludeLoader {
     const resolver: PackageResolver = packageResolver ??
       ((id, f, includingFile) => defaultPackageResolver(id, f, includingFile, resolveFrom))
 
-    const includingFile = baseDir ? nodePath.join(baseDir, '_placeholder') : undefined
-    const resolvedPath = resolver(identifier, file, includingFile)
+    // No reliable parent-file path is threaded into the loader; pass undefined.
+    // The default resolver falls back to `resolveFrom` / process.cwd() in this case.
+    // Custom resolvers MUST handle includingFile === undefined gracefully.
+    const resolvedPath = resolver(identifier, file, undefined)
 
     const content = readFileSync(resolvedPath)
-    // Empty content is valid for package includes (ipk08): contributes {} to merge
-    if (content.trim().length === 0) return makeResObj()
+    // Empty content (zero bytes) is valid for package includes (ipk08); contributes {}.
+    // Whitespace-only content is NOT zero-bytes — it falls through to S3.1/E10 enforcement
+    // via assertNonEmptyDocument below.
+    if (content.length === 0) return makeResObj()
 
     const tokens = tokenize(content)
     assertNonEmptyDocument(tokens, resolvedPath)
@@ -292,7 +296,7 @@ export class IncludeLoader {
     validatePackageIdentifier(identifier)
     validatePackageFile(file, identifier)
 
-    const { includeStack = [], baseDir, resolveFrom, packageResolver, readFile, readFileSync } = this.opts
+    const { includeStack = [], resolveFrom, packageResolver, readFile, readFileSync } = this.opts
     const cycleKey = JSON.stringify(['package', identifier, file])
 
     if (includeStack.includes(cycleKey)) {
@@ -309,16 +313,19 @@ export class IncludeLoader {
     const resolver: PackageResolver = packageResolver ??
       ((id, f, includingFile) => defaultPackageResolver(id, f, includingFile, resolveFrom))
 
-    const includingFile = baseDir ? nodePath.join(baseDir, '_placeholder') : undefined
-    const resolvedPath = resolver(identifier, file, includingFile)
+    // No reliable parent-file path is threaded into the loader; pass undefined.
+    // The default resolver falls back to `resolveFrom` / process.cwd() in this case.
+    // Custom resolvers MUST handle includingFile === undefined gracefully.
+    const resolvedPath = resolver(identifier, file, undefined)
 
     const read = readFile
       ? async (p: string) => readFile(p)
       : async (p: string) => readFileSync(p)
 
     const content = await read(resolvedPath)
-    // Empty content is valid for package includes (ipk08): contributes {} to merge
-    if (content.trim().length === 0) return makeResObj()
+    // Empty content (zero bytes) is valid for package includes (ipk08); contributes {}.
+    // Whitespace-only content falls through to S3.1/E10 enforcement via assertNonEmptyDocument.
+    if (content.length === 0) return makeResObj()
 
     const tokens = tokenize(content)
     assertNonEmptyDocument(tokens, resolvedPath)
@@ -331,7 +338,7 @@ export class IncludeLoader {
   }
 
   private loadSingle(candidate: string): ResObj | undefined {
-    const { readFileSync, includeStack = [], env } = this.opts
+    const { readFileSync, includeStack = [] } = this.opts
 
     if (includeStack.includes(candidate)) {
       throw new ResolveError(`circular include: ${candidate}`, candidate, 0, 0)
@@ -353,16 +360,16 @@ export class IncludeLoader {
     // S3.1 — HOCON.md L130: empty included files are invalid documents.
     assertNonEmptyDocument(tokens, candidate)
     const ast = parseTokens(tokens)
+    // Spread all opts to preserve packageResolver / resolveFrom / readFile across nested includes.
     return this.onBuildResObj(ast, {
-      env,
+      ...this.opts,
       baseDir: nodePath.dirname(candidate),
-      readFileSync,
       includeStack: [...includeStack, candidate],
     })
   }
 
   private async loadSingleAsync(candidate: string): Promise<ResObj | undefined> {
-    const { readFile, readFileSync, includeStack = [], env } = this.opts
+    const { readFile, readFileSync, includeStack = [] } = this.opts
     const read = readFile
       ? async (p: string) => readFile(p)
       : async (p: string) => readFileSync(p)
@@ -387,11 +394,10 @@ export class IncludeLoader {
     // S3.1 — HOCON.md L130: empty included files are invalid documents.
     assertNonEmptyDocument(tokens, candidate)
     const ast = parseTokens(tokens)
+    // Spread all opts to preserve packageResolver / resolveFrom across nested includes.
     return this.onBuildResObjAsync(ast, {
-      env,
+      ...this.opts,
       baseDir: nodePath.dirname(candidate),
-      readFileSync,
-      readFile,
       includeStack: [...includeStack, candidate],
     })
   }

--- a/src/internal/resolver/include-loader.ts
+++ b/src/internal/resolver/include-loader.ts
@@ -84,11 +84,18 @@ function defaultPackageResolver(
   identifier: string,
   file: string,
   includingFile: string | undefined,
+  baseDir: string | undefined,
   resolveFrom: string | string[] | undefined,
 ): string {
+  // Priority: explicit resolveFrom > baseDir (active parse context) >
+  // path.dirname(includingFile) (when threaded) > process.cwd() (last resort).
+  // Without this baseDir step, package resolution from within a nested file
+  // include falls back to cwd, breaking resolution for typical project layouts.
   const from = resolveFrom
     ? (Array.isArray(resolveFrom) ? resolveFrom : [resolveFrom])
-    : (includingFile ? [nodePath.dirname(includingFile)] : [process.cwd()])
+    : baseDir
+      ? [baseDir]
+      : (includingFile ? [nodePath.dirname(includingFile)] : [process.cwd()])
 
   let resolved: string
   try {
@@ -251,7 +258,7 @@ export class IncludeLoader {
     validatePackageIdentifier(identifier)
     validatePackageFile(file, identifier)
 
-    const { includeStack = [], resolveFrom, packageResolver, readFileSync } = this.opts
+    const { includeStack = [], baseDir, resolveFrom, packageResolver, readFileSync } = this.opts
     const cycleKey = JSON.stringify(['package', identifier, file])
 
     if (includeStack.includes(cycleKey)) {
@@ -266,12 +273,14 @@ export class IncludeLoader {
     }
 
     const resolver: PackageResolver = packageResolver ??
-      ((id, f, includingFile) => defaultPackageResolver(id, f, includingFile, resolveFrom))
+      ((id, f, includingFile, bDir) => defaultPackageResolver(id, f, includingFile, bDir, resolveFrom))
 
-    // No reliable parent-file path is threaded into the loader; pass undefined.
-    // The default resolver falls back to `resolveFrom` / process.cwd() in this case.
-    // Custom resolvers MUST handle includingFile === undefined gracefully.
-    const resolvedPath = resolver(identifier, file, undefined)
+    // The parent .conf's absolute path is not currently threaded through the loader,
+    // so `includingFile` is undefined. `baseDir` IS available from the parse context
+    // (set by the file-include loader via spread `...this.opts`) and gives the default
+    // resolver the right starting directory for `require.resolve`'s `paths`.
+    // Custom resolvers MUST handle both arguments being undefined gracefully.
+    const resolvedPath = resolver(identifier, file, undefined, baseDir)
 
     const content = readFileSync(resolvedPath)
     // Empty content (zero bytes) is valid for package includes (ipk08); contributes {}.
@@ -311,12 +320,14 @@ export class IncludeLoader {
     }
 
     const resolver: PackageResolver = packageResolver ??
-      ((id, f, includingFile) => defaultPackageResolver(id, f, includingFile, resolveFrom))
+      ((id, f, includingFile, bDir) => defaultPackageResolver(id, f, includingFile, bDir, resolveFrom))
 
-    // No reliable parent-file path is threaded into the loader; pass undefined.
-    // The default resolver falls back to `resolveFrom` / process.cwd() in this case.
-    // Custom resolvers MUST handle includingFile === undefined gracefully.
-    const resolvedPath = resolver(identifier, file, undefined)
+    // The parent .conf's absolute path is not currently threaded through the loader,
+    // so `includingFile` is undefined. `baseDir` IS available from the parse context
+    // (set by the file-include loader via spread `...this.opts`) and gives the default
+    // resolver the right starting directory for `require.resolve`'s `paths`.
+    // Custom resolvers MUST handle both arguments being undefined gracefully.
+    const resolvedPath = resolver(identifier, file, undefined, baseDir)
 
     const read = readFile
       ? async (p: string) => readFile(p)

--- a/src/internal/resolver/structure-builder.ts
+++ b/src/internal/resolver/structure-builder.ts
@@ -22,11 +22,9 @@ import { IncludeLoader } from './include-loader.js'
  * Encapsulates structure building, include loading, and substitution-path relativization.
  */
 export class StructureBuilder {
-  private opts: ResolveOptions
   private loader: IncludeLoader
 
   constructor(opts: ResolveOptions) {
-    this.opts = opts
     this.loader = new IncludeLoader(opts)
     this.loader.onBuildResObj = (a, o) => new StructureBuilder(o).build(a)
     this.loader.onBuildResObjAsync = async (a, o) => new StructureBuilder(o).buildAsync(a)
@@ -59,7 +57,13 @@ export class StructureBuilder {
     if (field.key.length === 0 && field.value.kind === 'include') {
       // Included files are parsed at their own root (pathPrefix=[]),
       // then relativized to the current scope's prefix.
-      const included = this.loader.load(field.value.path, field.value.required, field.value.isFile)
+      const { qualifier, path, required } = field.value
+      let included: ResObj
+      if (qualifier.kind === 'package') {
+        included = this.loader.loadPackage(qualifier.identifier, path, required)
+      } else {
+        included = this.loader.load(path, required, qualifier.kind === 'file')
+      }
       if (pathPrefix.length > 0) {
         this.relativizeResObj(included, pathPrefix)
       }
@@ -116,7 +120,13 @@ export class StructureBuilder {
 
   private async applyFieldAsync(obj: ResObj, field: AstField, pathPrefix: string[]): Promise<void> {
     if (field.key.length === 0 && field.value.kind === 'include') {
-      const included = await this.loader.loadAsync(field.value.path, field.value.required, field.value.isFile)
+      const { qualifier, path, required } = field.value
+      let included: ResObj
+      if (qualifier.kind === 'package') {
+        included = await this.loader.loadPackageAsync(qualifier.identifier, path, required)
+      } else {
+        included = await this.loader.loadAsync(path, required, qualifier.kind === 'file')
+      }
       if (pathPrefix.length > 0) {
         this.relativizeResObj(included, pathPrefix)
       }

--- a/src/internal/resolver/types.ts
+++ b/src/internal/resolver/types.ts
@@ -34,16 +34,29 @@ export type ResolverValue = HoconValue | SubstPlaceholder | ConcatPlaceholder | 
 
 /**
  * Custom resolver for `include package("id", "file")`.
- * Receives the identifier, the file argument, and (if known) the absolute path
- * of the including `.conf` file. Must return an absolute path or throw.
+ *
+ * Receives:
+ * - `identifier`, `file`: the qualifier arguments (post HOCON unescape, byte-exact)
+ * - `includingFile`: absolute path of the including `.conf` file when known
+ *   (currently always `undefined`; reserved for future threading from a future
+ *   `parseFile` integration)
+ * - `baseDir`: the directory context active when the include is resolved
+ *   (typically `path.dirname(includingFile)` of the parent, or the caller-set
+ *   `baseDir` parse option). Set when known, `undefined` for parses of literal
+ *   input strings without a directory context.
+ *
+ * Must return an absolute path or throw.
  *
  * When not provided, the default resolver uses `createRequire(import.meta.url)`
- * which works in both CJS and ESM Node contexts.
+ * which works in both CJS and ESM Node contexts. The default resolver picks the
+ * lookup starting paths in priority order:
+ *   `resolveFrom` > `baseDir` > `path.dirname(includingFile)` > `process.cwd()`
  */
 export type PackageResolver = (
   identifier: string,
   file: string,
   includingFile: string | undefined,
+  baseDir: string | undefined,
 ) => string
 
 export type ResolveOptions = {

--- a/src/internal/resolver/types.ts
+++ b/src/internal/resolver/types.ts
@@ -32,12 +32,30 @@ export type ResObj = {
 
 export type ResolverValue = HoconValue | SubstPlaceholder | ConcatPlaceholder | AppendPlaceholder | ResObj
 
+/**
+ * Custom resolver for `include package("id", "file")`.
+ * Receives the identifier, the file argument, and (if known) the absolute path
+ * of the including `.conf` file. Must return an absolute path or throw.
+ *
+ * When not provided, the default resolver uses `createRequire(import.meta.url)`
+ * which works in both CJS and ESM Node contexts.
+ */
+export type PackageResolver = (
+  identifier: string,
+  file: string,
+  includingFile: string | undefined,
+) => string
+
 export type ResolveOptions = {
   env: Record<string, string>
   baseDir: string | undefined
   readFileSync: (filePath: string) => string
   readFile?: (filePath: string) => Promise<string>
   includeStack?: string[]
+  /** Override the starting directory for `require.resolve` used by the default package resolver. */
+  resolveFrom?: string | string[]
+  /** Custom resolver for `include package(...)`. When provided, takes full control; `resolveFrom` is ignored. */
+  packageResolver?: PackageResolver
 }
 
 // Track parser-inserted separator whitespace values without leaking _separator

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -6,6 +6,7 @@ import { tokenize } from './internal/lexer/lexer.js'
 import { parseTokens } from './internal/parser/parser.js'
 import { resolve, resolveAsync } from './internal/resolver/resolver.js'
 import type { ResolveOptions } from './internal/resolver/resolver.js'
+import type { PackageResolver } from './internal/resolver/types.js'
 
 export type ParseOptions = {
   baseDir?: string
@@ -22,8 +23,8 @@ export type ParseOptions = {
   resolveFrom?: string | string[]
   /**
    * Custom resolver for `include package("id", "file")`.
-   * Receives the identifier, file argument, and (if known) the absolute path of the
-   * including `.conf` file. Must return an absolute path or throw.
+   * See {@link PackageResolver} for the full callback signature and contract
+   * (parameters, lookup-starting-path priority, error semantics).
    *
    * When provided, takes full control of resolution; `resolveFrom` is ignored.
    * Use this for Yarn Berry PnP, bundler contexts, edge runtimes, or test isolation.
@@ -32,7 +33,7 @@ export type ParseOptions = {
    * resolve case-insensitively for intermediate path segments. Use a custom
    * `packageResolver` for strict cross-platform enforcement.
    */
-  packageResolver?: (identifier: string, file: string, includingFile: string | undefined) => string
+  packageResolver?: PackageResolver
 }
 
 function getEnv(opts: ParseOptions): Record<string, string> {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,17 +1,38 @@
-import { tokenize } from './internal/lexer/lexer.js'
-import { parseTokens } from './internal/parser/parser.js'
-import { assertNonEmptyDocument } from './internal/parser/empty-check.js'
-import { resolve, resolveAsync } from './internal/resolver/resolver.js'
-import { Config } from './config.js'
-import type { ResolveOptions } from './internal/resolver/resolver.js'
 import * as fs from 'node:fs'
 import * as path from 'node:path'
+import { Config } from './config.js'
+import { assertNonEmptyDocument } from './internal/parser/empty-check.js'
+import { tokenize } from './internal/lexer/lexer.js'
+import { parseTokens } from './internal/parser/parser.js'
+import { resolve, resolveAsync } from './internal/resolver/resolver.js'
+import type { ResolveOptions } from './internal/resolver/resolver.js'
 
 export type ParseOptions = {
   baseDir?: string
   env?: Record<string, string>
   readFile?: (filePath: string) => Promise<string>
   readFileSync?: (filePath: string) => string
+  /**
+   * Override the starting directory (or directories) used when resolving
+   * `include package("id", "file")` via Node module resolution.
+   *
+   * Default: `path.dirname(includingConfFile)` when known, `process.cwd()` otherwise.
+   * Ignored when `packageResolver` is also provided.
+   */
+  resolveFrom?: string | string[]
+  /**
+   * Custom resolver for `include package("id", "file")`.
+   * Receives the identifier, file argument, and (if known) the absolute path of the
+   * including `.conf` file. Must return an absolute path or throw.
+   *
+   * When provided, takes full control of resolution; `resolveFrom` is ignored.
+   * Use this for Yarn Berry PnP, bundler contexts, edge runtimes, or test isolation.
+   *
+   * Note: on macOS/Windows (case-insensitive filesystems), the default resolver may
+   * resolve case-insensitively for intermediate path segments. Use a custom
+   * `packageResolver` for strict cross-platform enforcement.
+   */
+  packageResolver?: (identifier: string, file: string, includingFile: string | undefined) => string
 }
 
 function getEnv(opts: ParseOptions): Record<string, string> {
@@ -28,7 +49,7 @@ async function defaultReadFile(filePath: string): Promise<string> {
   return fs.promises.readFile(filePath, 'utf-8')
 }
 
-function buildResolveContext(input: string, opts: ParseOptions): { ast: ReturnType<typeof parseTokens>, resolveOpts: ResolveOptions } {
+function buildResolveContext(input: string, opts: ParseOptions): { ast: ReturnType<typeof parseTokens>; resolveOpts: ResolveOptions } {
   const tokens = tokenize(input)
   // S3.1 — HOCON.md L130: empty files (including whitespace-only and comment-only) are invalid.
   // Delegated to the shared assertNonEmptyDocument helper so the same guard fires
@@ -40,6 +61,8 @@ function buildResolveContext(input: string, opts: ParseOptions): { ast: ReturnTy
     baseDir: opts.baseDir,
     readFileSync: opts.readFileSync ?? defaultReadFileSync,
     readFile: opts.readFile,
+    resolveFrom: opts.resolveFrom,
+    packageResolver: opts.packageResolver,
   }
   return { ast, resolveOpts }
 }

--- a/tests/conformance/include-package.test.ts
+++ b/tests/conformance/include-package.test.ts
@@ -15,11 +15,11 @@
 // Fixture source: xx.hocon worktree (read-only reference)
 // Package content: xx.hocon testdata/hocon/include-package/_packages/
 
-import { readFileSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
-import { PackageLookupError, ParseError, ResolveError, parse } from '../../src/index.js'
 import type { PackageResolver } from '../../src/index.js'
+import { PackageLookupError, ParseError, ResolveError, parse } from '../../src/index.js'
 
 // ---- Paths ----------------------------------------------------------------
 
@@ -104,6 +104,15 @@ function parseFixture(name: string, registry: Registry): ReturnType<typeof parse
 // ---- Tests -----------------------------------------------------------------
 
 describe('E11 conformance — include-package fixtures (ipk01-ipk14)', () => {
+
+  // The xx.hocon sibling worktree must be present. Skip the suite in clean
+  // checkouts (no sibling worktree) so missing fixtures produce an actionable
+  // skip message rather than confusing ENOENT errors.
+  // Same skip-guard pattern as tests/conformance/properties-conflict.test.ts.
+  if (!existsSync(FIXTURE_DIR) || !existsSync(PACKAGES_DIR)) {
+    it.skip('fixtures unavailable — xx.hocon sibling worktree (incl-pkg-xx) not present', () => {})
+    return
+  }
 
   // ipk01: happy path — basic package include
   it('ipk01-basic: success, merged config', () => {

--- a/tests/conformance/include-package.test.ts
+++ b/tests/conformance/include-package.test.ts
@@ -1,0 +1,224 @@
+// tests/conformance/include-package.test.ts
+//
+// E11 conformance — xx.hocon fixture loop for include-package/ (ipk01-ipk14).
+//
+// Design: ts.hocon has no explicit registry — it delegates to Node require.resolve.
+// For conformance testing we inject a custom packageResolver that acts as an
+// in-memory registry, keyed by JSON.stringify([identifier, file]).
+//
+// Per-impl override:
+//   ipk03 (collision): NOT APPLICABLE for ts.hocon (no explicit registry).
+//   ipk07 (file case):  require.resolve on macOS/Linux may behave differently;
+//                       the basename case-check in defaultPackageResolver handles it,
+//                       but the custom resolver in tests enforces strict equality directly.
+//
+// Fixture source: xx.hocon worktree (read-only reference)
+// Package content: xx.hocon testdata/hocon/include-package/_packages/
+
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { PackageLookupError, ParseError, ResolveError, parse } from '../../src/index.js'
+import type { PackageResolver } from '../../src/index.js'
+
+// ---- Paths ----------------------------------------------------------------
+
+// The xx.hocon worktree is a sibling of this worktree under .claude/worktrees/.
+// Vitest sets process.cwd() to the project root (worktree root), so we navigate
+// from there: ../incl-pkg-xx/... resolves sibling worktree.
+const XX_FIXTURE_DIR = join(
+  process.cwd(),
+  '../incl-pkg-xx/testdata/hocon/include-package',
+)
+const FIXTURE_DIR = XX_FIXTURE_DIR
+const PACKAGES_DIR = join(XX_FIXTURE_DIR, '_packages')
+
+// ---- Registry builder -----------------------------------------------------
+
+type Registry = Map<string, string>
+
+function registryKey(identifier: string, file: string): string {
+  return JSON.stringify([identifier, file])
+}
+
+function makeResolver(registry: Registry): PackageResolver {
+  return (identifier: string, file: string) => {
+    const key = registryKey(identifier, file)
+    if (!registry.has(key)) {
+      throw new PackageLookupError(
+        `include package("${identifier}", "${file}"): not found in test registry`,
+        identifier,
+        file,
+        0,
+        0,
+      )
+    }
+    // Return a fake absolute path; content is supplied via readFileSync override
+    return `/test-registry/${identifier}/${file}`
+  }
+}
+
+function makeReadFileSync(registry: Registry): (p: string) => string {
+  return (p: string) => {
+    // Decode the fake path back to (identifier, file)
+    const prefix = '/test-registry/'
+    if (p.startsWith(prefix)) {
+      const rest = p.slice(prefix.length)
+      // identifier may contain '/' — file is always the last path segment (no sub-dirs in test data)
+      // We need to find the split point. The registry key tells us.
+      for (const [key, content] of registry) {
+        const [id, f] = JSON.parse(key) as [string, string]
+        if (rest === `${id}/${f}`) return content
+      }
+      throw Object.assign(new Error(`test registry miss: ${p}`), { code: 'ENOENT' })
+    }
+    // Fall through to real fs for non-registry paths
+    return readFileSync(p, 'utf-8')
+  }
+}
+
+// ---- Test-package content (from xx.hocon _packages/) ----------------------
+
+function readPackage(relPath: string): string {
+  return readFileSync(join(PACKAGES_DIR, relPath), 'utf-8')
+}
+
+// ---- Per-impl override: ipk03 is N/A for ts.hocon -------------------------
+// ts.hocon has no explicit registry; host require.resolve does not detect
+// two registrations of the same (id, file) with different content.
+// ipk03 is skipped via it.skip below.
+
+// ---- Helpers ---------------------------------------------------------------
+
+function fixtureContent(name: string): string {
+  return readFileSync(join(FIXTURE_DIR, `${name}.conf`), 'utf-8')
+}
+
+function parseFixture(name: string, registry: Registry): ReturnType<typeof parse> {
+  return parse(fixtureContent(name), {
+    packageResolver: makeResolver(registry),
+    readFileSync: makeReadFileSync(registry),
+  })
+}
+
+// ---- Tests -----------------------------------------------------------------
+
+describe('E11 conformance — include-package fixtures (ipk01-ipk14)', () => {
+
+  // ipk01: happy path — basic package include
+  it('ipk01-basic: success, merged config', () => {
+    const registry: Registry = new Map([
+      [registryKey('github.com/example/lib', 'reference.conf'),
+       readPackage('github.com_example_lib/reference.conf')],
+    ])
+    const config = parseFixture('ipk01-basic', registry)
+    expect(config.get('host')).toBe('example.com')
+    expect(config.get('port')).toBe(8080)
+    expect(config.get('app.name')).toBe('lib')
+  })
+
+  // ipk02: one-arg form must be rejected at parse time
+  it('ipk02-one-arg-rejected: ParseError on one-arg form', () => {
+    expect(() => parse(fixtureContent('ipk02-one-arg-rejected'), {}))
+      .toThrow(ParseError)
+  })
+
+  // ipk03: N/A for ts.hocon (no explicit registry, no collision detection)
+  it.skip('ipk03-collision: N/A for ts.hocon (no explicit registry)', () => {
+    // ts.hocon delegates to require.resolve; host filesystem doesn't detect
+    // two different byte-content registrations for the same (id, file) pair.
+    // Per-impl override: IMPL_OVERRIDE_NA.
+  })
+
+  // ipk04: registry miss (empty registry) — lookup failure
+  it('ipk04-lookup-miss: PackageLookupError on registry miss', () => {
+    const registry: Registry = new Map()
+    expect(() => parseFixture('ipk04-lookup-miss', registry))
+      .toThrow(PackageLookupError)
+  })
+
+  // ipk05: required(package(...)) + miss
+  it('ipk05-required-miss: PackageLookupError on required + miss', () => {
+    const registry: Registry = new Map()
+    expect(() => parseFixture('ipk05-required-miss', registry))
+      .toThrow(PackageLookupError)
+  })
+
+  // ipk06: case-sensitive identifier — "foo/bar" != "Foo/Bar"
+  it('ipk06-byte-exact-id-case: PackageLookupError on case-mismatch identifier', () => {
+    // Registry has ("Foo/Bar", "x.conf"); fixture uses ("foo/bar", "x.conf")
+    const registry: Registry = new Map([
+      [registryKey('Foo/Bar', 'x.conf'),
+       readPackage('github.com_example_lib_byte/Foo_Bar_x.conf')],
+    ])
+    expect(() => parseFixture('ipk06-byte-exact-id-case', registry))
+      .toThrow(PackageLookupError)
+  })
+
+  // ipk07: case-sensitive file — "reference.conf" != "Reference.conf"
+  it('ipk07-byte-exact-file-case: PackageLookupError on case-mismatch file', () => {
+    // Registry has ("github.com/example/lib", "Reference.conf"); fixture uses lowercase
+    const registry: Registry = new Map([
+      [registryKey('github.com/example/lib', 'Reference.conf'),
+       readPackage('github.com_example_lib_byte/github.com_example_lib_Reference.conf')],
+    ])
+    expect(() => parseFixture('ipk07-byte-exact-file-case', registry))
+      .toThrow(PackageLookupError)
+  })
+
+  // ipk08: empty registered content is NOT a lookup failure; contributes {}
+  it('ipk08-empty-content: success, empty include contributes {}', () => {
+    const registry: Registry = new Map([
+      [registryKey('github.com/example/lib', 'empty.conf'), ''],
+    ])
+    const config = parseFixture('ipk08-empty-content', registry)
+    expect(config.get('app')).toBe('host')
+  })
+
+  // ipk09: empty string file argument — ParseError (E11 decision 6)
+  it('ipk09-file-empty: ParseError on empty file argument', () => {
+    expect(() => parse(fixtureContent('ipk09-file-empty'), {}))
+      .toThrow(ParseError)
+  })
+
+  // ipk10: absolute path file argument — ParseError (E11 decision 6)
+  it('ipk10-file-absolute: ParseError on absolute path file argument', () => {
+    expect(() => parse(fixtureContent('ipk10-file-absolute'), {}))
+      .toThrow(ParseError)
+  })
+
+  // ipk11: .. traversal in file argument — ParseError (E11 decision 6)
+  it('ipk11-file-traversal: ParseError on .. in file argument', () => {
+    expect(() => parse(fixtureContent('ipk11-file-traversal'), {}))
+      .toThrow(ParseError)
+  })
+
+  // ipk12: backslash in file argument (after HOCON unescape: literal \) — ParseError (E11 decision 6)
+  it('ipk12-file-backslash: ParseError on backslash in file argument', () => {
+    // The fixture contains package("foo", "x\\y.conf"); after HOCON unescape → "x\y.conf"
+    // Validation must run on the unescaped string and reject the literal backslash.
+    expect(() => parse(fixtureContent('ipk12-file-backslash'), {}))
+      .toThrow(ParseError)
+  })
+
+  // ipk13: self-include cycle
+  it('ipk13-cycle-self: ResolveError on self-include cycle', () => {
+    const selfContent = readPackage('_cycle/ipk13-self.conf')
+    const registry: Registry = new Map([
+      [registryKey('foo', 'self.conf'), selfContent],
+    ])
+    expect(() => parseFixture('ipk13-cycle-self', registry))
+      .toThrow(ResolveError)
+  })
+
+  // ipk14: mutual-include cycle
+  it('ipk14-cycle-mutual: ResolveError on mutual-include cycle', () => {
+    const registry: Registry = new Map([
+      [registryKey('foo', 'a.conf'), readPackage('_cycle/ipk14-a.conf')],
+      [registryKey('foo', 'b.conf'), readPackage('_cycle/ipk14-b.conf')],
+    ])
+    expect(() => parseFixture('ipk14-cycle-mutual', registry))
+      .toThrow(ResolveError)
+  })
+
+})

--- a/tests/e11-must-fixes-regression.test.ts
+++ b/tests/e11-must-fixes-regression.test.ts
@@ -1,0 +1,108 @@
+// tests/e11-must-fixes-regression.test.ts
+//
+// Regression tests for the four must-fix items surfaced by multi-agent-review
+// of the initial E11 ts.hocon implementation. Each test pins post-review behavior
+// to prevent future drift.
+//
+// Must-fix items (cross-review, all critical):
+//   (1) parser: missing comma between args was silently accepted
+//   (2) loader: includingFile passed to packageResolver was a synthesised "_placeholder" path
+//   (3) loader: whitespace-only registered content was treated as empty (S3.1 short-circuit)
+//   (4) loader: loadSingle / loadSingleAsync rebuilt ResolveOptions and dropped packageResolver/resolveFrom
+
+import { describe, expect, it } from 'vitest'
+import { ParseError, parse } from '../src/index.js'
+import type { PackageResolver } from '../src/index.js'
+
+describe('E11 must-fix #1 — parser requires comma between package() args', () => {
+  it('rejects package("id" "file") with no comma (ParseError)', () => {
+    expect(() => parse('include package("foo" "bar.conf")')).toThrow(ParseError)
+  })
+
+  // One-arg form rejection is already covered by tests/e11-parser-package.test.ts;
+  // this regression file targets only the missing-comma branch that previously fell through.
+})
+
+describe('E11 must-fix #2 — packageResolver receives undefined for includingFile', () => {
+  it('does not pass a synthesised "_placeholder" path', () => {
+    let receivedIncludingFile: string | undefined | symbol = Symbol('unset')
+    const resolver: PackageResolver = (_id, _file, includingFile) => {
+      receivedIncludingFile = includingFile
+      return '/fake/registry/foo/bar.conf'
+    }
+    const readFileSync = (_p: string) => 'a = 1'
+    parse('include package("foo", "bar.conf")', { packageResolver: resolver, readFileSync })
+    expect(receivedIncludingFile).toBeUndefined()
+    // Concretely: must not contain the substring "_placeholder" or any synthesised tail.
+    expect(typeof receivedIncludingFile).toBe('undefined')
+  })
+})
+
+describe('E11 must-fix #3 — empty vs whitespace-only registered content', () => {
+  it('zero-byte registered content is valid (E11 carve-out, contributes {})', () => {
+    const resolver: PackageResolver = () => '/fake/registry/foo/empty.conf'
+    const readFileSync = (_p: string) => '' // zero bytes
+    const cfg = parse(
+      'a = 1\ninclude package("foo", "empty.conf")',
+      { packageResolver: resolver, readFileSync },
+    )
+    expect(cfg.getNumber('a')).toBe(1)
+  })
+
+  it('whitespace-only registered content fires S3.1/E10 enforcement (throws)', () => {
+    const resolver: PackageResolver = () => '/fake/registry/foo/ws.conf'
+    const readFileSync = (_p: string) => '   \n\n  ' // whitespace only — NOT zero bytes
+    expect(() =>
+      parse('include package("foo", "ws.conf")', { packageResolver: resolver, readFileSync }),
+    ).toThrow()
+  })
+
+  it('comment-only registered content fires S3.1/E10 enforcement (throws)', () => {
+    const resolver: PackageResolver = () => '/fake/registry/foo/comment.conf'
+    const readFileSync = (_p: string) => '# only a comment\n'
+    expect(() =>
+      parse('include package("foo", "comment.conf")', { packageResolver: resolver, readFileSync }),
+    ).toThrow()
+  })
+})
+
+describe('E11 must-fix #4 — packageResolver/resolveFrom preserved across nested includes', () => {
+  it('an outer include "..." chain that reaches an inner include package(...) still uses the caller-provided packageResolver', () => {
+    // Bug being pinned: loadSingle rebuilt ResolveOptions with only {env, baseDir, readFileSync, includeStack}
+    // — packageResolver was dropped. Inner include package(...) then errored "not configured".
+    // Post-fix: loadSingle spreads ...this.opts, preserving packageResolver/resolveFrom/readFile.
+
+    let packageResolverCalled = false
+    let resolverReceivedId = ''
+    let resolverReceivedFile = ''
+    const resolver: PackageResolver = (id, file, _includingFile) => {
+      packageResolverCalled = true
+      resolverReceivedId = id
+      resolverReceivedFile = file
+      return '/fake/registry/foo/bar.conf'
+    }
+
+    const files = new Map<string, string>([
+      ['/virtual/a.conf', 'include package("foo", "bar.conf")\nlocal = "from_a"'],
+      ['/fake/registry/foo/bar.conf', 'x = 42'],
+    ])
+    const readFileSync = (p: string) => {
+      const content = files.get(p)
+      if (content === undefined) {
+        throw Object.assign(new Error(`enoent: ${p}`), { code: 'ENOENT' })
+      }
+      return content
+    }
+
+    const cfg = parse(
+      'include "/virtual/a.conf"',
+      { packageResolver: resolver, readFileSync },
+    )
+
+    expect(packageResolverCalled).toBe(true)
+    expect(resolverReceivedId).toBe('foo')
+    expect(resolverReceivedFile).toBe('bar.conf')
+    expect(cfg.getNumber('x')).toBe(42)
+    expect(cfg.getString('local')).toBe('from_a')
+  })
+})

--- a/tests/e11-parser-package.test.ts
+++ b/tests/e11-parser-package.test.ts
@@ -1,0 +1,64 @@
+// tests/e11-parser-package.test.ts
+//
+// E11 parser-level tests for `include package(...)` qualifier.
+// Tests the AST shape produced by the parser and parser-level rejection of invalid forms.
+
+import { describe, it, expect } from 'vitest'
+import { tokenize } from '../src/internal/lexer/lexer.js'
+import { parseTokens } from '../src/internal/parser/parser.js'
+import { ParseError } from '../src/errors.js'
+import type { AstNode } from '../src/internal/parser/ast.js'
+
+function parse(input: string): AstNode {
+  return parseTokens(tokenize(input))
+}
+
+describe('E11 parser — include package() AST', () => {
+  it('parses two-arg package() into include node with qualifier.kind=package', () => {
+    const ast = parse('include package("github.com/example/lib", "reference.conf")')
+    expect(ast.kind).toBe('object')
+    if (ast.kind !== 'object') return
+    expect(ast.fields).toHaveLength(1)
+    const field = ast.fields[0]!
+    expect(field.key).toHaveLength(0)
+    const inc = field.value
+    expect(inc.kind).toBe('include')
+    if (inc.kind !== 'include') return
+    expect(inc.qualifier).toEqual({ kind: 'package', identifier: 'github.com/example/lib' })
+    expect(inc.path).toBe('reference.conf')
+    expect(inc.required).toBe(false)
+  })
+
+  it('parses required(package(...)) with required=true', () => {
+    const ast = parse('include required(package("foo", "bar.conf"))')
+    if (ast.kind !== 'object') return
+    const inc = ast.fields[0]!.value
+    expect(inc.kind).toBe('include')
+    if (inc.kind !== 'include') return
+    expect(inc.required).toBe(true)
+    expect(inc.qualifier).toEqual({ kind: 'package', identifier: 'foo' })
+    expect(inc.path).toBe('bar.conf')
+  })
+
+  it('rejects one-arg form package("id/file") with ParseError', () => {
+    expect(() => parse('include package("github.com/example/lib/reference.conf")')).toThrow(ParseError)
+  })
+
+  it('parses bare include "path" into qualifier.kind=bare', () => {
+    const ast = parse('include "foo.conf"')
+    if (ast.kind !== 'object') return
+    const inc = ast.fields[0]!.value
+    expect(inc.kind).toBe('include')
+    if (inc.kind !== 'include') return
+    expect(inc.qualifier).toEqual({ kind: 'bare' })
+  })
+
+  it('parses file() include into qualifier.kind=file', () => {
+    const ast = parse('include file("foo.conf")')
+    if (ast.kind !== 'object') return
+    const inc = ast.fields[0]!.value
+    expect(inc.kind).toBe('include')
+    if (inc.kind !== 'include') return
+    expect(inc.qualifier).toEqual({ kind: 'file' })
+  })
+})


### PR DESCRIPTION
## Summary

- Implement `include package("<id>", "<file>")` per xx.hocon **E11** spec (cross-impl tracking: [o3co/xx.hocon#33](https://github.com/o3co/xx.hocon/issues/33)).
- AST discriminated qualifier union (`kind: 'package' | 'bare' | 'file' | 'url' | 'classpath'`); two-arg form mandatory, one-arg + missing-comma rejected at parse time.
- Public `PackageResolver` type + `packageResolver` / `resolveFrom` parser options. Default resolver: `createRequire(import.meta.url)` + Node `require.resolve` (works in CJS and ESM).
- **Yarn Berry PnP → fail-with-error** (cross-impl decision X1 — see `.claude/include-package-design-summary.md`).
- Cycle detection via JSON-stringified `("package", id, file)` cycle key, integrated with existing include-cycle detection.
- File argument validated **after HOCON string unescaping** (per E11 decision 5/6) — rejects empty, absolute, `..`, `./`, backslash, consecutive `/`.
- Empty registered content (zero bytes) contributes `{}` per E11 carve-out; whitespace-only content falls through to S3.1/E10 enforcement.
- Custom `PackageLookupError extends ResolveError` for telemetry.

## Multi-agent-review

Round 1 surfaced **4 critical must-fix items** (2 convergent Claude+Codex, 1 Claude-only, 1 Codex-only). All applied in commit `66738a4` with 6 regression tests in `tests/e11-must-fixes-regression.test.ts` pinning post-fix behavior:

1. Parser: missing comma between args now requires explicit `ParseError` (was silently accepted)
2. Loader: `includingFile` passed to resolvers is now `undefined` (was synthesised `_placeholder` — API contract violation)
3. Loader: empty-check uses `content.length === 0` (was `content.trim().length === 0` — masked S3.1 for whitespace-only content)
4. Loader: `loadSingle` / `loadSingleAsync` now spread `...this.opts` (was rebuilding ResolveOptions, dropping `packageResolver` / `resolveFrom` across nested include chains)

## Test plan

- [ ] E11 areas all green: 24 tests across `tests/e11-parser-package.test.ts`, `tests/conformance/include-package.test.ts`, `tests/e11-must-fixes-regression.test.ts`
- [ ] Manual: register a sample npm package, verify `include package("@scope/pkg", "reference.conf")` resolves
- [ ] CI: full suite (note: this worktree has 46 pre-existing ENOENT failures in `tests/lightbend/testdata/expected/` — confirmed pre-existing via stash-and-rerun; CI should not be affected)

Closes [#109](https://github.com/o3co/ts.hocon/issues/109) (the original Node-only proposal). Cross-impl spec at [o3co/xx.hocon#33](https://github.com/o3co/xx.hocon/issues/33).

🤖 Generated with [Claude Code](https://claude.com/claude-code)