### PR TITLE
fix(pkg): canonicalize repository.url for trusted-publishing exact match

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/o3co/ts.hocon"
+    "url": "git+https://github.com/o3co/ts.hocon.git"
   },
   "license": "Apache-2.0",
   "engines": {


### PR DESCRIPTION
npm requires `repository.url` to exactly match the repository for trusted publishing (docs §Supported CI/CD providers → repository URL matching). Ours was the non-canonical `https://github.com/o3co/ts.hocon`, auto-normalized by npm on every publish — suspected trigger of the all-paths E403 on v1.9.0. Canonicalized to `git+https://github.com/o3co/ts.hocon.git`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)