### PR TITLE
fix(render): canonicalize leading-zero numeric values in JSON output (go.hocon#50)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — leading-zero numeric values render as valid canonical JSON ([xx.hocon#50](https://github.com/o3co/xx.hocon/issues/50))
+
+- **Leading-zero numeric *value* literals now render as canonical JSON numbers** (Lightbend / rs.hocon parity). `renderHoconAsJSON` emitted numeric-value lexemes verbatim, so `b = 023` / `c = 08.53` produced `{"b":023,"c":08.53}` — not valid JSON, and divergent from Lightbend/rs (which emit `23` / `8.53`). The renderer now strips redundant leading zeros from the integer part of a number lexeme before emitting (`023`→`23`, `-08.53`→`-8.53`, `007`→`7`; `0`, `0.5`, `1.0` unchanged), matching the xx.hocon `lzv01` cross-impl fixture and byte-identical to go.hocon's equivalent fix. Render-only: `getString`/concat still return the verbatim source lexeme (S10.11), so `getString('0100')` is unchanged. The broader numeric-canonical family (exponent `1e3`→`1000.0`, trailing-zero `1.50`→`1.5`, `-0`→`0`) is a separate, untested convergence tracked as a follow-up. No public API change. Pinned by `tests/deferred-resolution.test.ts`.
+
 ## [1.6.1] - 2026-05-29
 
 Bugfix release: S13b.2 `+=` accumulation across includes ([go.hocon#134](https://github.com/o3co/go.hocon/issues/134)) — the follow-up deferred from v1.6.0. No public API changes; safe drop-in upgrade from v1.6.0. `package.json` stays at `"0.0.0-snapshot"`; the release workflow bumps from the tag.

--- a/src/config.ts
+++ b/src/config.ts
@@ -551,9 +551,15 @@ function renderHoconAsJSON(v: HoconValue): string {
         case 'null': return 'null'
         case 'boolean': return v.raw
         case 'number': {
-          const n = Number(v.raw)
-          if (Number.isFinite(n)) return v.raw
-          return JSON.stringify(v.raw)
+          // Canonicalize leading zeros so the lexeme renders as a valid JSON
+          // number matching Lightbend/rs.hocon ("023"->23, "-08.5"->-8.5);
+          // xx.hocon#50. Render-only: getString/concat still see the verbatim
+          // lexeme (S10.11), so this does not affect string coercion. Emit raw
+          // only when the normalized lexeme is a valid JSON number; otherwise
+          // quote (e.g. `1.`, which ts classifies as a number but go renders as
+          // a string) so we never emit invalid JSON — byte-aligned with go.hocon.
+          const norm = normalizeLeadingZeroNumber(v.raw)
+          return JSON_NUMBER_RE.test(norm) ? norm : JSON.stringify(v.raw)
         }
         case 'string': return JSON.stringify(v.raw)
       }
@@ -574,4 +580,20 @@ function renderHoconAsJSON(v: HoconValue): string {
   }
   // Should never reach here for valid HoconValue.
   throw new Error(`renderHoconAsJSON: unsupported value kind (unresolved placeholder?)`)
+}
+
+/** RFC 8259 JSON number grammar — gates the numeric render fast-path so a
+ * lexeme is only emitted unquoted when it is a valid JSON number. */
+const JSON_NUMBER_RE = /^-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?$/
+
+/**
+ * normalizeLeadingZeroNumber — strips redundant leading zeros from the integer
+ * part of a numeric lexeme so it renders as a valid JSON number (xx.hocon#50):
+ * "023"->"23", "-08.53"->"-8.53", "007"->"7", while "0", "0.5", "1.0" are
+ * unchanged. The fractional/exponent tail is left verbatim — this only removes
+ * the leading-zero divergence that produced invalid JSON, scoped to the render
+ * path (the source lexeme is still preserved for S10.11 string coercion).
+ */
+function normalizeLeadingZeroNumber(raw: string): string {
+  return raw.replace(/^([+-]?)0+(\d)/, '$1$2')
 }

--- a/tests/deferred-resolution.test.ts
+++ b/tests/deferred-resolution.test.ts
@@ -188,6 +188,38 @@ describe('Config._renderJSONForTest', () => {
     // Parse both to compare structurally (key order may differ from JSON.stringify)
     expect(JSON.parse(got)).toEqual(JSON.parse(expected))
   })
+
+  // xx.hocon#50: leading-zero numeric VALUE literals must render as valid,
+  // canonical JSON numbers matching Lightbend/rs.hocon ("023"->23, "08.53"->8.53,
+  // "-023"->-23). Previously ts emitted the raw lexeme verbatim ("023"), which is
+  // not valid JSON and diverged from rs/Lightbend. Asserted on the exact string
+  // (not via JSON.parse, which would throw on the old invalid output and mask the
+  // regression). Render-only: getString still returns the preserved lexeme
+  // (S10.11) — see config.test.ts getString('0100').
+  it('canonicalizes leading-zero numeric values (xx.hocon#50)', () => {
+    const c = parse('a = 01\nb = 023\nc = 08.53\nd = -023\ne = 007\nf = 00\ng = 000.5\nh = 0\ni = 0.5\nj = 1.0\nk = 100\nl = -08.53')
+    expect(c._renderJSONForTest()).toBe(
+      '{"a":1,"b":23,"c":8.53,"d":-23,"e":7,"f":0,"g":0.5,"h":0,"i":0.5,"j":1.0,"k":100,"l":-8.53}',
+    )
+  })
+
+  // xx.hocon#50 is intentionally scoped to leading zeros. The broader
+  // numeric-canonical family (exponent, trailing-zero, negative-zero) still
+  // renders verbatim and diverges from Lightbend/rs (which emit 1000.0 / 1.5 / 0).
+  // Valid JSON, just not yet canonical. Pinned so the follow-up full-canonical
+  // work (xx.hocon#53) must update this test deliberately, not silently. Output
+  // is byte-identical to go.hocon's TestRenderJSONForTest_DeferredNumericFamilyUnchanged.
+  it('leaves the deferred numeric-canonical family verbatim (xx.hocon#53)', () => {
+    const c = parse('a = 1e3\nb = 1.50\nc = -0\nd = 0e5')
+    expect(c._renderJSONForTest()).toBe('{"a":1e3,"b":1.50,"c":-0,"d":0e5}')
+  })
+
+  // xx.hocon#50 review (Copilot): a number-typed lexeme that is not a valid JSON
+  // number (`1.`, trailing dot — number-typed here, string in go) must be quoted,
+  // never emitted as invalid JSON. Output matches go.hocon's `"1."`.
+  it('quotes a number lexeme that is not valid JSON (1.)', () => {
+    expect(parse('a = 1.')._renderJSONForTest()).toBe('{"a":"1."}')
+  })
 })
 
 // ─── E11 package include with deferred (dr17, programmatic) ──────────────────


