### PR TITLE
fix(config): getString on null scalar must throw per S17.6 (#88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — S17.6 spec compliance
+
+- **`getString()` on a null-typed scalar now throws `ConfigError` instead of returning `"null"`** ([#88](https://github.com/o3co/ts.hocon/issues/88)). Per HOCON spec L1252, asking for a non-null type when the value is null must be an error. The other typed getters (`getNumber`, `getBoolean`, `getDuration`, …) already rejected null via their coerce/check paths; `getString` was the lone exception. A null-type guard is added in `getString` for parity.
+
 ## [1.4.1] - 2026-05-22
 
 Cross-impl bugfix release: addresses [go.hocon#105](https://github.com/o3co/go.hocon/issues/105) (cgordon-reported Lightbend divergence on empty/comment-only includes) at the ts.hocon layer, and pins go.hocon#106 (include-ordering / self-ref-through-include) which already worked correctly here. Pure include-path behaviour; no public API changes; safe drop-in upgrade from v1.4.0.

--- a/src/config.ts
+++ b/src/config.ts
@@ -85,6 +85,13 @@ export class Config {
 
   getString(path: string): string {
     const v = this.requireScalar(path)
+    // HOCON spec L1252 (S17.6): null → any non-null type is an error. The
+    // other typed getters (getNumber, getBoolean, getDuration, …) already
+    // reject `null`-valueType scalars via their coerce/check paths; getString
+    // previously returned the raw `"null"` string. Reject here for parity.
+    if (v.valueType === 'null') {
+      throw new ConfigError(`expected string at ${path}, got null`, path)
+    }
     return v.raw
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -90,7 +90,7 @@ export class Config {
     // reject `null`-valueType scalars via their coerce/check paths; getString
     // previously returned the raw `"null"` string. Reject here for parity.
     if (v.valueType === 'null') {
-      throw new ConfigError(`expected string at ${path}, got null`, path)
+      throw new ConfigError(`expected string at ${path}, got ${v.valueType}`, path)
     }
     return v.raw
   }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -522,8 +522,7 @@ describe('S17.5 - "null" string vs null literal', () => {
 
 // S17.6 — null → other type: error (HOCON spec L1252)
 describe('S17.6 - null to other type must error', () => {
-  // Issue #88: getString() on null-typed value should throw but currently returns "null"
-  it.fails('S17.6: getString() on null value should throw ConfigError', () => {
+  it('S17.6: getString() on null value throws ConfigError (#88)', () => {
     const c = parse('val = null')
     expect(() => c.getString('val')).toThrow(ConfigError)
   })


### PR DESCRIPTION
## Summary

Closes [#88](https://github.com/o3co/ts.hocon/issues/88). Per HOCON spec L1252 (\"if the application asks for a specific type and finds null instead, that should usually result in an error\"), \`getString()\` on a \`null\`-typed scalar must throw. Previously it returned the raw \`\"null\"\` string via the \`v.raw\` passthrough.

## Changes

- \`src/config.ts\` — \`getString\` adds a \`valueType === 'null'\` guard, matching the existing rejection in \`getNumber\` / \`getBoolean\` / \`getDuration\`.
- \`tests/config.test.ts\` — S17.6 \`it.fails(...)\` pin flipped to a positive assertion (closes #88 marker added).
- \`CHANGELOG.md\` — Unreleased / Fixed entry.

## Semver

Spec-compliance fix; not a breaking change under the doctrine for libraries implementing external specs.

## Test plan

- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm test\` — full suite green (991 passed)
- [ ] Maintainer: confirm CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)