### PR TITLE
feat(value): getValue + HoconValue accessors (1.8 value introspection)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — value introspection: `Config.getValue` + `HoconValue` accessors (1.8)
+
+Cross-impl coordinated MINOR (1.8) responsibility "value → type for any node" + value introspection, ported to the ts idiom (rs.hocon [#140](https://github.com/o3co/rs.hocon/pull/140) / go.hocon [#150](https://github.com/o3co/go.hocon/pull/150) merged). ts already satisfied "value → type" via `getValidated` (zod); this release fills the introspection gap — the public `HoconValue` union previously had no retrieval handle and no accessors.
+
+- **`Config.getValue(path): ReadonlyHoconValue | undefined`** — returns the raw value node at `path` for structural introspection, where `get` decodes to a plain JS value. Missing path → `undefined`; unresolved node or subtree → `NotResolvedError` (the `HoconValue` union has no placeholder variant, so an unresolved value cannot be represented — same stance as `getConfig` / `getList`). `getValue('')` returns the root object node.
+- **Value accessor functions** (exported from the package root) — `asString` (strict: scalar/string only), `asNumber` and `asBoolean` (scalar coerced via the same `coerceNumber` / `coerceBoolean` as the typed getters), `asObject`, `asArray`, and the type guards `isObject` / `isArray` / `isScalar` plus `isNull`. They mirror rs.hocon's `HoconValue::as_* / is_*`; `asNumber` unifies rs's `as_i64` + `as_f64` because TS has a single `number` type.
+- **`ReadonlyHoconValue`** — a new exported, deeply-immutable view of `HoconValue` (`ReadonlyMap` / `readonly[]` recursively). `getValue` returns live nodes (not clones) typed as this, so callers cannot mutate the parsed tree; `HoconValue` remains assignable to it, so the accessors accept both forms. Integer-coercion parity (rs/go's non-whole-float reject) is N/A — TS `number` is float64 and int-ness is zod's concern (`z.number().int()`). No breaking changes; additive public API. `package.json` stays at `"0.0.0-snapshot"`; the release workflow bumps from the tag.
+
 ## [1.7.1] - 2026-06-14
 
 Cross-impl coordinated patch release (v1.7.1 across go.hocon / ts.hocon / rs.hocon). **No functional changes in ts.hocon.** The substantive change in this patch is rs.hocon's false-positive `circular substitution` fix ([rs.hocon#136](https://github.com/o3co/rs.hocon/pull/136)); ts.hocon was unaffected — it already resolves the same self-ref-below-merge shapes (verified in the cross-impl audit) — so this release carries no ts-side change and exists for cross-impl version parity (precedent: v1.7.0's coordinated sync). No public API changes; safe drop-in upgrade from v1.7.0. `package.json` stays at `"0.0.0-snapshot"`; the release workflow bumps from the tag.

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,7 +11,7 @@ import {
 import { isConcat, isResObj, isSubst, mergeUnresolved } from './internal/resolver/types.js'
 import type { ResObj, ResolveOptions as InternalResolveOptions } from './internal/resolver/types.js'
 import { numericObjectToArray } from './value/numeric-array.js'
-import type { HoconValue, ScalarValueType } from './value.js'
+import type { HoconValue, ReadonlyHoconValue, ScalarValueType } from './value.js'
 
 export class Config {
   /** @internal resolved flag: true when no substitution placeholders remain. */
@@ -81,6 +81,41 @@ export class Config {
     const v = this.lookupNode(path)
     if (v === undefined) return undefined
     return hoconToJs(v)
+  }
+
+  /**
+   * Returns the raw {@link HoconValue} node at `path` as a deeply-immutable
+   * {@link ReadonlyHoconValue} view, or `undefined` if the path is absent. Unlike
+   * `get` (which decodes to a plain JS value), this exposes the value tree for
+   * structural introspection via the `value.ts` accessors (`asString`, `asObject`,
+   * `isScalar`, …).
+   *
+   * `getValue('')` returns the root object node.
+   *
+   * Throws {@link NotResolvedError} when the node (or its subtree) is unresolved:
+   * the `HoconValue` union has no placeholder variant, so an unresolved value
+   * cannot be represented. This matches `getConfig` / `getList`.
+   */
+  getValue(path: string): ReadonlyHoconValue | undefined {
+    const v = this.lookupNode(path)
+    if (v === undefined) {
+      // Absent: a placeholder leaf is omitted from the partial root, so an
+      // unresolved scalar reads as "missing" — distinguish it from a genuinely
+      // absent path (matches the typed scalar getters' requireScalar branch).
+      if (!this._resolved && this._resObjRootSubtreeHasPlaceholders(path)) {
+        throw new NotResolvedError(path)
+      }
+      return undefined
+    }
+    // A present scalar is always a concrete literal/resolved value (placeholder
+    // scalars are omitted, never present) — return it without the placeholder
+    // check, matching getString/getNumber. A present object/array container may
+    // still hide placeholder children omitted from the partial root, so apply
+    // the subtree check there, matching getConfig/getList.
+    if (v.kind !== 'scalar' && !this._resolved && this._resObjRootSubtreeHasPlaceholders(path)) {
+      throw new NotResolvedError(path)
+    }
+    return v
   }
 
   getString(path: string): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,5 +8,9 @@ export {
 } from './parse.js'
 export type { ParseOptions, ResolveOptions } from './parse.js'
 export type { PackageResolver } from './internal/resolver/types.js'
-export type { HoconValue, ScalarValueType } from './value.js'
+export type { HoconValue, ReadonlyHoconValue, ScalarValueType } from './value.js'
+export {
+  asString, asNumber, asBoolean, asObject, asArray,
+  isObject, isArray, isScalar, isNull,
+} from './value.js'
 export { fromMap, empty } from './value-factory.js'

--- a/src/value.ts
+++ b/src/value.ts
@@ -1,3 +1,5 @@
+import { coerceBoolean, coerceNumber } from './coerce.js'
+
 // JavaScript の Map は挿入順を保証するため keys フィールド不要
 export type ScalarValueType = 'string' | 'number' | 'boolean' | 'null'
 
@@ -5,3 +7,77 @@ export type HoconValue =
   | { kind: 'object'; fields: Map<string, HoconValue> }
   | { kind: 'array'; items: HoconValue[] }
   | { kind: 'scalar'; raw: string; valueType: ScalarValueType }
+
+/**
+ * Deeply-immutable view of a {@link HoconValue}. `Config.getValue` returns this
+ * so callers cannot mutate the parsed configuration tree (the live nodes are
+ * shared, not cloned). `Map`/array containers become `ReadonlyMap`/`readonly[]`
+ * recursively, so `.set` / `.push` / element assignment are compile errors.
+ *
+ * `HoconValue` is structurally assignable to `ReadonlyHoconValue`, so internal
+ * code holding a mutable node can return it here, and the accessor functions
+ * below accept both forms.
+ */
+export type ReadonlyHoconValue =
+  | { readonly kind: 'object'; readonly fields: ReadonlyMap<string, ReadonlyHoconValue> }
+  | { readonly kind: 'array'; readonly items: readonly ReadonlyHoconValue[] }
+  | { readonly kind: 'scalar'; readonly raw: string; readonly valueType: ScalarValueType }
+
+// ─── value accessors ──────────────────────────────────────────────────────────
+// Standalone functions (HoconValue is a discriminated-union `type`, not a class,
+// so methods are not possible). Mirror rs.hocon's `HoconValue::as_*` / `is_*`.
+
+/** Scalar string only (strict): non-string scalars and containers → undefined. */
+export function asString(v: ReadonlyHoconValue): string | undefined {
+  return v.kind === 'scalar' && v.valueType === 'string' ? v.raw : undefined
+}
+
+/**
+ * Scalar coerced to a number via {@link coerceNumber} (lenient, matching the
+ * `getNumber` getter: a numeric-looking string scalar coerces too). TS has a
+ * single `number` type, so this unifies rs's `as_i64` + `as_f64`.
+ */
+export function asNumber(v: ReadonlyHoconValue): number | undefined {
+  return v.kind === 'scalar' ? coerceNumber(v.raw) : undefined
+}
+
+/** Scalar coerced to a boolean via {@link coerceBoolean} (true/yes/on, false/no/off). */
+export function asBoolean(v: ReadonlyHoconValue): boolean | undefined {
+  return v.kind === 'scalar' ? coerceBoolean(v.raw) : undefined
+}
+
+/** The object's fields, or undefined if not an object. */
+export function asObject(v: ReadonlyHoconValue): ReadonlyMap<string, ReadonlyHoconValue> | undefined {
+  return v.kind === 'object' ? v.fields : undefined
+}
+
+/** The array's items, or undefined if not an array. */
+export function asArray(v: ReadonlyHoconValue): readonly ReadonlyHoconValue[] | undefined {
+  return v.kind === 'array' ? v.items : undefined
+}
+
+/** Type guard: narrows to the object variant. */
+export function isObject(
+  v: ReadonlyHoconValue,
+): v is { readonly kind: 'object'; readonly fields: ReadonlyMap<string, ReadonlyHoconValue> } {
+  return v.kind === 'object'
+}
+
+/** Type guard: narrows to the array variant. */
+export function isArray(
+  v: ReadonlyHoconValue,
+): v is { readonly kind: 'array'; readonly items: readonly ReadonlyHoconValue[] } {
+  return v.kind === 'array'
+}
+
+/** Type guard: narrows to the scalar variant. */
+export function isScalar(
+  v: ReadonlyHoconValue,
+): v is { readonly kind: 'scalar'; readonly raw: string; readonly valueType: ScalarValueType } {
+  return v.kind === 'scalar'
+}
+
+/** True for a null scalar. */
+export function isNull(v: ReadonlyHoconValue): boolean {
+  return v.kind === 'scalar' && v.valueType === 'null'
+}

--- a/tests/config-getvalue.test.ts
+++ b/tests/config-getvalue.test.ts
@@ -1,0 +1,103 @@
+// tests/config-getvalue.test.ts
+import { describe, expect, it } from 'vitest'
+import { parseString, parseStringWithOptions } from '../src/parse.js'
+import { NotResolvedError } from '../src/errors.js'
+import { asObject, asString, isObject } from '../src/value.js'
+
+describe('Config.getValue — raw HoconValue node access', () => {
+  const c = parseString('a = 1\nb { c = 2 }\nd = [10, 20]\ns = "hi"')
+
+  it('returns a scalar node for a scalar path', () => {
+    const v = c.getValue('a')
+    expect(v).toEqual({ kind: 'scalar', raw: '1', valueType: 'number' })
+  })
+
+  it('returns a string scalar node verbatim', () => {
+    const v = c.getValue('s')
+    expect(v).toEqual({ kind: 'scalar', raw: 'hi', valueType: 'string' })
+  })
+
+  it('returns an object node for an object path', () => {
+    const v = c.getValue('b')
+    expect(v?.kind).toBe('object')
+    if (v && isObject(v)) {
+      expect([...v.fields.keys()]).toEqual(['c'])
+    } else {
+      throw new Error('expected object node')
+    }
+  })
+
+  it('returns a nested scalar via dotted path', () => {
+    expect(c.getValue('b.c')).toEqual({ kind: 'scalar', raw: '2', valueType: 'number' })
+  })
+
+  it('returns an array node for an array path', () => {
+    const v = c.getValue('d')
+    expect(v?.kind).toBe('array')
+    if (v?.kind === 'array') {
+      expect(v.items).toHaveLength(2)
+    }
+  })
+
+  it('returns undefined for a genuinely missing path', () => {
+    expect(c.getValue('nope')).toBeUndefined()
+    expect(c.getValue('b.nope')).toBeUndefined()
+  })
+
+  // Documented behaviour: getValue('') returns the root object node.
+  it("getValue('') returns the root node", () => {
+    const root = c.getValue('')
+    expect(root?.kind).toBe('object')
+    if (root && isObject(root)) {
+      expect([...root.fields.keys()]).toEqual(['a', 'b', 'd', 's'])
+    } else {
+      throw new Error('expected root object node')
+    }
+  })
+
+  it('composes with the value accessors', () => {
+    const b = c.getValue('b')
+    const fields = b ? asObject(b) : undefined
+    const cNode = fields?.get('c')
+    expect(cNode).toEqual({ kind: 'scalar', raw: '2', valueType: 'number' })
+    expect(asString(c.getValue('s')!)).toBe('hi')
+  })
+})
+
+describe('Config.getValue — unresolved paths throw NotResolvedError', () => {
+  it('throws on a direct unresolved substitution', () => {
+    const c = parseStringWithOptions('a = ${x}', { resolveSubstitutions: false })
+    expect(() => c.getValue('a')).toThrow(NotResolvedError)
+  })
+
+  it('throws on an object subtree containing an unresolved placeholder', () => {
+    const c = parseStringWithOptions('a { x = ${b} }', { resolveSubstitutions: false })
+    expect(() => c.getValue('a')).toThrow(NotResolvedError)
+  })
+
+  it('throws on an array containing an unresolved placeholder', () => {
+    const c = parseStringWithOptions('items = [${a}, 2]', { resolveSubstitutions: false })
+    expect(() => c.getValue('items')).toThrow(NotResolvedError)
+  })
+
+  it('returns a literal (non-placeholder) node on an otherwise-unresolved config', () => {
+    const c = parseStringWithOptions('lit = "value"\nsub = ${KEY}', { resolveSubstitutions: false })
+    expect(c.getValue('lit')).toEqual({ kind: 'scalar', raw: 'value', valueType: 'string' })
+  })
+
+  // A scalar that was a substitution but is now resolved must NOT throw just
+  // because a *different* path is still unresolved (allowUnresolved mode). It is
+  // a concrete value — getValue must agree with getString, which returns it.
+  it('returns a now-resolved scalar even when other paths stay unresolved (allowUnresolved)', () => {
+    const c = parseStringWithOptions(
+      'a = ${avail}\nb = ${missing}\navail = "hello"',
+      { resolveSubstitutions: false },
+    )
+    const r = c.resolve({ allowUnresolved: true, useSystemEnvironment: false })
+    expect(r.isResolved()).toBe(false)
+    expect(r.getString('a')).toBe('hello')
+    expect(r.getValue('a')).toEqual({ kind: 'scalar', raw: 'hello', valueType: 'string' })
+    // the genuinely-unresolved sibling still throws
+    expect(() => r.getValue('b')).toThrow(NotResolvedError)
+  })
+})

--- a/tests/value-accessors.test.ts
+++ b/tests/value-accessors.test.ts
@@ -1,0 +1,132 @@
+// tests/value-accessors.test.ts
+import { describe, expect, it } from 'vitest'
+import {
+  asString, asNumber, asBoolean, asObject, asArray,
+  isObject, isArray, isScalar, isNull,
+} from '../src/value.js'
+import type { HoconValue } from '../src/value.js'
+
+const str = (raw: string): HoconValue => ({ kind: 'scalar', raw, valueType: 'string' })
+const num = (raw: string): HoconValue => ({ kind: 'scalar', raw, valueType: 'number' })
+const bool = (raw: string): HoconValue => ({ kind: 'scalar', raw, valueType: 'boolean' })
+const nul = (): HoconValue => ({ kind: 'scalar', raw: 'null', valueType: 'null' })
+const obj = (fields: Record<string, HoconValue>): HoconValue =>
+  ({ kind: 'object', fields: new Map(Object.entries(fields)) })
+const arr = (...items: HoconValue[]): HoconValue => ({ kind: 'array', items })
+
+describe('asString (strict — scalar/string only)', () => {
+  it('returns raw for a string scalar', () => {
+    expect(asString(str('hello'))).toBe('hello')
+  })
+  it('returns undefined for non-string scalars (strict, no coercion)', () => {
+    expect(asString(num('42'))).toBeUndefined()
+    expect(asString(bool('true'))).toBeUndefined()
+    expect(asString(nul())).toBeUndefined()
+  })
+  it('returns undefined for object and array', () => {
+    expect(asString(obj({}))).toBeUndefined()
+    expect(asString(arr())).toBeUndefined()
+  })
+})
+
+describe('asNumber (scalar → coerceNumber, lenient like getNumber)', () => {
+  it('returns the value for a numeric scalar', () => {
+    expect(asNumber(num('3.14'))).toBe(3.14)
+    expect(asNumber(num('-7'))).toBe(-7)
+  })
+  it('coerces a numeric-looking string scalar (parity with getNumber)', () => {
+    expect(asNumber(str('42'))).toBe(42)
+  })
+  it('returns undefined for non-numeric scalars', () => {
+    expect(asNumber(str('hello'))).toBeUndefined()
+    expect(asNumber(bool('true'))).toBeUndefined()
+    expect(asNumber(nul())).toBeUndefined()
+  })
+  it('returns undefined for object and array', () => {
+    expect(asNumber(obj({}))).toBeUndefined()
+    expect(asNumber(arr())).toBeUndefined()
+  })
+})
+
+describe('asBoolean (scalar → coerceBoolean)', () => {
+  it('returns the value for a boolean scalar', () => {
+    expect(asBoolean(bool('true'))).toBe(true)
+    expect(asBoolean(bool('false'))).toBe(false)
+  })
+  it('coerces boolean-like string scalars (yes/no/on/off)', () => {
+    expect(asBoolean(str('yes'))).toBe(true)
+    expect(asBoolean(str('off'))).toBe(false)
+  })
+  it('returns undefined for non-boolean scalars', () => {
+    expect(asBoolean(str('maybe'))).toBeUndefined()
+    expect(asBoolean(num('1'))).toBeUndefined()
+    expect(asBoolean(nul())).toBeUndefined()
+  })
+  it('returns undefined for object and array', () => {
+    expect(asBoolean(obj({}))).toBeUndefined()
+    expect(asBoolean(arr())).toBeUndefined()
+  })
+})
+
+describe('asObject', () => {
+  it('returns the fields map for an object', () => {
+    const m = asObject(obj({ a: str('x'), b: num('1') }))
+    expect(m).toBeDefined()
+    expect(m?.get('a')).toEqual(str('x'))
+    expect([...m!.keys()]).toEqual(['a', 'b'])
+  })
+  it('returns undefined for scalar and array', () => {
+    expect(asObject(str('x'))).toBeUndefined()
+    expect(asObject(arr())).toBeUndefined()
+  })
+})
+
+describe('asArray', () => {
+  it('returns the items for an array', () => {
+    const items = asArray(arr(num('1'), num('2')))
+    expect(items).toBeDefined()
+    expect(items).toHaveLength(2)
+    expect(items?.[0]).toEqual(num('1'))
+  })
+  it('returns undefined for scalar and object', () => {
+    expect(asArray(str('x'))).toBeUndefined()
+    expect(asArray(obj({}))).toBeUndefined()
+  })
+})
+
+describe('type guards isObject / isArray / isScalar', () => {
+  it('isObject is true only for objects', () => {
+    expect(isObject(obj({}))).toBe(true)
+    expect(isObject(arr())).toBe(false)
+    expect(isObject(str('x'))).toBe(false)
+  })
+  it('isArray is true only for arrays', () => {
+    expect(isArray(arr())).toBe(true)
+    expect(isArray(obj({}))).toBe(false)
+    expect(isArray(str('x'))).toBe(false)
+  })
+  it('isScalar is true only for scalars', () => {
+    expect(isScalar(str('x'))).toBe(true)
+    expect(isScalar(num('1'))).toBe(true)
+    expect(isScalar(obj({}))).toBe(false)
+    expect(isScalar(arr())).toBe(false)
+  })
+  it('narrows the type (compile-time guard, exercised at runtime)', () => {
+    const v: HoconValue = obj({ k: str('v') })
+    if (isObject(v)) {
+      expect(v.fields.get('k')).toEqual(str('v'))
+    } else {
+      throw new Error('expected isObject to narrow')
+    }
+  })
+})
+
+describe('isNull', () => {
+  it('is true only for a null scalar', () => {
+    expect(isNull(nul())).toBe(true)
+    expect(isNull(str('null'))).toBe(false)
+    expect(isNull(num('0'))).toBe(false)
+    expect(isNull(obj({}))).toBe(false)
+    expect(isNull(arr())).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

Cross-impl coordinated MINOR **1.8** — responsibility "value → type for any node" + value introspection — ported to the ts idiom. This is the final impl of the trio (rs.hocon [#140](https://github.com/o3co/rs.hocon/pull/140) ✅ / go.hocon [#150](https://github.com/o3co/go.hocon/pull/150) ✅ merged).

ts already satisfied **value → type** via `getValidated` (zod). The gap was **value introspection**: the public `HoconValue` union had no retrieval handle and no accessors (rs F2-type under-provisioning). This PR closes it.

## What's added (additive public API)

- **`Config.getValue(path): ReadonlyHoconValue | undefined`** — raw value-node accessor, where `get` decodes to a plain JS value.
  - missing → `undefined`; unresolved node/subtree → `NotResolvedError` (the `HoconValue` union has no placeholder variant — same stance as `getConfig`/`getList`).
  - A present **scalar** is a concrete value, returned without the placeholder check (matches the typed scalar getters); present **containers** still run the subtree check (matches `getConfig`/`getList`).
  - `getValue('')` → root object node (documented + tested).
- **Value accessors** (exported from package root): `asString` (strict scalar/string), `asNumber`/`asBoolean` (reuse `coerceNumber`/`coerceBoolean`, lenient like the getters), `asObject`, `asArray`, type guards `isObject`/`isArray`/`isScalar`, and `isNull`. Mirror rs's `HoconValue::as_*`/`is_*`; `asNumber` unifies rs's `as_i64`+`as_f64` (TS has one `number`).
- **`ReadonlyHoconValue`** — new exported deeply-immutable view (`ReadonlyMap` / `readonly[]` recursively, readonly leaf fields + discriminant). `getValue` returns live nodes (no clone) typed as this, so callers cannot mutate the parsed tree; `HoconValue` stays assignable to it so the accessors accept both forms.

Integer-coercion parity (rs/go's non-whole-float reject) is **N/A** — TS `number` is float64 and int-ness is zod's concern (`z.number().int()`).

## Design note — mutability (★1)

Chose the **readonly type view** (no runtime clone) after empirically verifying with `tsc`: `Readonly<T>` is *shallow* (leaves `Map.set`/`array.push`/element-assign open), whereas the hand-written `ReadonlyHoconValue` union blocks container mutation **and** scalar-leaf/`kind` reassignment at compile time, while staying clean in diagnostics.

## Tests

TDD: 33 new tests (`tests/value-accessors.test.ts`, `tests/config-getvalue.test.ts`) covering every accessor's positive/negative/container cases and `getValue`'s scalar/object/array/nested/missing/`('')`/unresolved-direct/unresolved-subtree/unresolved-array/literal-on-unresolved-config paths. Full suite: **1159 passed**, typecheck + build clean.

## Review

`/multi-agent-review` (Claude + Codex) run once. Both flagged (convergent must-fix) that `ReadonlyHoconValue` scalar fields were mutable → fixed (readonly leaf fields + discriminant; verified). Codex additionally caught a false `NotResolvedError` for a now-resolved scalar when other paths stay unresolved (`allowUnresolved`) → fixed (per-type check matching `getString`) + regression test.

## Versioning

No version bump — `package.json` stays `"0.0.0-snapshot"`; CHANGELOG entry under `[Unreleased]`. 1.8 ships as the coordinated rs/go/ts release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)