### PR TITLE
feat(S3.5): array-root document rejected with a type error, not a syntax error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — array-root document rejected with a type error (S3.5, [xx.hocon#64](https://github.com/o3co/xx.hocon/pull/64))
+
+- **`parse("[1,2]")` now throws `ConfigError` ("document has type array rather than
+  object at file root", HOCON.md L989-991) instead of `ParseError` "expected key, got
+  lbracket".** An array-root document is syntactically valid HOCON ("both JSON and
+  HOCON allow arrays as root values in a document"); the reference implementation
+  parses it and rejects at the Config boundary (`Parseable.forceParsedToObject`,
+  `ConfigException.WrongType`). The parser now accepts `[` at root and parses the
+  array value — malformed arrays (`[1,2`) and trailing content after the root array
+  remain `ParseError`s — and `buildResolveContext()` rejects the array-root AST with
+  the type error. Include paths (file + package, sync + async) raise `ResolveError`
+  "included file has array at file root … (HOCON.md L993-994)" naming the included
+  source, improving the S14b.1 diagnostic (previously the generic parser error).
+  Net behavior is unchanged (array-root documents still error) — only the error class,
+  layer, and message change. Pinned by `tests/spec-s3-5-array-root.test.ts` and
+  `tests/conformance/array-root.test.ts` (xx.hocon `array-root/ar01–ar03` `.error`
+  sidecars).
+
 ### Fixed — empty document parses to `{}` (S3.1 corrected, [xx.hocon#62](https://github.com/o3co/xx.hocon/pull/62))
 
 - **`parse("")` (and whitespace-only / comment-only / BOM-only input) returns an empty

--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,12 @@ DEFERRED_RESOLUTION_DIR     := tests/lightbend/testdata/hocon/deferred-resolutio
 DEFERRED_RESOLUTION_EXP_DIR := tests/lightbend/testdata/expected/hocon/deferred-resolution
 KEY_HYPHEN_DIR              := tests/lightbend/testdata/hocon/key-hyphen-position
 PATH_EXPR_WS_DIR            := tests/lightbend/testdata/hocon/path-expr-whitespace
+ARRAY_ROOT_DIR              := tests/lightbend/testdata/hocon/array-root
 
 .PHONY: testdata test
 
 testdata:
-	@if [ -f .xx-hocon-version ] && [ -d "$(EXPECTED_DIR)" ] && [ -d "$(UNITS_DIR)" ] && [ -d "$(UNQUOTED_STARTS_DIR)" ] && [ -d "$(UNQUOTED_PARENS_DIR)" ] && [ -d "$(DEFERRED_RESOLUTION_DIR)" ] && [ -d "$(KEY_HYPHEN_DIR)" ] && [ -d "$(PATH_EXPR_WS_DIR)" ]; then \
+	@if [ -f .xx-hocon-version ] && [ -d "$(EXPECTED_DIR)" ] && [ -d "$(UNITS_DIR)" ] && [ -d "$(UNQUOTED_STARTS_DIR)" ] && [ -d "$(UNQUOTED_PARENS_DIR)" ] && [ -d "$(DEFERRED_RESOLUTION_DIR)" ] && [ -d "$(KEY_HYPHEN_DIR)" ] && [ -d "$(PATH_EXPR_WS_DIR)" ] && [ -d "$(ARRAY_ROOT_DIR)" ]; then \
 	  remote_sha=$$(curl -sf "https://api.github.com/repos/$(TESTDATA_REPO)/commits/$(TESTDATA_REF)" | grep '"sha"' | head -1 | cut -d'"' -f4) && \
 	  local_sha=$$(cat .xx-hocon-version) && \
 	  if [ "$$remote_sha" = "$$local_sha" ]; then \
@@ -29,6 +30,7 @@ testdata:
 	mkdir -p "$(DEFERRED_RESOLUTION_EXP_DIR)" && \
 	mkdir -p "$(KEY_HYPHEN_DIR)" && \
 	mkdir -p "$(PATH_EXPR_WS_DIR)" && \
+	mkdir -p "$(ARRAY_ROOT_DIR)" && \
 	curl -sfL "https://github.com/$(TESTDATA_REPO)/archive/$(TESTDATA_REF).tar.gz" -o "$$tmpdir/archive.tar.gz" && \
 	tar xzf "$$tmpdir/archive.tar.gz" -C "$$tmpdir" --strip-components=1 && \
 	cp -R "$$tmpdir/expected/hocon/." "$(EXPECTED_DIR)/" && \
@@ -38,6 +40,7 @@ testdata:
 	cp -R "$$tmpdir/testdata/hocon/deferred-resolution/." "$(DEFERRED_RESOLUTION_DIR)/" && \
 	cp -R "$$tmpdir/testdata/hocon/key-hyphen-position/." "$(KEY_HYPHEN_DIR)/" && \
 	cp -R "$$tmpdir/testdata/hocon/path-expr-whitespace/." "$(PATH_EXPR_WS_DIR)/" && \
+	{ [ ! -d "$$tmpdir/testdata/hocon/array-root" ] || cp -R "$$tmpdir/testdata/hocon/array-root/." "$(ARRAY_ROOT_DIR)/"; } && \
 	curl -sf "https://api.github.com/repos/$(TESTDATA_REPO)/commits/$(TESTDATA_REF)" | grep '"sha"' | head -1 | cut -d'"' -f4 > .xx-hocon-version && \
 	echo "Done. Fetched $$(cat .xx-hocon-version)"
 

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -1,6 +1,6 @@
 # HOCON Spec Compliance — ts.hocon
 
-This file extends the canonical item definitions in [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx.hocon/blob/main/docs/spec-checklist.md). It inherits all 209 items in the same order, adding `tests:` and `status:` fields for this implementation.
+This file extends the canonical item definitions in [`xx.hocon/docs/spec-checklist.md`](https://github.com/o3co/xx.hocon/blob/main/docs/spec-checklist.md). It inherits all 210 items in the same order, adding `tests:` and `status:` fields for this implementation.
 
 - **`tests:`** — path to the test or fixture exercising each item, or `—` when no test covers it (test debt).
 - **`status:`** — uses the glyphs defined in the template legend (✅ ⚠️ ❌ 🤷 ➖). Default is 🤷 (no test, unverified).
@@ -86,6 +86,14 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
 - **S3.4** Unbalanced trailing `}` without opening `{` is invalid — §Omit root braces (L138)
   tests: tests/parser.test.ts:234
   status: ❌ ([#55](https://github.com/o3co/ts.hocon/issues/55)) — related test passes but specific case (unbraced root + stray `}`) is not covered
+- **S3.5** Array-root document is valid syntax; object-rooted parse API rejects with a type error — §Include semantics: merging (L989-991)
+  tests: tests/spec-s3-5-array-root.test.ts; tests/conformance/array-root.test.ts (ar01–ar03 `.error` sidecars)
+  status: ✅ — Added 2026-07-23. `Parser.parse()` accepts `[` at root and parses the array
+  value (malformed arrays / trailing content stay `ParseError`); `buildResolveContext()`
+  rejects an array-root AST with `ConfigError` ("document has type array rather than
+  object at file root"), matching Lightbend's `Parseable.forceParsedToObject`
+  (`WrongType`). Previously rejected with `ParseError` "expected key, got lbracket" —
+  right net outcome, wrong kind at the wrong layer.
 
 ## S4. Key-value separator
 
@@ -515,8 +523,10 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
 ### S14b. Include semantics: merging
 
 - **S14b.1** Included root must be an object (array → error) — §Include semantics: merging (L993)
-  tests: tests/resolver.test.ts:781
-  status: ✅
+  tests: tests/resolver.test.ts:781; tests/spec-s3-5-array-root.test.ts (include + package variants)
+  status: ✅ — Diagnostics improved with S3.5 (2026-07-23): the include loader now raises
+  `ResolveError` "included file has array at file root … (HOCON.md L993-994)" naming the
+  included source, instead of the parser's generic "expected key" syntax error.
 - **S14b.2** Included keys merge per duplicate-key rules — §Include semantics: merging (L997)
   tests: tests/resolver.test.ts:255
   status: ✅

--- a/src/internal/parser/parser.ts
+++ b/src/internal/parser/parser.ts
@@ -47,6 +47,22 @@ class Parser {
 
       return { kind: 'object', fields: allFields, pos: first.pos }
     }
+    if (t.kind === 'lbracket') {
+      // S3.5 (HOCON.md L989-991): "both JSON and HOCON allow arrays as root
+      // values in a document" — an array-root document is valid syntax. The
+      // object-rooted Config API rejects it AFTER the parse, at the Config
+      // boundary (see buildResolveContext / IncludeLoader), matching
+      // Lightbend's Parseable.forceParsedToObject (WrongType, not a syntax
+      // error). Malformed arrays and trailing content remain syntax errors.
+      this.advance()
+      const arr = this.parseArray()
+      this.skip('newline')
+      const remaining = this.peek()
+      if (remaining.kind !== 'eof') {
+        throw new ParseError(`Unexpected token '${remaining.value}' after root array`, remaining.line, remaining.col)
+      }
+      return arr
+    }
     return this.parseObject(false)
   }
 

--- a/src/internal/parser/parser.ts
+++ b/src/internal/parser/parser.ts
@@ -61,7 +61,10 @@ class Parser {
       if (remaining.kind !== 'eof') {
         throw new ParseError(`Unexpected token '${remaining.value}' after root array`, remaining.line, remaining.col)
       }
-      return arr
+      // Anchor the root array's pos at the opening `[` (parseArray records the
+      // first element's position) so the Config-boundary type error can point
+      // at the bracket that opened the array root.
+      return { ...arr, pos: { line: t.line, col: t.col } }
     }
     return this.parseObject(false)
   }

--- a/src/internal/resolver/include-loader.ts
+++ b/src/internal/resolver/include-loader.ts
@@ -31,6 +31,23 @@ function isPnpPath(p: string): boolean {
 }
 
 /**
+ * S14b.1 (HOCON.md L993-994): an included file must contain an object, not an
+ * array. The document itself is valid HOCON syntax (S3.5, L989-991) — the
+ * rejection is a type constraint at include-load time, naming the included
+ * source, matching Lightbend's forceParsedToObject on the include path.
+ */
+function assertObjectRootedInclude(ast: AstNode, sourcePath: string): void {
+  if (ast.kind === 'array') {
+    throw new ResolveError(
+      `included file has array at file root — an included file must contain an object, not an array (HOCON.md L993-994): ${sourcePath}`,
+      sourcePath,
+      ast.pos.line,
+      ast.pos.col,
+    )
+  }
+}
+
+/**
  * Validate the file argument of `package("id", "file")` per E11 decision 6.
  * Runs on the post-HOCON-unescape string value.
  * Throws `ParseError` on violation (structural constraint, not a resolution failure).
@@ -295,6 +312,7 @@ export class IncludeLoader {
     // AST, contributing {} (ipk08 and variants). No emptiness guard.
     const tokens = tokenize(content)
     const ast = parseTokens(tokens)
+    assertObjectRootedInclude(ast, resolvedPath)
     return this.onBuildResObj(ast, {
       ...this.opts,
       baseDir: nodePath.dirname(resolvedPath),
@@ -342,6 +360,7 @@ export class IncludeLoader {
     // content is a valid empty document contributing {} — same rule as loadPackage.
     const tokens = tokenize(content)
     const ast = parseTokens(tokens)
+    assertObjectRootedInclude(ast, resolvedPath)
     return this.onBuildResObjAsync(ast, {
       ...this.opts,
       baseDir: nodePath.dirname(resolvedPath),
@@ -374,6 +393,7 @@ export class IncludeLoader {
     // include-path carve-out is now simply the rule; parseTokens on an empty
     // stream yields an empty object AST contributing {}.
     const ast = parseTokens(tokens)
+    assertObjectRootedInclude(ast, candidate)
     // Spread all opts to preserve packageResolver / resolveFrom / readFile across nested includes.
     return this.onBuildResObj(ast, {
       ...this.opts,
@@ -407,6 +427,7 @@ export class IncludeLoader {
     const tokens = tokenize(content)
     // S3.1 (corrected, xx.hocon E10): same rule as loadSingle — empty document contributes {}.
     const ast = parseTokens(tokens)
+    assertObjectRootedInclude(ast, candidate)
     // Spread all opts to preserve packageResolver / resolveFrom across nested includes.
     return this.onBuildResObjAsync(ast, {
       ...this.opts,

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { Config } from './config.js'
+import { ConfigError } from './errors.js'
 import { tokenize } from './internal/lexer/lexer.js'
 import { parseTokens } from './internal/parser/parser.js'
 import { buildTree, containsPlaceholders, resolve, resolveAsync } from './internal/resolver/resolver.js'
@@ -81,6 +82,16 @@ function buildResolveContext(input: string, opts: ParseOptions): { ast: ReturnTy
   // comment-only document parses to the empty object. (L130-132 is the JSON
   // baseline, not HOCON-normative — see xx.hocon E10, corrected 2026-07-23.)
   const ast = parseTokens(tokens)
+  // S3.5 — HOCON.md L989-991: an array-root document is valid syntax, but the
+  // object-rooted Config API rejects it at the Config boundary with a TYPE
+  // error, matching Lightbend's Parseable.forceParsedToObject
+  // (ConfigException.WrongType "has type LIST rather than object at file root").
+  if (ast.kind === 'array') {
+    throw new ConfigError(
+      'document has type array rather than object at file root (HOCON.md L989-991); the Config API requires an object root',
+      '',
+    )
+  }
   const resolveOpts: InternalResolveOptions = {
     env: getEnv(opts),
     baseDir: opts.baseDir,

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -86,9 +86,12 @@ function buildResolveContext(input: string, opts: ParseOptions): { ast: ReturnTy
   // object-rooted Config API rejects it at the Config boundary with a TYPE
   // error, matching Lightbend's Parseable.forceParsedToObject
   // (ConfigException.WrongType "has type LIST rather than object at file root").
+  // The message carries the source origin + the opening bracket's position
+  // (Lightbend's WrongType includes the origin and line likewise).
   if (ast.kind === 'array') {
+    const origin = opts.originDescription ?? 'input'
     throw new ConfigError(
-      'document has type array rather than object at file root (HOCON.md L989-991); the Config API requires an object root',
+      `${origin}: ${ast.pos.line}:${ast.pos.col}: document has type array rather than object at file root (HOCON.md L989-991); the Config API requires an object root`,
       '',
     )
   }

--- a/tests/conformance/array-root.test.ts
+++ b/tests/conformance/array-root.test.ts
@@ -24,14 +24,18 @@ const fixtureDir = fileURLToPath(
 )
 
 describe('S3.5 conformance — array-root fixtures (ar01-ar03) must error', () => {
-  if (!existsSync(fixtureDir)) {
+  // `make testdata` creates the group dir unconditionally, so dir existence
+  // alone is not evidence the fixtures landed — an empty dir must also skip,
+  // or the suite would silently pass with zero assertions executed.
+  const entries = existsSync(fixtureDir)
+    ? readdirSync(fixtureDir)
+        .sort()
+        .filter(f => f.endsWith('.conf') && !f.endsWith('-inner.conf'))
+    : []
+  if (entries.length === 0) {
     it.skip('fixtures unavailable — array-root group not synced (run `make testdata`)', () => {})
     return
   }
-
-  const entries = readdirSync(fixtureDir)
-    .sort()
-    .filter(f => f.endsWith('.conf') && !f.endsWith('-inner.conf'))
 
   for (const entry of entries) {
     it(`${entry} — array-at-file-root document errors (type error, not syntax)`, () => {

--- a/tests/conformance/array-root.test.ts
+++ b/tests/conformance/array-root.test.ts
@@ -1,0 +1,42 @@
+// tests/conformance/array-root.test.ts
+//
+// S3.5 conformance — xx.hocon fixture loop for array-root variants
+// (ar01-ar03). Each fixture ships a Lightbend-generated .error sidecar
+// (ConfigException$WrongType "has type LIST rather than object at file root");
+// per the .error-sidecar convention the conformance assertion is "an error is
+// raised" — the class pin (type error, not syntax error) lives in
+// tests/spec-s3-5-array-root.test.ts.
+//
+// ar03-inner.conf is a sibling include-target, not a standalone fixture
+// (see xx.hocon fixture-conventions §Sibling include-target files).
+//
+// Fixtures from: tests/lightbend/testdata/hocon/array-root/ (synced via
+// `make testdata`; the suite skips when the group is not yet synced).
+
+import { existsSync, readdirSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import { parseFile } from '../../src/index.js'
+
+const fixtureDir = fileURLToPath(
+  new URL('../lightbend/testdata/hocon/array-root', import.meta.url)
+)
+
+describe('S3.5 conformance — array-root fixtures (ar01-ar03) must error', () => {
+  if (!existsSync(fixtureDir)) {
+    it.skip('fixtures unavailable — array-root group not synced (run `make testdata`)', () => {})
+    return
+  }
+
+  const entries = readdirSync(fixtureDir)
+    .sort()
+    .filter(f => f.endsWith('.conf') && !f.endsWith('-inner.conf'))
+
+  for (const entry of entries) {
+    it(`${entry} — array-at-file-root document errors (type error, not syntax)`, () => {
+      const run = () => parseFile(join(fixtureDir, entry))
+      expect(run).toThrow(/array (at|rather than object at) file root/i)
+    })
+  }
+})

--- a/tests/spec-s3-5-array-root.test.ts
+++ b/tests/spec-s3-5-array-root.test.ts
@@ -1,0 +1,104 @@
+// tests/spec-s3-5-array-root.test.ts
+//
+// S3.5 — An array-root document (`[1,2]`) is syntactically valid HOCON
+// (HOCON.md L989-991: "both JSON and HOCON allow arrays as root values in a
+// document"), but the object-rooted Config API rejects it with a TYPE error
+// at the Config boundary, produced after a successful syntax parse.
+// Reference: Lightbend parses the document, then Parseable.forceParsedToObject
+// throws ConfigException.WrongType "has type LIST rather than object at file
+// root". The former behavior — ParseError "expected key, got lbracket" from
+// the parser — was the right net outcome (reject) as the wrong kind of error
+// at the wrong layer.
+//
+// S14b.1 (HOCON.md L993-994): an INCLUDED file with an array root is invalid;
+// the error names the included file (Lightbend applies the same WrongType via
+// the include loader).
+//
+// Fixtures: xx.hocon array-root/ar01-ar03 with .error sidecars (see
+// tests/conformance/array-root.test.ts for the fixture loop).
+
+import { describe, expect, it } from 'vitest'
+import { ConfigError, ParseError, ResolveError, parse, parseAsync } from '../src/index.js'
+
+describe('S3.5 — array-root document rejected with a type error (HOCON.md L989-991)', () => {
+  // --- Top-level: type error (ConfigError), not a syntax error ---
+
+  it('parse("[1,2]") throws ConfigError naming array-at-file-root', () => {
+    expect(() => parse('[1,2]')).toThrow(ConfigError)
+    expect(() => parse('[1,2]')).toThrow(/array rather than object at file root/i)
+  })
+
+  it('parse("[1,2]") does NOT throw ParseError (document is valid syntax)', () => {
+    try {
+      parse('[1,2]')
+      expect.unreachable('parse must throw')
+    } catch (e) {
+      expect(e).not.toBeInstanceOf(ParseError)
+    }
+  })
+
+  it('multiline array of objects also rejects with ConfigError', () => {
+    const src = '[\n  { a : 1 },\n  { b : 2 }\n]\n'
+    expect(() => parse(src)).toThrow(ConfigError)
+    expect(() => parse(src)).toThrow(/array rather than object at file root/i)
+  })
+
+  it('empty array root also rejects with ConfigError', () => {
+    expect(() => parse('[]')).toThrow(ConfigError)
+  })
+
+  it('async parse of array root rejects with ConfigError', async () => {
+    await expect(parseAsync('[1,2]')).rejects.toThrow(ConfigError)
+  })
+
+  // --- Malformed arrays remain syntax errors ---
+
+  it('unterminated array root stays a ParseError (syntax)', () => {
+    expect(() => parse('[1,2')).toThrow(ParseError)
+  })
+
+  it('trailing content after root array stays a ParseError (syntax)', () => {
+    expect(() => parse('[1,2]\na = 1')).toThrow(ParseError)
+  })
+
+  // --- S14b.1: included file with array root (L993-994) ---
+
+  const fileReader = (files: Record<string, string>) => (p: string) => {
+    const v = files[p.split('/').pop()!]
+    if (v === undefined) {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+    }
+    return v
+  }
+
+  it('include of array-root file throws ResolveError naming the included file', () => {
+    const files = { 'arr.conf': '[1,2]' }
+    const run = () => parse('include "arr.conf"\na = 1', { readFileSync: fileReader(files) })
+    expect(run).toThrow(ResolveError)
+    expect(run).toThrow(/array at file root/i)
+    expect(run).toThrow(/arr\.conf/)
+  })
+
+  it('include package of array-root content throws ResolveError naming the resolved path', () => {
+    const run = () =>
+      parse('include package("my-lib", "ref.conf")\na = 1', {
+        packageResolver: () => '/fake/pkg/ref.conf',
+        readFileSync: (p: string) => {
+          if (p === '/fake/pkg/ref.conf') return '[1,2]'
+          throw Object.assign(new Error(`ENOENT: ${p}`), { code: 'ENOENT' })
+        },
+      })
+    expect(run).toThrow(ResolveError)
+    expect(run).toThrow(/array at file root/i)
+  })
+
+  // --- Non-root arrays are unaffected (regression guards) ---
+
+  it('array as a field value still parses', () => {
+    expect(parse('a = [1,2]').get('a')).toEqual([1, 2])
+  })
+
+  it('braced root with array field still parses', () => {
+    expect(parse('{ a = [1,2] }').get('a')).toEqual([1, 2])
+  })
+})

--- a/tests/spec-s3-5-array-root.test.ts
+++ b/tests/spec-s3-5-array-root.test.ts
@@ -28,13 +28,24 @@ describe('S3.5 — array-root document rejected with a type error (HOCON.md L989
     expect(() => parse('[1,2]')).toThrow(/array rather than object at file root/i)
   })
 
+  it('type error carries the origin and the opening bracket position', () => {
+    expect(() => parse('[1,2]')).toThrow(/input: 1:1/)
+    expect(() => parse('\n  [1,2]', { originDescription: 'my-source' })).toThrow(/my-source: 2:3/)
+  })
+
+  it('deferred parse (resolveSubstitutions: false) also rejects with ConfigError', () => {
+    expect(() => parse('[1,2]', { resolveSubstitutions: false })).toThrow(ConfigError)
+  })
+
   it('parse("[1,2]") does NOT throw ParseError (document is valid syntax)', () => {
+    let caught: unknown
     try {
       parse('[1,2]')
-      expect.unreachable('parse must throw')
     } catch (e) {
-      expect(e).not.toBeInstanceOf(ParseError)
+      caught = e
     }
+    expect(caught).toBeDefined()
+    expect(caught).not.toBeInstanceOf(ParseError)
   })
 
   it('multiline array of objects also rejects with ConfigError', () => {
@@ -77,6 +88,31 @@ describe('S3.5 — array-root document rejected with a type error (HOCON.md L989
     expect(run).toThrow(ResolveError)
     expect(run).toThrow(/array at file root/i)
     expect(run).toThrow(/arr\.conf/)
+  })
+
+  it('include of array-root file (async) throws ResolveError — loadSingleAsync guard', async () => {
+    const files: Record<string, string> = { 'arr.conf': '[1,2]' }
+    const run = parseAsync('include "arr.conf"\na = 1', {
+      readFile: async (p: string) => {
+        const v = files[p.split('/').pop()!]
+        if (v === undefined) throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' })
+        return v
+      },
+    })
+    await expect(run).rejects.toThrow(ResolveError)
+    await expect(run).rejects.toThrow(/array at file root/i)
+  })
+
+  it('include package of array-root content (async) throws ResolveError — loadPackageAsync guard', async () => {
+    const run = parseAsync('include package("my-lib", "ref.conf")\na = 1', {
+      packageResolver: () => '/fake/pkg/ref.conf',
+      readFile: async (p: string) => {
+        if (p === '/fake/pkg/ref.conf') return '[1,2]'
+        throw Object.assign(new Error(`ENOENT: ${p}`), { code: 'ENOENT' })
+      },
+    })
+    await expect(run).rejects.toThrow(ResolveError)
+    await expect(run).rejects.toThrow(/array at file root/i)
   })
 
   it('include package of array-root content throws ResolveError naming the resolved path', () => {


### PR DESCRIPTION
## Summary

Implements S3.5 from [xx.hocon#64](https://github.com/o3co/xx.hocon/pull/64): an array-root document (`[1,2]`) is **syntactically valid HOCON** (HOCON.md L989-991: "both JSON and HOCON allow arrays as root values in a document"); the reference implementation parses it, then rejects at the Config boundary via `Parseable.forceParsedToObject` with `ConfigException.WrongType` "has type LIST rather than object at file root". Previously ts.hocon rejected with `ParseError` "expected key, got lbracket" — the right net outcome (reject) as the wrong kind of error at the wrong layer. Surfaced during the S3.1 review round; all four impls behaved identically.

## Changes

- **Parser** — new `[` root branch: parses the array value (anchored at the opening bracket); malformed arrays (`[1,2`) and trailing content after the root array remain `ParseError`s.
- **Config boundary** — `buildResolveContext()` rejects an array-root AST with `ConfigError` carrying origin + position: `input: 1:1: document has type array rather than object at file root (HOCON.md L989-991)`. Covers all entry points incl. the deferred lifecycle.
- **Include paths** — `assertObjectRootedInclude` at all 4 load paths (file + package, sync + async): `ResolveError` "included file has array at file root … (HOCON.md L993-994)" naming the included source — improves the S14b.1 diagnostic.
- **Makefile** — `make testdata` now syncs the `array-root/` fixture group (guarded until xx#64 merges).
- **Tests** — TDD RED→GREEN: type-error class + origin/position pins, NOT-ParseError pin, malformed/trailing guards, include + package variants (sync + async), deferred pin, non-root regression guards; conformance ar01–ar03 fixture loop (skip-guard until fixtures sync).
- **Docs** — spec-compliance S3.5 added (210 items) + S14b.1 notes; CHANGELOG.

**Net behavior unchanged** — array-root documents still error; only the error class, layer, and message change. No public API changes.

## Verification

- RED observed first (7 type-error expectations failing), GREEN: 1216 passed / 1 expected fail (pre-existing) / 7 skipped; `tsc --noEmit` clean; build clean.
- Multi-agent review (Claude + Codex): the Critical (Makefile sync gap), Important (async guards unpinned), and Codex P2 (source metadata on the type error) all addressed in the follow-up commit.

## Notes

- Reviewer observation relayed to xx.hocon: root-array concatenation (`[1] [2]`) is a candidate fixture (ar04) — currently a ParseError here; Lightbend behavior unprobed.
- Pre-existing (unchanged): `parseFile` does not default `originDescription` to the file path; explicit `originDescription` is honored in the new error.

## Cross-impl

go.hocon / rs.hocon / py.hocon PRs follow; matrix roll-up in xx.hocon once all four land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)