### PR TITLE
release(v1.4.1): finalize CHANGELOG — cross-impl bugfix release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-05-22
+
+Cross-impl bugfix release: addresses [go.hocon#105](https://github.com/o3co/go.hocon/issues/105) (cgordon-reported Lightbend divergence on empty/comment-only includes) at the ts.hocon layer, and pins go.hocon#106 (include-ordering / self-ref-through-include) which already worked correctly here. Pure include-path behaviour; no public API changes; safe drop-in upgrade from v1.4.0.
+
 ### Tests
 
 - **Cross-impl regression tests for include ordering ([go.hocon#106](https://github.com/o3co/go.hocon/issues/106))**. Pin Lightbend-equivalent semantics for `include` directives — scalar override, parent-after-include, self-referential append through include, both-object deep-merge, nested-include scope isolation, and sequential includes — so the existing correct behaviour does not regress when the merge logic is touched. No production-code change; `ts.hocon`'s `deepMergeResObjInto` already implements src-wins + prior-capture.


### PR DESCRIPTION
## Summary

Cross-impl bugfix release. Addresses [go.hocon#105](https://github.com/o3co/go.hocon/issues/105) (cgordon-reported Lightbend divergence on empty/comment-only includes) at the ts.hocon layer; pins go.hocon#106 regression which already worked. No public API changes; safe drop-in upgrade from v1.4.0.

Already merged to develop:
- 373392c #106 cross-impl regression test
- 4dbf00d #105 cross-impl fix

## Release plan

1. Merge this release-prep PR
2. Tag `v1.4.1` from develop tip
3. Release workflow bumps from the tag (package.json stays `0.0.0-snapshot`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)