### PR TITLE
docs(changelog): correct v1.4.0 E12 cross-reference (#99 → go.hocon#99)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,10 @@ Cross-impl bugfix release: addresses [go.hocon#105](https://github.com/o3co/go.h
 
 ## [1.4.0] - 2026-05-21
 
-### Added — E12 deferred substitution resolution (closes [#99](https://github.com/o3co/ts.hocon/issues/99))
+### Added — E12 deferred substitution resolution (external request via [go.hocon#99](https://github.com/o3co/go.hocon/issues/99))
 
 This release adds the Lightbend-aligned `parseStringWithOptions → withFallback → resolve()`
-lifecycle requested in [#99](https://github.com/o3co/ts.hocon/issues/99).
+lifecycle requested by [@cgordon](https://github.com/cgordon) (see [go.hocon#99](https://github.com/o3co/go.hocon/issues/99)).
 Existing `parse()` / `parseFile()` behaviour is unchanged (still parse-and-resolve
 in one call); the new API surface is purely additive.
 


### PR DESCRIPTION
## Summary

The v1.4.0 CHANGELOG cited `closes [#99]` linking to ts.hocon#99, but [ts.hocon#99](https://github.com/o3co/ts.hocon/pull/99) is actually `ci(release): add make testdata before Test — fixes v1.2.0 publish`, **NOT** the cgordon E12 request. The actual external request issue is [go.hocon#99](https://github.com/o3co/go.hocon/issues/99), filed by @cgordon in the go.hocon tracker as the cross-impl ask landing site.

## Change

- Heading citation: `(closes [#99](.../ts.hocon/issues/99))` → `(external request via [go.hocon#99](.../go.hocon/issues/99))`
- Body link: `requested in [#99](.../ts.hocon/issues/99)` → `requested by [@cgordon](https://github.com/cgordon) (see [go.hocon#99](.../go.hocon/issues/99))`

## Impact

- git tag `v1.4.0` and the npm package `@o3co/ts.hocon@1.4.0` are unaffected — this is a CHANGELOG.md historical correction only.
- No code change.

## Test plan

- [ ] Verify the new go.hocon#99 links resolve correctly
- [ ] Confirm no other `#99`-style refs in CHANGELOG.md need similar correction (`grep '#99' CHANGELOG.md` showed only the two fixed locations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)