### PR TITLE
release(v1.7.0): cross-impl sync — xx.hocon#50 render fix + go-driven minor bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-05-30
+
+Cross-impl release coordinated to land at v1.7.0 across go.hocon / ts.hocon / rs.hocon. The minor bump is driven by go.hocon's new `GetXxxE` accessor family ([go.hocon#142](https://github.com/o3co/go.hocon/issues/142), additive public API); ts.hocon's content for this cycle is the cross-impl leading-zero JSON-render validity fix ([xx.hocon#50](https://github.com/o3co/xx.hocon/issues/50), byte-aligned with go.hocon's equivalent fix) — no new ts-side public API, but the version syncs with go/rs per project convention. No breaking changes; safe drop-in upgrade from v1.6.1. `package.json` stays at `"0.0.0-snapshot"`; the release workflow bumps from the tag.
+
 ### Fixed — leading-zero numeric values render as valid canonical JSON ([xx.hocon#50](https://github.com/o3co/xx.hocon/issues/50))
 
 - **Leading-zero numeric *value* literals now render as canonical JSON numbers** (Lightbend / rs.hocon parity). `renderHoconAsJSON` emitted numeric-value lexemes verbatim, so `b = 023` / `c = 08.53` produced `{"b":023,"c":08.53}` — not valid JSON, and divergent from Lightbend/rs (which emit `23` / `8.53`). The renderer now strips redundant leading zeros from the integer part of a number lexeme before emitting (`023`→`23`, `-08.53`→`-8.53`, `007`→`7`; `0`, `0.5`, `1.0` unchanged), matching the xx.hocon `lzv01` cross-impl fixture and byte-identical to go.hocon's equivalent fix. Render-only: `getString`/concat still return the verbatim source lexeme (S10.11), so `getString('0100')` is unchanged. The broader numeric-canonical family (exponent `1e3`→`1000.0`, trailing-zero `1.50`→`1.5`, `-0`→`0`) is a separate, untested convergence tracked as a follow-up. No public API change. Pinned by `tests/deferred-resolution.test.ts`.


### PR DESCRIPTION
## Summary
- Cross-impl sync at v1.7.0. The minor bump is driven by [go.hocon#142](https://github.com/o3co/go.hocon/issues/142) (additive `GetXxxE` accessor family in go.hocon).
- ts-side content this cycle: [xx.hocon#50](https://github.com/o3co/xx.hocon/issues/50) — leading-zero numeric VALUE JSON-render validity fix, byte-aligned with go.hocon's equivalent fix.
- No new ts-side public API; the version syncs per project convention (v1.6.0 precedent).
- No breaking changes; safe drop-in upgrade from v1.6.1.
- `package.json` stays at `"0.0.0-snapshot"` — release.yml uses `pnpm version` from the tag (not idempotent per [release-version-convention](memory)).

## Test plan
- [x] CHANGELOG section moved from `[Unreleased]` to `## [1.7.0] - 2026-05-30` with intro paragraph
- [x] No code changes (release-prep only)
- [x] `package.json` left untouched (workflow bumps from tag)