### PR TITLE
test(resolver): cross-impl regression for go.hocon#128 — include-child env-with-default

### DIFF
--- a/tests/issue128-include-env-fallback.test.ts
+++ b/tests/issue128-include-env-fallback.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Cross-impl regression tests for go.hocon#128 — include-child
+ * `${?ENV_VAR}` env-with-default pattern silently erases the prior
+ * duplicate-key assignment when the env var is unset.
+ *
+ * Pattern under test (canonical Lightbend reference.conf idiom):
+ *
+ *   registry {
+ *     instance-id = "localhost"
+ *     instance-id = ${?REGISTRY_INSTANCE_ID}
+ *   }
+ *
+ * Spec basis: S7.1 (later non-object overrides earlier) +
+ * S13.2/S13.11 (optional substitution undefined → field not created,
+ * i.e. the second assignment "disappears", leaving the prior) +
+ * S14b.2 (included keys merge per duplicate-key rules — include
+ * boundary is invisible to the merge semantics).
+ *
+ * go.hocon v1.4.1–v1.5.2 lost the include-child's `priorValues` across
+ * a separate lenient-resolve pass; ts.hocon merges include content into
+ * the parent's tree at structure-build time (`deepMergeResObjInto`
+ * preserves both fields and priorValues), so a single substitution-
+ * resolve pass over the merged tree never strips the prior. These tests
+ * pin that behaviour so a future refactor to a multi-pass shape can't
+ * silently regress.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { parse, parseStringWithOptions, defaultParseOptions } from '../src/index.js'
+import type { PackageResolver } from '../src/index.js'
+
+const ENV_KEYS = [
+  'GH128_TS_FILE_UNSET',
+  'GH128_TS_FILE_SET',
+  'GH128_TS_PKG_UNSET',
+  'GH128_TS_PKG_SET',
+  'GH128_TS_PKG_DEFERRED',
+] as const
+
+describe('go.hocon#128 cross-impl — include-child env-with-default preserves prior', () => {
+  beforeEach(() => {
+    for (const k of ENV_KEYS) delete process.env[k]
+  })
+  afterEach(() => {
+    for (const k of ENV_KEYS) delete process.env[k]
+  })
+
+  const buildParseWithFiles = (files: Map<string, string>) => {
+    const readFileSync = (p: string) => {
+      const content = files.get(p)
+      if (content === undefined) {
+        throw Object.assign(new Error(`enoent: ${p}`), { code: 'ENOENT' })
+      }
+      return content
+    }
+    return (input: string) => parse(input, { readFileSync })
+  }
+
+  it('include "file": env unset → prior in-source default is retained', () => {
+    const files = new Map<string, string>([
+      [
+        '/virtual/child.conf',
+        'registry {\n  instance-id = "localhost"\n  instance-id = ${?GH128_TS_FILE_UNSET}\n}\n',
+      ],
+    ])
+    const cfg = buildParseWithFiles(files)('include "/virtual/child.conf"\n')
+    expect(cfg.getString('registry.instance-id')).toBe('localhost')
+  })
+
+  it('include "file": env set → env value overrides prior default', () => {
+    process.env.GH128_TS_FILE_SET = 'from-env'
+    const files = new Map<string, string>([
+      [
+        '/virtual/child.conf',
+        'registry {\n  instance-id = "localhost"\n  instance-id = ${?GH128_TS_FILE_SET}\n}\n',
+      ],
+    ])
+    const cfg = buildParseWithFiles(files)('include "/virtual/child.conf"\n')
+    expect(cfg.getString('registry.instance-id')).toBe('from-env')
+  })
+
+  it('include package(...): env unset → prior in-source default is retained', () => {
+    const resolver: PackageResolver = () => '/fake/registry/issue128/reference.conf'
+    const readFileSync = (_p: string) =>
+      'registry {\n  instance-id = "localhost"\n  instance-id = ${?GH128_TS_PKG_UNSET}\n}\n'
+    const cfg = parse(
+      'include package("github.com/o3co/ts.hocon/test/issue128-unset", "reference.conf")\n',
+      { packageResolver: resolver, readFileSync },
+    )
+    expect(cfg.getString('registry.instance-id')).toBe('localhost')
+  })
+
+  it('include package(...): env set → env value overrides prior default', () => {
+    process.env.GH128_TS_PKG_SET = 'from-pkg-env'
+    const resolver: PackageResolver = () => '/fake/registry/issue128/reference.conf'
+    const readFileSync = (_p: string) =>
+      'registry {\n  instance-id = "localhost"\n  instance-id = ${?GH128_TS_PKG_SET}\n}\n'
+    const cfg = parse(
+      'include package("github.com/o3co/ts.hocon/test/issue128-set", "reference.conf")\n',
+      { packageResolver: resolver, readFileSync },
+    )
+    expect(cfg.getString('registry.instance-id')).toBe('from-pkg-env')
+  })
+
+  it('include package(...): deferred resolve path also retains prior when env unset', () => {
+    const resolver: PackageResolver = () => '/fake/registry/issue128/reference.conf'
+    const readFileSync = (_p: string) =>
+      'registry {\n  instance-id = "localhost"\n  instance-id = ${?GH128_TS_PKG_DEFERRED}\n}\n'
+    const opts = { ...defaultParseOptions(), packageResolver: resolver, readFileSync, resolveSubstitutions: false }
+    const unresolved = parseStringWithOptions(
+      'include package("github.com/o3co/ts.hocon/test/issue128-deferred", "reference.conf")\n',
+      opts,
+    )
+    const cfg = unresolved.resolve()
+    expect(cfg.getString('registry.instance-id')).toBe('localhost')
+  })
+})

