### PR TITLE
chore(release): 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-07-26
+
 ### Changed (behavior) — read this before upgrading
 
 Several fixes below change what previously "worked", always by refusing or


### PR DESCRIPTION
Cuts 1.11.0 from the merged fixes (#170).

**Why 1.11.0 and not 1.10.1.** By this package's own semver arithmetic it is a patch. The version is aligned across the four implementations, and go.hocon's release in this wave adds public API, so the whole line moves together.

**This release fixes a package that was unusable from CommonJS.** Every one of the seven published CJS entrypoints threw at load in 1.10.0. Anyone on `require()` should upgrade; anyone who worked around it can drop the workaround. CJS TypeScript consumers can now compile too — the `.d.cts` files shipped in 1.10.0 but nothing referenced them, so `node16` resolution hit TS1479.

**Behaviour changes are in this release**, and the CHANGELOG leads with them. Briefly: JSONC rejects documents it used to accept (fused tokens, trailing content), integers past int64 throw where they used to round silently, `APP_FOO.BAR` no longer nests, and `toObject()` output can now contain `__proto__`/`constructor`/`prototype` keys — the docs and SECURITY.md name the copy patterns that are unsafe with such an object, since `Object.assign` and naive deep-merge take their setter from the destination and the library cannot disarm them.

CHANGELOG only; package.json stays at 0.0.0-snapshot and the workflow sets the version from the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)