### PR TITLE
fix!: duration unit names are case-sensitive (S19.8) + spec-compliance doc sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — **BREAKING**: duration unit names are case-sensitive (S19.8, HOCON.md L1304)
+
+- **`getDuration` now rejects non-lowercase duration units** per HOCON.md L1304 ("The
+  supported unit strings for duration are case sensitive and must be lowercase").
+  Previously `parseDuration` lowercased the unit before lookup, so `"5 MS"`,
+  `"5 Seconds"`, `"5 DAYS"` were wrongly accepted; they now throw `ConfigError`.
+  Lowercase units (`ms`, `seconds`, …) are unaffected. Aligns with go.hocon (already
+  compliant) and rs.hocon's equivalent fix in the same cross-impl cycle. Flips the
+  S19.8 compliance cell ❌ → ✅.
+
 ## [1.8.0] - 2026-06-16
 
 ### Added — value introspection: `Config.getValue` + `HoconValue` accessors (1.8)

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ c.getBytes('max-size')          // 536870912 (bytes)
 c.getBytes('max-size', 'MiB')  // 512
 ```
 
-Supported duration units: `ns`, `us`, `ms`, `s`, `m`, `h`, `d` (and long forms like `seconds`, `minutes`).
+Supported duration units: `ns`, `us`, `ms`, `s`, `m`, `h`, `d` (and long forms like `seconds`, `minutes`). Duration unit names are case-sensitive and must be lowercase (HOCON spec); byte units below accept the cases shown.
 Supported byte units: `B`, `KB`/`KiB`, `MB`/`MiB`, `GB`/`GiB`, `TB`/`TiB` (and long forms like `megabytes`, `mebibytes`).
 
 ## Spec Compliance

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ c.getBytes('max-size')          // 536870912 (bytes)
 c.getBytes('max-size', 'MiB')  // 512
 ```
 
-Supported duration units: `ns`, `us`, `ms`, `s`, `m`, `h`, `d` (and long forms like `seconds`, `minutes`). Duration unit names are case-sensitive and must be lowercase (HOCON spec); byte units below accept the cases shown.
+Supported duration units: `ns`, `us`, `ms`, `s`, `m`, `h`, `d` (and long forms like `seconds`, `minutes`). Duration unit names are case-sensitive and must be lowercase (HOCON spec). Byte units are more case-tolerant: the canonical forms below plus lowercase aliases (`kb`, `kib`, …), any-case long forms (`megabytes`), and single-letter powers-of-two in both cases (`K`/`k`, per Lightbend).
 Supported byte units: `B`, `KB`/`KiB`, `MB`/`MiB`, `GB`/`GiB`, `TB`/`TiB` (and long forms like `megabytes`, `mebibytes`).
 
 ## Spec Compliance

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -443,8 +443,9 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
   tests: tests/resolver.test.ts:67; tests/parse.test.ts:186
   status: ✅
 - **S13b.2** `+=` on non-array prior value → error — §`+=` field separator (L732)
-  tests: tests/resolver.test.ts:696
-  status: ❌ (see #81) — resolver wraps the scalar as a single-element array instead of erroring
+  tests: tests/resolver.test.ts:731,735,739 (S13b.2 error assertions: number scalar, string scalar, object prior)
+  status: ✅ — the resolver now errors instead of wrapping the scalar as a single-element array ([#81](https://github.com/o3co/ts.hocon/issues/81) fixed); numeric-keyed-object prior still succeeds via S15.3, matching the `${?a} [b]` desugar.
+
 - **S13b.3** `+=` works on first mention of key (no prior `=`) — §`+=` field separator (L734)
   tests: tests/resolver.test.ts:74
   status: ✅
@@ -655,9 +656,9 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
   tests: tests/config.test.ts:507 — kept as a sanity check that quoted `"null"` is stored as a string scalar and unquoted `null` is stored as the null scalar; no type-conversion is exercised.
   status: ➖
 - **S17.6** null → other type: error — §Automatic type conversions (L1252)
-  tests: tests/config.test.ts:527 (pin .fails for getString); tests/config.test.ts:532,537,542 (3 passing sub-rules)
-  status: ⚠️ (3-of-4 partial; passing sub-rules are *incidentally* satisfied)
-  `getNumber()`, `getBoolean()`, and `getList()` on a null-typed value throw `ConfigError`, but **not** because `requireScalar` enforces "no null→T conversion" — the impl coincidentally lacks a coercion path from `null` to numeric/boolean/array types, so the typed accessors fall through to "not a number / not a boolean / not an array" errors. The contract is not structurally enforced. `getString()` on null silently returns the raw string `"null"` and is pinned via `.fails`. When fixing #88, add a single explicit `valueType === 'null'` rejection at the `requireScalar` boundary so all four accessors become contract-enforced together. See issue #88.
+  tests: tests/config.test.ts (S17.6 describe block: getString/getNumber/getBoolean/getList on null all throw)
+  status: ✅ — all four typed accessors throw `ConfigError` on a null value ([#88](https://github.com/o3co/ts.hocon/issues/88) fixed; `getString` no longer returns the string `"null"`).
+
 - **S17.7** object → other type: error — §Automatic type conversions (L1254)
   tests: tests/config.test.ts:549
   status: ✅
@@ -778,13 +779,8 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
   status: ✅
 - **S22.2** Intermediate non-object hides earlier object across files — §Config object merging (L1406)
   tests: tests/config.test.ts (S22.2 describe block)
-  status: ❌
-  notes: `deepMergeHocon` always recursively merges objects regardless of intermediate
-  non-object values. Probe: `c1({a:{x:1}}).withFallback(c2({a:42})).withFallback(c3({a:{y:2}}))`
-  → `{a:{x:1,y:2}}`. Expected per spec L1410-1417: `{a:{x:1}}` (the non-object `42` in c2
-  prevents c1's `{x:1}` from merging with c3's `{y:2}`). Fix requires `withFallback` /
-  `deepMergeHocon` to track value-sequence history per key, not just the current types.
-  Tests pinned with `it.fails`.
+  status: ✅ — `c1({a:{x:1}}).withFallback(c2({a:42})).withFallback(c3({a:{y:2}}))` → `{a:{x:1}}` per spec L1410-1417; the non-object `42` prevents the merge across the barrier. Adjacent-object merge and non-object-wins sub-rules pinned in the same block.
+
 - **S22.3** Setting key to null clears earlier object value — §Config object merging (L1436)
   tests: tests/config.test.ts (S22.3 describe block)
   status: ✅

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -725,12 +725,11 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
   status: ✅
 - **S19.8** Duration unit names are case sensitive (lowercase only) — §Duration format (L1304)
   tests: tests/config.test.ts (S19.8 describe block)
-  status: ❌
-  notes: `parseDuration` applies `.toLowerCase()` to the unit string before lookup, making
-  unit names case-insensitive. Probe: `"5 MS"` → 5, `"5 Seconds"` → 5000, `"5 DAYS"` →
-  432000000. Spec L1304: "The supported unit strings for duration are case sensitive and must
-  be lowercase." Fix: remove the `.toLowerCase()` call in `parseDuration` and rely on the
-  exact map keys. Tests pinned with `it.fails`.
+  status: ✅
+  notes: `parseDuration` matches the unit string case-sensitively against the lowercase
+  unit map; `"5 MS"`, `"5 Seconds"`, `"5 DAYS"` throw `ConfigError`, lowercase units are
+  accepted. The former `.toLowerCase()` on the unit was removed (BREAKING: previously
+  accepted non-lowercase units are now rejected per spec L1304).
 
 ## S20. Period format
 

--- a/src/coerce.ts
+++ b/src/coerce.ts
@@ -77,7 +77,8 @@ export function parseDuration(value: string, outputUnit: DurationUnit = 'ms'): n
   if (i === 0) return NaN
   const num = Number(trimmed.slice(0, i))
   if (Number.isNaN(num)) return NaN
-  const unit = trimHoconWs(trimmed.slice(i)).toLowerCase()
+  // S19.8 — unit match is case-sensitive per HOCON.md L1304 (lowercase only).
+  const unit = trimHoconWs(trimmed.slice(i))
   const divisor = OUTPUT_DURATION_UNITS[outputUnit]
   if (divisor === undefined) return NaN
   // S18.1 + S18.4: bare number (no unit) → treat as default unit (ms)

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -754,24 +754,26 @@ describe('S18 - plus-sign prefix support in parseDuration/parseBytes', () => {
 })
 
 // S19.8 — duration unit names are case sensitive, lowercase only (HOCON spec L1304)
-// Probe (2026-05-13): "5 MS" → 5, "5 Seconds" → 5000, "5 DAYS" → 432000000.
-// parseDuration applies .toLowerCase() to the unit before lookup, making it case-insensitive.
 // Spec L1304: "The supported unit strings for duration are case sensitive and must be lowercase."
 describe('S19.8 - duration unit names are case-sensitive lowercase (HOCON spec L1304)', () => {
-  it.fails('S19.8: "5 MS" should be rejected — uppercase unit is invalid per spec', () => {
-    // Currently parseDuration lowercases → "ms" → 5 ms. Should reject.
+  it('S19.8: "5 MS" is rejected — uppercase unit is invalid per spec', () => {
     const c = parse('a = "5 MS"')
     expect(() => c.getDuration('a')).toThrow(ConfigError)
   })
 
-  it.fails('S19.8: "5 Seconds" should be rejected — mixed-case unit is invalid per spec', () => {
+  it('S19.8: "5 Seconds" is rejected — mixed-case unit is invalid per spec', () => {
     const c = parse('b = "5 Seconds"')
     expect(() => c.getDuration('b')).toThrow(ConfigError)
   })
 
-  it.fails('S19.8: "5 DAYS" should be rejected — uppercase unit is invalid per spec', () => {
+  it('S19.8: "5 DAYS" is rejected — uppercase unit is invalid per spec', () => {
     const c = parse('c = "5 DAYS"')
     expect(() => c.getDuration('c')).toThrow(ConfigError)
+  })
+
+  it('S19.8: "5 S" is rejected — uppercase single-letter unit is invalid (unlike byte units)', () => {
+    const c = parse('d = "5 S"')
+    expect(() => c.getDuration('d')).toThrow(ConfigError)
   })
 
   it('S19.8: "5 ms" (lowercase) is accepted', () => {


### PR DESCRIPTION
## Summary
- **BREAKING (S19.8, HOCON.md L1304)**: `getDuration` now rejects non-lowercase duration units — `parseDuration` no longer lowercases the unit before lookup, so `"5 MS"` / `"5 Seconds"` / `"5 DAYS"` throw `ConfigError`. Lowercase units unchanged. Aligns with go.hocon (already compliant); rs.hocon ships the equivalent fix in the same cycle. The three `it.fails` pins flip to plain `it`, plus a new uppercase-single-letter case (`"5 S"`), README note, and CHANGELOG Unreleased entry.
- **docs(spec-compliance) sync**: three rows still carried ❌/⚠️ from before their fixes landed — S13b.2 (❌→✅, #81), S17.6 (⚠️→✅, #88), S22.2 (❌→✅). Verified by running the cited tests and runtime probes on this branch.

With this PR ts.hocon's ground truth is ✅183 / ⚠️2 / ❌1 (spec-total 88.0%, in-scope 98.9%). Cross-impl matrix re-roll-up lands in xx.hocon (PR to follow).

## Review
Pre-PR multi-agent review (Claude + Codex) ran on the S19.8 commit: no Critical/Important findings; both Minor nits (README case note, single-letter uppercase test) are applied.

## Verification
- `pnpm test`: 1194 passed, 1 expected fail (unrelated known gap us15/ts#73), 6 fixture-gated skips
- `pnpm typecheck` / `pnpm build`: green

🤖 Generated with [Claude Code](https://claude.com/claude-code)