--- a/tests/issue128-include-env-fallback.test.ts
+++ b/tests/issue128-include-env-fallback.test.ts
@@ -23,28 +23,17 @@
  * resolve pass over the merged tree never strips the prior. These tests
  * pin that behaviour so a future refactor to a multi-pass shape can't
  * silently regress.
+ *
+ * Hermeticity: env is injected via `ParseOptions.env`; `process.env` is
+ * never read or mutated. Matches the convention documented in
+ * `tests/env-var-list.test.ts` ("parse(input, { env }) ONLY").
  */
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import { parse, parseStringWithOptions, defaultParseOptions } from '../src/index.js'
 import type { PackageResolver } from '../src/index.js'
 
-const ENV_KEYS = [
-  'GH128_TS_FILE_UNSET',
-  'GH128_TS_FILE_SET',
-  'GH128_TS_PKG_UNSET',
-  'GH128_TS_PKG_SET',
-  'GH128_TS_PKG_DEFERRED',
-] as const
-
 describe('go.hocon#128 cross-impl — include-child env-with-default preserves prior', () => {
-  beforeEach(() => {
-    for (const k of ENV_KEYS) delete process.env[k]
-  })
-  afterEach(() => {
-    for (const k of ENV_KEYS) delete process.env[k]
-  })
-
-  const buildParseWithFiles = (files: Map<string, string>) => {
+  const buildParseWithFiles = (files: Map<string, string>, env: Record<string, string>) => {
     const readFileSync = (p: string) => {
       const content = files.get(p)
       if (content === undefined) {
@@ -52,7 +41,7 @@ describe('go.hocon#128 cross-impl — include-child env-with-default preserves p
       }
       return content
     }
-    return (input: string) => parse(input, { readFileSync })
+    return (input: string) => parse(input, { readFileSync, env })
   }
 
   it('include "file": env unset → prior in-source default is retained', () => {
@@ -62,19 +51,20 @@ describe('go.hocon#128 cross-impl — include-child env-with-default preserves p
         'registry {\n  instance-id = "localhost"\n  instance-id = ${?GH128_TS_FILE_UNSET}\n}\n',
       ],
     ])
-    const cfg = buildParseWithFiles(files)('include "/virtual/child.conf"\n')
+    const cfg = buildParseWithFiles(files, {})('include "/virtual/child.conf"\n')
     expect(cfg.getString('registry.instance-id')).toBe('localhost')
   })
 
   it('include "file": env set → env value overrides prior default', () => {
-    process.env.GH128_TS_FILE_SET = 'from-env'
     const files = new Map<string, string>([
       [
         '/virtual/child.conf',
         'registry {\n  instance-id = "localhost"\n  instance-id = ${?GH128_TS_FILE_SET}\n}\n',
       ],
     ])
-    const cfg = buildParseWithFiles(files)('include "/virtual/child.conf"\n')
+    const cfg = buildParseWithFiles(files, { GH128_TS_FILE_SET: 'from-env' })(
+      'include "/virtual/child.conf"\n',
+    )
     expect(cfg.getString('registry.instance-id')).toBe('from-env')
   })
 
@@ -84,19 +74,18 @@ describe('go.hocon#128 cross-impl — include-child env-with-default preserves p
       'registry {\n  instance-id = "localhost"\n  instance-id = ${?GH128_TS_PKG_UNSET}\n}\n'
     const cfg = parse(
       'include package("github.com/o3co/ts.hocon/test/issue128-unset", "reference.conf")\n',
-      { packageResolver: resolver, readFileSync },
+      { packageResolver: resolver, readFileSync, env: {} },
     )
     expect(cfg.getString('registry.instance-id')).toBe('localhost')
   })
 
   it('include package(...): env set → env value overrides prior default', () => {
-    process.env.GH128_TS_PKG_SET = 'from-pkg-env'
     const resolver: PackageResolver = () => '/fake/registry/issue128/reference.conf'
     const readFileSync = (_p: string) =>
       'registry {\n  instance-id = "localhost"\n  instance-id = ${?GH128_TS_PKG_SET}\n}\n'
     const cfg = parse(
       'include package("github.com/o3co/ts.hocon/test/issue128-set", "reference.conf")\n',
-      { packageResolver: resolver, readFileSync },
+      { packageResolver: resolver, readFileSync, env: { GH128_TS_PKG_SET: 'from-pkg-env' } },
     )
     expect(cfg.getString('registry.instance-id')).toBe('from-pkg-env')
   })
@@ -105,7 +94,13 @@ describe('go.hocon#128 cross-impl — include-child env-with-default preserves p
     const resolver: PackageResolver = () => '/fake/registry/issue128/reference.conf'
     const readFileSync = (_p: string) =>
       'registry {\n  instance-id = "localhost"\n  instance-id = ${?GH128_TS_PKG_DEFERRED}\n}\n'
-    const opts = { ...defaultParseOptions(), packageResolver: resolver, readFileSync, resolveSubstitutions: false }
+    const opts = {
+      ...defaultParseOptions(),
+      packageResolver: resolver,
+      readFileSync,
+      env: {},
+      resolveSubstitutions: false,
+    }
     const unresolved = parseStringWithOptions(
       'include package("github.com/o3co/ts.hocon/test/issue128-deferred", "reference.conf")\n',
       opts,


### PR DESCRIPTION
## Summary

Cross-impl regression suite pinning ts.hocon's correct handling of the canonical Lightbend reference.conf idiom

```hocon
key = "default"
key = ${?ENV_VAR}
```

when reached through `include "file"` or `include package(...)`. Mirrors the cross-impl pattern used for [go.hocon#105](https://github.com/o3co/ts.hocon/blob/develop/tests/issue105-empty-include.test.ts) and [go.hocon#106](https://github.com/o3co/ts.hocon/blob/develop/tests/issue106-include-ordering.test.ts).

## Why this lands now

[go.hocon#128](https://github.com/o3co/go.hocon/issues/128) (PR [#129](https://github.com/o3co/go.hocon/pull/129)) fixed a resolver bug where the include-child's `priorValues` were stripped across a separate lenient-resolve pass — env unset through `include package(...)` silently erased the prior default. The go.hocon PR description flagged ts.hocon and rs.hocon as cross-impl follow-up candidates.

Empirical result (this branch): **ts.hocon does NOT exhibit the bug**. The architecture differs: ts.hocon merges include content into the parent's tree at structure-build time via [`deepMergeResObjInto`](https://github.com/o3co/ts.hocon/blob/develop/src/internal/resolver/utils.ts#L95-L99) (which preserves both `fields` and `priorValues`), then runs a **single** substitution-resolve pass over the merged tree. The "include-child does its own lenient resolveSubstitutions pass that strips priorValues" failure mode is structurally absent.

This PR pins that behaviour so a future refactor to a multi-pass shape cannot silently regress.

## Spec basis

- **S7.1** Later non-object key overrides earlier (`docs/spec-checklist.md`)
- **S13.2** + **S13.11** Optional substitution undefined → field not created (so the second assignment "disappears", leaving the prior)
- **S14b.2** Included keys merge per duplicate-key rules — include boundary is invisible to the merge semantics
- Lightbend [`equiv04/missing-substitutions.conf`](https://github.com/o3co/hocon2/blob/main/testdata/lightbend/equiv04/missing-substitutions.conf): `a = ${?NOT_DEFINED}` alone → `{}` (S13.11 fires only when there's no prior)

## Coverage (5 tests)

| Test | Path | Env state |
|---|---|---|
| 1 | `include "file"` | unset → prior retained |
| 2 | `include "file"` | set → env value applied |
| 3 | `include package(...)` | unset → prior retained |
| 4 | `include package(...)` | set → env value applied |
| 5 | `include package(...)` deferred-resolve (`resolveSubstitutions: false` then `Config.resolve()`) | unset → prior retained |

## Test plan

- [x] `pnpm exec vitest run tests/issue128-include-env-fallback.test.ts` → **5 PASS**
- [x] `pnpm exec vitest run` (full suite) → **1137 PASS / 4 expected-fail / 6 skipped** (no regressions vs. develop)

## Cross-impl pin status

| impl | bug? | regression test |
|---|---|---|
| go.hocon | YES (v1.4.1–v1.5.2) | go.hocon PR [#129](https://github.com/o3co/go.hocon/pull/129) |
| ts.hocon | NO | this PR |
| rs.hocon | NO | sibling PR [#126](https://github.com/o3co/rs.hocon/pull/126) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)