### PR TITLE
fix(resolver): empty/comment-only include is no-op (cross-impl go.hocon#105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Cross-impl regression tests for include ordering ([go.hocon#106](https://github.com/o3co/go.hocon/issues/106))**. Pin Lightbend-equivalent semantics for `include` directives — scalar override, parent-after-include, self-referential append through include, both-object deep-merge, nested-include scope isolation, and sequential includes — so the existing correct behaviour does not regress when the merge logic is touched. No production-code change; `ts.hocon`'s `deepMergeResObjInto` already implements src-wins + prior-capture.
 
+### Changed — include path
+
+- **Empty / comment-only / whitespace-only included files contribute an empty config** ([go.hocon#105](https://github.com/o3co/go.hocon/issues/105), Lightbend compatibility). Previously, `include "empty.conf"` (or comment-only / whitespace-only / BOM-only content) errored with `empty file is not a valid HOCON document (HOCON.md L130)`. This blocked the common optional-override-file pattern. The carve-out is **narrow** — applies only to the file-include code path (`loadSingle` / `loadSingleAsync`); top-level empty parses (`parse("")`) and E11 package includes (which already had their own zero-byte carve-out) are unchanged. Reported via go.hocon by [@cgordon](https://github.com/cgordon); cross-impl with [go.hocon PR #110](https://github.com/o3co/go.hocon/pull/110) and [rs.hocon PR #108](https://github.com/o3co/rs.hocon/pull/108).
+
 ## [1.4.0] - 2026-05-21
 
 ### Added — E12 deferred substitution resolution (closes [#99](https://github.com/o3co/ts.hocon/issues/99))

--- a/src/internal/resolver/include-loader.ts
+++ b/src/internal/resolver/include-loader.ts
@@ -1,7 +1,7 @@
 import { createRequire } from 'node:module'
 import * as nodePath from 'node:path'
 import { PackageLookupError, ParseError, ResolveError } from '../../errors.js'
-import { assertNonEmptyDocument } from '../parser/empty-check.js'
+import { assertNonEmptyDocument, hasContentTokens } from '../parser/empty-check.js'
 import type { AstNode } from '../parser/ast.js'
 import { tokenize } from '../lexer/lexer.js'
 import { parseTokens } from '../parser/parser.js'
@@ -368,8 +368,13 @@ export class IncludeLoader {
     }
 
     const tokens = tokenize(content)
-    // S3.1 — HOCON.md L130: empty included files are invalid documents.
-    assertNonEmptyDocument(tokens, candidate)
+    // Lightbend-compat carve-out (#105): an empty / whitespace-only /
+    // comment-only included file contributes an empty config rather than
+    // erroring with S3.1. Top-level empty parses (parse("")) remain invalid;
+    // this scope is intentionally narrow — the include path only.
+    if (!hasContentTokens(tokens)) {
+      return makeResObj()
+    }
     const ast = parseTokens(tokens)
     // Spread all opts to preserve packageResolver / resolveFrom / readFile across nested includes.
     return this.onBuildResObj(ast, {
@@ -402,8 +407,10 @@ export class IncludeLoader {
     }
 
     const tokens = tokenize(content)
-    // S3.1 — HOCON.md L130: empty included files are invalid documents.
-    assertNonEmptyDocument(tokens, candidate)
+    // Lightbend-compat carve-out (#105): same rule as loadSingle.
+    if (!hasContentTokens(tokens)) {
+      return makeResObj()
+    }
     const ast = parseTokens(tokens)
     // Spread all opts to preserve packageResolver / resolveFrom across nested includes.
     return this.onBuildResObjAsync(ast, {

--- a/tests/issue105-empty-include.test.ts
+++ b/tests/issue105-empty-include.test.ts
@@ -1,0 +1,85 @@
+/**
+ * go.hocon#105 cross-impl fix: empty / whitespace-only / comment-only
+ * included files should contribute an empty config instead of erroring
+ * with the S3.1 top-level rejection. Narrow scope — file-include only;
+ * top-level empty parses still error.
+ */
+import { describe, expect, it } from 'vitest'
+import { parse, ParseError } from '../src/index.js'
+
+describe('go.hocon#105 cross-impl — empty/comment-only include is no-op', () => {
+  const buildParseWithFiles = (files: Map<string, string>) => {
+    const readFileSync = (p: string) => {
+      const content = files.get(p)
+      if (content === undefined) {
+        throw Object.assign(new Error(`enoent: ${p}`), { code: 'ENOENT' })
+      }
+      return content
+    }
+    return (input: string) => parse(input, { readFileSync })
+  }
+
+  it('zero-byte include contributes an empty config', () => {
+    const files = new Map<string, string>([
+      ['/virtual/empty.conf', ''],
+    ])
+    const cfg = buildParseWithFiles(files)('include "/virtual/empty.conf"\na = 1\n')
+    expect(cfg.getNumber('a')).toBe(1)
+  })
+
+  it('hash-comment-only include is a no-op', () => {
+    const files = new Map<string, string>([
+      ['/virtual/c.conf', '# only a comment\n# another\n'],
+    ])
+    const cfg = buildParseWithFiles(files)('include "/virtual/c.conf"\na = 1\n')
+    expect(cfg.getNumber('a')).toBe(1)
+  })
+
+  it('slash-comment-only include is a no-op', () => {
+    const files = new Map<string, string>([
+      ['/virtual/c.conf', '// only a comment\n'],
+    ])
+    const cfg = buildParseWithFiles(files)('include "/virtual/c.conf"\na = 1\n')
+    expect(cfg.getNumber('a')).toBe(1)
+  })
+
+  it('whitespace-only include is a no-op', () => {
+    const files = new Map<string, string>([
+      ['/virtual/ws.conf', '   \n\t\n\n'],
+    ])
+    const cfg = buildParseWithFiles(files)('include "/virtual/ws.conf"\na = 1\n')
+    expect(cfg.getNumber('a')).toBe(1)
+  })
+
+  it('Unicode-whitespace-only include is a no-op (NBSP, en-quad, line sep)', () => {
+    const files = new Map<string, string>([
+      ['/virtual/uws.conf', '   \n'],
+    ])
+    const cfg = buildParseWithFiles(files)('include "/virtual/uws.conf"\na = 1\n')
+    expect(cfg.getNumber('a')).toBe(1)
+  })
+
+  it('BOM-only include is a no-op', () => {
+    const files = new Map<string, string>([
+      ['/virtual/bom.conf', '﻿\n'],
+    ])
+    const cfg = buildParseWithFiles(files)('include "/virtual/bom.conf"\na = 1\n')
+    expect(cfg.getNumber('a')).toBe(1)
+  })
+
+  it('top-level empty parses still error (S3.1 scope intact)', () => {
+    expect(() => parse('')).toThrow(ParseError)
+    expect(() => parse('# only a comment\n')).toThrow(ParseError)
+    expect(() => parse('// only a comment\n')).toThrow(ParseError)
+    expect(() => parse('   \n  ')).toThrow(ParseError)
+  })
+
+  it('non-empty include still parses normally (regression guard)', () => {
+    const files = new Map<string, string>([
+      ['/virtual/c.conf', '# leading\nb = 2\n# trailing\n'],
+    ])
+    const cfg = buildParseWithFiles(files)('include "/virtual/c.conf"\na = 1\n')
+    expect(cfg.getNumber('a')).toBe(1)
+    expect(cfg.getNumber('b')).toBe(2)
+  })
+})

--- a/tests/issue105-empty-include.test.ts
+++ b/tests/issue105-empty-include.test.ts
@@ -53,7 +53,7 @@ describe('go.hocon#105 cross-impl — empty/comment-only include is no-op', () =
 
   it('Unicode-whitespace-only include is a no-op (NBSP, en-quad, line sep)', () => {
     const files = new Map<string, string>([
-      ['/virtual/uws.conf', '   \n'],
+      ['/virtual/uws.conf', '\u00A0\u2000\u2028\n'],
     ])
     const cfg = buildParseWithFiles(files)('include "/virtual/uws.conf"\na = 1\n')
     expect(cfg.getNumber('a')).toBe(1)
@@ -61,7 +61,7 @@ describe('go.hocon#105 cross-impl — empty/comment-only include is no-op', () =
 
   it('BOM-only include is a no-op', () => {
     const files = new Map<string, string>([
-      ['/virtual/bom.conf', '﻿\n'],
+      ['/virtual/bom.conf', '\uFEFF\n'],
     ])
     const cfg = buildParseWithFiles(files)('include "/virtual/bom.conf"\na = 1\n')
     expect(cfg.getNumber('a')).toBe(1)

--- a/tests/spec-s3-1-empty-include.test.ts
+++ b/tests/spec-s3-1-empty-include.test.ts
@@ -50,7 +50,7 @@ describe('S3.1 — included file is empty/comment-only (Lightbend-compat carve-o
   })
 
   it('include: BOM-only included file is no-op', () => {
-    const files = { 'bom.conf': '﻿' }
+    const files = { 'bom.conf': '\uFEFF' }
     const cfg = parse('include "bom.conf"\na = 1', { readFileSync: fileReader(files) })
     expect(cfg.getNumber('a')).toBe(1)
   })

--- a/tests/spec-s3-1-empty-include.test.ts
+++ b/tests/spec-s3-1-empty-include.test.ts
@@ -1,78 +1,87 @@
 // tests/spec-s3-1-empty-include.test.ts
 //
-// S3.1 — Empty included file is an invalid HOCON document (HOCON.md L130)
-// Verifies that the assertNonEmptyDocument guard fires on the include-loader
-// path, not only on the top-level parse path.
+// Lightbend-compat carve-out for go.hocon#105 — empty / whitespace-only /
+// comment-only / BOM-only INCLUDED files contribute an empty config
+// instead of erroring with S3.1.
+//
+// S3.1 (HOCON.md L130) "empty files are invalid documents" remains
+// enforced for TOP-LEVEL parses (parse(""), parseFile on empty as root) —
+// see tests/spec-s3-1-empty-top-level.test.ts. This file pins the
+// narrower include-path carve-out and serves as a regression guard
+// against the previous strict-reject behaviour returning.
 
 import { describe, it, expect } from 'vitest'
 import { parse } from '../src/index.js'
 import { ParseError } from '../src/errors.js'
 
-describe('S3.1 — empty included file is invalid (HOCON.md L130)', () => {
-  // --- Error cases ---
+const fileReader = (files: Record<string, string>) => (p: string) => {
+  const v = files[p.split('/').pop()!]
+  if (v === undefined) {
+    throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+  }
+  return v
+}
 
-  it('S3.1 include: rejects completely empty included file', () => {
-    const files: Record<string, string> = { 'empty.conf': '' }
-    expect(() =>
-      parse('include "empty.conf"', {
-        readFileSync: (p) => files[p.split('/').pop()!] ?? (() => { throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' }) })(),
-      })
-    ).toThrow(ParseError)
+describe('S3.1 — included file is empty/comment-only (Lightbend-compat carve-out #105)', () => {
+  // --- Carve-out cases: must NOT throw, contribute empty ---
+
+  it('include: completely empty included file is no-op', () => {
+    const files = { 'empty.conf': '' }
+    const cfg = parse('include "empty.conf"\na = 1', { readFileSync: fileReader(files) })
+    expect(cfg.getNumber('a')).toBe(1)
   })
 
-  it('S3.1 include: error message mentions "empty file"', () => {
-    const files: Record<string, string> = { 'empty.conf': '' }
-    expect(() =>
-      parse('include "empty.conf"', {
-        readFileSync: (p) => files[p.split('/').pop()!] ?? (() => { throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' }) })(),
-      })
-    ).toThrow(/empty file/i)
+  it('include: whitespace-only included file is no-op', () => {
+    const files = { 'ws.conf': '   \n  \t  ' }
+    const cfg = parse('include "ws.conf"\na = 1', { readFileSync: fileReader(files) })
+    expect(cfg.getNumber('a')).toBe(1)
   })
 
-  it('S3.1 include: rejects whitespace-only included file', () => {
-    const files: Record<string, string> = { 'ws.conf': '   \n  \t  ' }
-    expect(() =>
-      parse('include "ws.conf"', {
-        readFileSync: (p) => files[p.split('/').pop()!] ?? (() => { throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' }) })(),
-      })
-    ).toThrow(ParseError)
+  it('include: hash-comment-only included file is no-op', () => {
+    const files = { 'comments.conf': '# only a comment\n# another\n' }
+    const cfg = parse('include "comments.conf"\na = 1', { readFileSync: fileReader(files) })
+    expect(cfg.getNumber('a')).toBe(1)
   })
 
-  it('S3.1 include: rejects comment-only included file', () => {
-    const files: Record<string, string> = { 'comments.conf': '# only a comment\n// another comment\n' }
-    expect(() =>
-      parse('include "comments.conf"', {
-        readFileSync: (p) => files[p.split('/').pop()!] ?? (() => { throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' }) })(),
-      })
-    ).toThrow(ParseError)
+  it('include: slash-comment-only included file is no-op', () => {
+    const files = { 'comments.conf': '// only a comment\n' }
+    const cfg = parse('include "comments.conf"\na = 1', { readFileSync: fileReader(files) })
+    expect(cfg.getNumber('a')).toBe(1)
   })
 
-  it('S3.1 include: rejects BOM-only included file', () => {
-    const files: Record<string, string> = { 'bom.conf': '﻿' }
-    expect(() =>
-      parse('include "bom.conf"', {
-        readFileSync: (p) => files[p.split('/').pop()!] ?? (() => { throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' }) })(),
-      })
-    ).toThrow(ParseError)
+  it('include: BOM-only included file is no-op', () => {
+    const files = { 'bom.conf': '﻿' }
+    const cfg = parse('include "bom.conf"\na = 1', { readFileSync: fileReader(files) })
+    expect(cfg.getNumber('a')).toBe(1)
   })
 
-  // --- Positive guard (must NOT throw) ---
+  // --- Non-empty controls (regression guard) ---
 
-  it('S3.1 include positive: include of non-empty file succeeds', () => {
-    const files: Record<string, string> = { 'non-empty.conf': 'a = 1' }
+  it('include positive: non-empty file still parses', () => {
+    const files = { 'non-empty.conf': 'a = 1' }
     expect(() =>
-      parse('include "non-empty.conf"', {
-        readFileSync: (p) => files[p.split('/').pop()!] ?? (() => { throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' }) })(),
-      })
+      parse('include "non-empty.conf"', { readFileSync: fileReader(files) }),
     ).not.toThrow()
   })
 
-  it('S3.1 include positive: include of file with comment then field succeeds', () => {
-    const files: Record<string, string> = { 'with-comment.conf': '# header\nb = 2' }
+  it('include positive: comment + field still parses', () => {
+    const files = { 'with-comment.conf': '# header\nb = 2' }
     expect(() =>
-      parse('include "with-comment.conf"', {
-        readFileSync: (p) => files[p.split('/').pop()!] ?? (() => { throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' }) })(),
-      })
+      parse('include "with-comment.conf"', { readFileSync: fileReader(files) }),
     ).not.toThrow()
+  })
+
+  // --- Top-level scope preserved ---
+
+  it('top-level parse("") still rejects per S3.1', () => {
+    expect(() => parse('')).toThrow(ParseError)
+  })
+
+  it('top-level whitespace-only still rejects per S3.1', () => {
+    expect(() => parse('   \n\t')).toThrow(ParseError)
+  })
+
+  it('top-level comment-only still rejects per S3.1', () => {
+    expect(() => parse('# only a comment\n')).toThrow(ParseError)
   })
 })


### PR DESCRIPTION
## Summary

Cross-impl fix for the same issue reported in [go.hocon#105](https://github.com/o3co/go.hocon/issues/105) (cgordon). Lightbend Config treats an empty / whitespace-only / comment-only / BOM-only included file as a no-op; `ts.hocon` previously errored via the S3.1 enforcement in `assertNonEmptyDocument`. This blocks the optional-override-file pattern:

```hocon
include \"optional-overrides.conf\"
a = 1
```

## Scope

**Narrow:** only the file-include path (`loadSingle` / `loadSingleAsync`). Top-level parses (`parse(\"\")`, `parseFile` on empty as root) continue to error per S3.1. E11 `include package(...)` is unchanged — it already had its own zero-byte carve-out (`ipk08`) and intentionally enforces S3.1 on whitespace/comment-only registered content.

## Changes

- `src/internal/resolver/include-loader.ts` — `assertNonEmptyDocument` replaced with `!hasContentTokens(tokens)` early-return in both sync and async loaders.
- `src/internal/parser/empty-check.ts` — no change; `hasContentTokens` was already exported.
- `tests/issue105-empty-include.test.ts` — 8 new scenarios pinning the carve-out + top-level reject guard.
- `tests/spec-s3-1-empty-include.test.ts` — updated to assert the new Lightbend-compat contract (carve-out cases now expect no-op; non-empty regression guards and top-level S3.1 enforcement still pinned).
- `CHANGELOG.md` — Unreleased entry.

## Cross-impl

Pairs with:
- `o3co/go.hocon#105` (fix, [PR #110](https://github.com/o3co/go.hocon/pull/110))
- `o3co/rs.hocon` (fix, follow-up PR)

## Test plan

- [x] `pnpm test tests/issue105-empty-include.test.ts` — 8 PASS
- [x] `pnpm test tests/spec-s3-1-empty-include.test.ts` — all green after update
- [x] `pnpm test` — full suite 1001 passed
- [ ] Maintainer: confirm CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)