### PR DESCRIPTION
## Summary
- **xx.hocon#50** (ts side): leading-zero numeric *value* literals now render as valid, canonical JSON numbers matching Lightbend/rs.hocon. `b = 023` / `c = 08.53` previously rendered `{"b":023,"c":08.53}` (invalid JSON) via `_renderJSONForTest`; now `{"b":23,"c":8.53}`.
- `renderHoconAsJSON` strips redundant leading zeros from the integer part of a number lexeme (`023`→`23`, `-08.53`→`-8.53`, `007`→`7`; `0`, `0.5`, `1.0` unchanged).
- **Render-only**: `getString`/concat still return the verbatim lexeme (S10.11) — `getString('0100')` unchanged.

## Context
The convergence target (number) is already project canon: E8 + the `us13` oracle fixture (`{"a":1}`). Output is **byte-identical** to the paired go.hocon PR (o3co/go.hocon#144). Verified 4-way against the new xx.hocon `lzv01` fixture (o3co/xx.hocon#52).

The broader numeric-canonical family (exponent `1e3`→`1000.0`, trailing-zero `1.50`→`1.5`, `-0`→`0`) is a separate, untested convergence — follow-up issue to be filed.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm test` green (1155 pass)
- [x] `pnpm coverage` passes thresholds
- [x] New test in `tests/deferred-resolution.test.ts` pins `{"a":1,"b":23,"c":8.53,...}`
- [x] go/ts/rs/Lightbend agree on the lzv01 repro