### PR TITLE
release(v1.6.1): go.hocon#134 += include accumulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.6.1] - 2026-05-29
+
+Bugfix release: S13b.2 `+=` accumulation across includes ([go.hocon#134](https://github.com/o3co/go.hocon/issues/134)) — the follow-up deferred from v1.6.0. No public API changes; safe drop-in upgrade from v1.6.0. `package.json` stays at `"0.0.0-snapshot"`; the release workflow bumps from the tag.
 
 ### Fixed — S13b.2 `+=` accumulation across includes ([go.hocon#134](https://github.com/o3co/go.hocon/issues/134))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [1.6.1] - 2026-05-29
 
 Bugfix release: S13b.2 `+=` accumulation across includes ([go.hocon#134](https://github.com/o3co/go.hocon/issues/134)) — the follow-up deferred from v1.6.0. No public API changes; safe drop-in upgrade from v1.6.0. `package.json` stays at `"0.0.0-snapshot"`; the release workflow bumps from the tag.


### PR DESCRIPTION
## Summary

Release-prep for **v1.6.1** (ts.hocon). Promotes the `[Unreleased]` CHANGELOG section to `## [1.6.1] - 2026-05-29`.

Bugfix release, no public API changes — safe drop-in from v1.6.0:
- **go.hocon#134** — S13b.2 `+=` accumulation across includes (the follow-up deferred from v1.6.0).

## Release flow

After merge to develop, `v1.6.1` is tagged on the merged develop tip; `release.yml` (push tag `v*`) sets the version from the tag (`package.json` stays `0.0.0-snapshot`, workflow bumps idempotently) and publishes to npm.

## Test plan

- [x] CHANGELOG-only change; full suite already green on develop (#134 merged, 237b60d)

🤖 Generated with [Claude Code](https://claude.com/claude-code)