### PR TITLE
fix(docs): isolate gh-pages deploy in a worktree to prevent node_modules leak

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -67,14 +67,24 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           # Stage freshly-built typedoc output outside the work tree.
+          # `docs/.` instead of `docs/*` so we copy dotfiles (e.g. `.nojekyll`)
+          # and don't fail when the directory is empty (unmatched glob).
           BUILT=$(mktemp -d)
-          cp -r docs/* "$BUILT/"
+          cp -r docs/. "$BUILT/"
 
           # Bootstrap gh-pages on the remote if missing (first-time deploy).
+          # The push may race with a concurrent deploy creating the branch
+          # first; treat that as success by re-checking after a failed push.
           if ! git ls-remote --exit-code --heads origin gh-pages > /dev/null 2>&1; then
             EMPTY_TREE=$(git mktree </dev/null)
             EMPTY_COMMIT=$(git commit-tree "$EMPTY_TREE" -m "Initial empty gh-pages")
-            git push origin "$EMPTY_COMMIT:refs/heads/gh-pages"
+            if ! git push origin "$EMPTY_COMMIT:refs/heads/gh-pages"; then
+              if ! git ls-remote --exit-code --heads origin gh-pages > /dev/null 2>&1; then
+                echo "gh-pages bootstrap push failed and branch still absent" >&2
+                exit 1
+              fi
+              echo "gh-pages was created concurrently; continuing"
+            fi
           fi
 
           # Operate on gh-pages in an isolated worktree so the develop work tree
@@ -101,7 +111,8 @@ jobs:
 
             rm -rf "v${VERSION}"
             mkdir -p "v${VERSION}"
-            cp -r "$BUILT/"* "v${VERSION}/"
+            # `$BUILT/.` matches the dotfile/empty-glob fix above.
+            cp -r "$BUILT/." "v${VERSION}/"
 
             cat > index.html << REDIRECT
             <!DOCTYPE html>

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -66,37 +66,62 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          TEMP_DIR=$(mktemp -d)
-          cp -r docs/* "$TEMP_DIR/"
+          # Stage freshly-built typedoc output outside the work tree.
+          BUILT=$(mktemp -d)
+          cp -r docs/* "$BUILT/"
 
-          git fetch origin gh-pages:gh-pages 2>/dev/null || true
-          git checkout --orphan gh-pages-tmp
-          git rm -rf . 2>/dev/null || true
-
-          if git rev-parse --verify gh-pages 2>/dev/null; then
-            git checkout gh-pages -- . 2>/dev/null || true
+          # Bootstrap gh-pages on the remote if missing (first-time deploy).
+          if ! git ls-remote --exit-code --heads origin gh-pages > /dev/null 2>&1; then
+            EMPTY_TREE=$(git mktree </dev/null)
+            EMPTY_COMMIT=$(git commit-tree "$EMPTY_TREE" -m "Initial empty gh-pages")
+            git push origin "$EMPTY_COMMIT:refs/heads/gh-pages"
           fi
 
-          rm -rf "v${VERSION}"
-          mkdir -p "v${VERSION}"
-          cp -r "$TEMP_DIR/"* "v${VERSION}/"
+          # Operate on gh-pages in an isolated worktree so the develop work tree
+          # (node_modules/, dist/, etc.) cannot leak into the published branch.
+          # This was the root cause of the historic 107MB node_modules bloat:
+          # `git checkout --orphan` + `git rm -rf .` on the develop work tree
+          # left untracked node_modules/ in place, which then got picked up by
+          # `git add -A` once gh-pages content was restored.
+          git fetch origin gh-pages
+          WORKTREE=$(mktemp -d)
+          git worktree add "$WORKTREE" origin/gh-pages
 
-          cat > index.html << REDIRECT
-          <!DOCTYPE html>
-          <html>
-          <head>
-            <meta http-equiv="refresh" content="0; url=v${VERSION}/" />
-            <title>Redirecting to latest docs</title>
-          </head>
-          <body>
-            <p>Redirecting to <a href="v${VERSION}/">v${VERSION}</a>...</p>
-          </body>
-          </html>
+          (
+            cd "$WORKTREE"
+
+            # One-time cleanup: remove any non-deploy content that may have
+            # leaked from past deploys (node_modules, stray top-level docs/,
+            # etc.). Allow-list: versioned dirs (vX.Y.Z) + root index.html.
+            find . -mindepth 1 -maxdepth 1 \
+              ! -name '.git' \
+              ! -name 'index.html' \
+              ! -regex '\./v[0-9].*' \
+              -exec rm -rf {} +
+
+            rm -rf "v${VERSION}"
+            mkdir -p "v${VERSION}"
+            cp -r "$BUILT/"* "v${VERSION}/"
+
+            cat > index.html << REDIRECT
+            <!DOCTYPE html>
+            <html>
+            <head>
+              <meta http-equiv="refresh" content="0; url=v${VERSION}/" />
+              <title>Redirecting to latest docs</title>
+            </head>
+            <body>
+              <p>Redirecting to <a href="v${VERSION}/">v${VERSION}</a>...</p>
+            </body>
+            </html>
           REDIRECT
 
-          # Note: root redirect always points to the version being deployed.
-          # If an older tag is pushed after a newer one, the redirect will
-          # temporarily point to the older version until the next deploy.
-          git add -A
-          git diff --cached --quiet && echo "No changes to commit" || git commit -m "docs: deploy API docs for v${VERSION}"
-          git push origin HEAD:gh-pages --force
+            # Note: root redirect always points to the version being deployed.
+            # If an older tag is pushed after a newer one, the redirect will
+            # temporarily point to the older version until the next deploy.
+            git add -A
+            git diff --cached --quiet && echo "No changes to commit" || git commit -m "docs: deploy API docs for v${VERSION}"
+            git push origin HEAD:gh-pages
+          )
+
+          git worktree remove --force "$WORKTREE"


### PR DESCRIPTION
## Summary

The `Deploy API Docs` workflow has been committing `node_modules/` (~107MB) into every published `gh-pages` snapshot since the very first deploy. Verified on current `origin/gh-pages` HEAD `5aff940` (v1.7.0): `du -sh node_modules → 107M`.

Root cause: the deploy step ran `git checkout --orphan gh-pages-tmp` followed by `git rm -rf .` on the develop work tree. `git rm` only removes **tracked** files, so the untracked `node_modules/` was left in place. After restoring the existing gh-pages content with `git checkout gh-pages -- .`, the trailing `git add -A` picked up the leftover `node_modules/` and committed it.

## Fix

- **Isolate the deploy in a separate worktree** via `git worktree add /tmp/... origin/gh-pages`. The develop work tree's untracked artifacts (`node_modules/`, `dist/`) are physically inaccessible from the deploy directory, so `git add -A` cannot reach them. This makes the leak structurally impossible going forward.
- **One-time cleanup** in the same step: `find` evicts anything at the worktree root other than `vX.Y.Z/` version directories and `index.html`. On the next deploy (e.g. v1.8.0), the existing 107MB `node_modules/` and the stray top-level `docs/` will be removed in the same commit that publishes the new docs.
- **Bootstrap step** added so first-time deploys (no remote `gh-pages` yet) still work.
- **Drop `--force` push** — the new worktree-based commit is a fast-forward on top of `origin/gh-pages`, so force is no longer needed.

## Why this didn't surface sooner

- The workflow technically succeeded on every release — `gh release` view shows green for v1.0.0..v1.7.0.
- The redirect `index.html` worked, so the docs site was functional.
- The bloat only showed up via explicit `du -sh node_modules` on a gh-pages worktree.

Tracked in memory entry `v1-release-followup` ("ts.hocon docs workflow bug ... cherry-pick 方式に変える案あり") — this PR adopts a worktree-based approach instead, which is cleaner than cherry-pick.

## Test plan

- [ ] YAML syntax validates (verified locally via `ruby -ryaml`)
- [ ] Workflow only fires on tag push (`v*`), so cannot run as a PR check — must be validated on the next `v1.8.0`-or-later release
- [ ] After next deploy: confirm `du -sh node_modules` on `gh-pages` is empty (no `node_modules/` exists at all)
- [ ] After next deploy: confirm top-level `docs/` is gone
- [ ] After next deploy: confirm `vX.Y.Z/` version dirs from v1.0.0..v1.7.0 are preserved
- [ ] After next deploy: confirm the new `vX.Y.Z/` dir has the typedoc content
- [ ] After next deploy: confirm `index.html` redirects to the new version