### PR TITLE
fix(release): idempotent version-from-tag step + revert package.json bump

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,19 @@ jobs:
           cache: pnpm
 
       - name: Set version from tag
-        run: pnpm version "${GITHUB_REF#refs/tags/v}" --no-git-tag-version --no-commit-hooks
+        # Idempotent: skip the bump if package.json is already at the tag's
+        # version. `pnpm version X` errors with "Version not changed" if the
+        # current version equals X, which broke v1.4.0 publish when the
+        # release-prep PR pre-bumped package.json (see scope AGENTS.md
+        # "Release version-bump convention").
+        run: |
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          CURRENT=$(node -p "require('./package.json').version")
+          if [ "$TAG_VERSION" != "$CURRENT" ]; then
+            pnpm version "$TAG_VERSION" --no-git-tag-version --no-commit-hooks
+          else
+            echo "package.json already at $CURRENT — skipping bump"
+          fi
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@o3co/ts.hocon",
-  "version": "1.4.0",
+  "version": "0.0.0-snapshot",
   "description": "Full Lightbend HOCON spec-compliant parser and config library for TypeScript",
   "keywords": [
     "hocon",


### PR DESCRIPTION
## Summary

v1.4.0 publish broke when the release-prep PR pre-bumped `package.json` from `0.0.0-snapshot` to `1.4.0`. The Release workflow's `pnpm version \${TAG}` step errored with `Version not changed` because the current value already matched the target.

Two changes:

1. **Revert `package.json`** to `0.0.0-snapshot` — restores the convention that develop holds the snapshot value and CI bumps from the tag.
2. **Make `Set version from tag` idempotent** — mirror rs.hocon's `publish.yml` pattern with an explicit `if TAG_VERSION != CURRENT` guard. Skip the bump when already matching.

Convention now enforced by code, not just by implicit workflow assumption. Documented in scope `AGENTS.md` "Release version-bump convention".

## Test plan

- [x] `node -p "require('./package.json').version"` returns `0.0.0-snapshot`
- [x] Bash `if` guard syntactically valid (verified inline)
- [ ] After merge: delete + recreate `v1.4.0` tag → workflow runs, bumps from `0.0.0-snapshot` to `1.4.0`, publishes to npm