### PR TITLE
ci(release): publish via npm CLI — pnpm's registry PUT rejected under npm's new token policy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,4 +104,13 @@ jobs:
           make_latest: true
 
       - name: Publish
-        run: pnpm publish --access public --no-git-checks --provenance
+        # npm CLI, not pnpm: npm's trusted-publishing OIDC token exchange is
+        # first-class in the npm client. pnpm 10.30.2 (pinned via
+        # packageManager) signed provenance but its registry PUT was rejected
+        # with E403 once npm's July 2026 token-policy enforcement landed —
+        # v1.9.0 publish failed 3× despite a correctly configured Trusted
+        # Publisher (o3co/ts.hocon + release.yml) and the recommended
+        # "require 2FA and disallow tokens" publishing access. Provenance is
+        # generated automatically under trusted publishing; the explicit flag
+        # keeps the intent visible.
+        run: npm publish --access public --provenance


### PR DESCRIPTION
## Summary

v1.9.0's npm publish failed 3× with `E403 Forbidden` at the registry `PUT` — after provenance signing succeeded — despite a correctly configured Trusted Publisher (`o3co/ts.hocon` + `release.yml`) and switching the package's publishing access to the recommended "Require two-factor authentication and disallow tokens". v1.8.0 published fine on 2026-06-15 with the identical workflow and the same pinned `pnpm@10.30.2`, so the remaining variable is npm's July 2026 token-policy enforcement rejecting pnpm's publish path (its OIDC use covers provenance but evidently not the trusted-publishing token exchange the registry now requires).

## Change

`pnpm publish --access public --no-git-checks --provenance` → **`npm publish --access public --provenance`** — npm CLI implements the trusted-publishing OIDC exchange first-class (provenance is auto-generated under trusted publishing; the explicit flag keeps intent visible).

## Follow-up

After merge: re-push the `v1.9.0` tag at the updated tree so the Release workflow re-runs with the npm CLI publish step (npm has no 1.9.0 yet — no republish conflict; the existing GitHub Release is updated in place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)