### PR TITLE
ci(release): doc-canonical OIDC workflow with staged publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,22 +19,19 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@v6
         with:
           node-version: "24"
-          cache: pnpm
-          # Writes ~/.npmrc with an _authToken placeholder consumed via
-          # NODE_AUTH_TOKEN on the Publish step (granular access token,
-          # bypass-2FA). Temporary fallback while npm support investigates the
-          # registry-side E403 that rejects this package's OIDC
-          # trusted-publishing PUTs (exchange succeeds with 201; PUT 403 —
-          # see PR #156/#157/#158 diagnostics).
+          # Doc-canonical trusted-publishing setup (docs.npmjs.com
+          # /trusted-publishers §Step 2): registry-url set, no caching in
+          # release builds.
+          package-manager-cache: false
           registry-url: "https://registry.npmjs.org"
 
       - name: Set version from tag
@@ -120,9 +117,12 @@ jobs:
         # "require 2FA and disallow tokens" publishing access. Provenance is
         # generated automatically under trusted publishing; the explicit flag
         # keeps the intent visible.
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public --provenance --loglevel verbose
+        # Staged publishing via OIDC (docs §Step 2 example: `npm stage
+        # publish`): the direct-publish PUT has been rejected 403 by the
+        # registry across every auth class; staging submits for maintainer
+        # review instead of publishing directly — a maintainer then approves
+        # with 2FA (npm stage approve / npmjs.com Staged Packages tab).
+        run: npm stage publish --loglevel verbose
 
       - name: Dump npm debug log on failure
         # Surfaces the OIDC trusted-publishing token exchange (npm redacts


### PR DESCRIPTION
Aligns the Release workflow with the canonical trusted-publishing example (docs §Step 2): checkout@v6 / setup-node@v6 / registry-url / no release-build caching, and switches the publish to `npm stage publish` over pure OIDC. If the registry accepts staging where it rejected direct publishes, v1.9.0 lands in Staged Packages for a 2FA approve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)