### PR TITLE
ci(release): force token auth for the fallback test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,7 +122,15 @@ jobs:
         # keeps the intent visible.
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public --provenance --loglevel verbose
+          # Force token auth: npm 11+ auto-detects the Actions OIDC env and
+          # prefers it over NODE_AUTH_TOKEN (verified in run 30005076744 —
+          # the exchange POST fired despite the token being set). Blanking
+          # the detection vars makes this run genuinely test the granular
+          # token. --provenance dropped for this path: sigstore needs the
+          # OIDC id-token we just disabled.
+          ACTIONS_ID_TOKEN_REQUEST_URL: ""
+          ACTIONS_ID_TOKEN_REQUEST_TOKEN: ""
+        run: npm publish --access public --loglevel verbose
 
       - name: Dump npm debug log on failure
         # Surfaces the OIDC trusted-publishing token exchange (npm redacts


### PR DESCRIPTION
Run 30005076744 proved npm 11+ prefers the Actions OIDC env over NODE_AUTH_TOKEN — the granular token was never exercised. Blanks the OIDC detection vars on the Publish step and drops --provenance for this path (sigstore needs the id-token). Completes the token-auth discriminator for the registry-403 investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)