### PR TITLE
ci(release): unset OIDC vars at shell level (runner ignores ACTIONS_* env overrides)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,15 +119,13 @@ jobs:
         # keeps the intent visible.
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          # Force token auth: npm 11+ auto-detects the Actions OIDC env and
-          # prefers it over NODE_AUTH_TOKEN (verified in run 30005076744 —
-          # the OIDC exchange fired despite the token being set). Blanking
-          # the detection vars makes this run genuinely exercise the granular
-          # access token. --provenance omitted: sigstore needs the OIDC
-          # id-token we just disabled.
-          ACTIONS_ID_TOKEN_REQUEST_URL: ""
-          ACTIONS_ID_TOKEN_REQUEST_TOKEN: ""
-        run: npm publish --access public --loglevel verbose
+        # Force token auth. Step-level env blanking of ACTIONS_ID_TOKEN_* is
+        # IGNORED by the runner (reserved prefix — run 30005827460 showed the
+        # idtoken fetch hitting a real URL despite blank overrides), so npm
+        # kept preferring OIDC. `env -u` unsets at the shell level, which the
+        # runner cannot reinject. --provenance omitted: sigstore needs the
+        # OIDC id-token we are removing.
+        run: env -u ACTIONS_ID_TOKEN_REQUEST_URL -u ACTIONS_ID_TOKEN_REQUEST_TOKEN npm publish --access public --loglevel verbose
 
       - name: Dump npm debug log on failure
         # Surfaces the OIDC trusted-publishing token exchange (npm redacts


### PR DESCRIPTION
Run 30005827460 proved step-env blanking of `ACTIONS_ID_TOKEN_REQUEST_*` is ignored by the runner (reserved prefix) — the idtoken fetch still hit a real URL and OIDC kept winning. `env -u` removes the vars at the shell level, making `NODE_AUTH_TOKEN` (granular token) the only credential. Completes the genuine token-auth discriminator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)