### PR TITLE
test(conformance): dispatch the properties format in the ingestion harness

### DIFF
--- a/tests/conformance/format-ingestion.test.ts
+++ b/tests/conformance/format-ingestion.test.ts
@@ -15,6 +15,7 @@ import { fileURLToPath } from 'node:url'
 import type { Config } from '../../src/config.js'
 import { loadEnv, parseDotEnv } from '../../src/adapters/env.js'
 import { parseJsonc } from '../../src/adapters/jsonc.js'
+import { parsePropertiesConfig } from '../../src/adapters/properties.js'
 import { parseTomlConfig } from '../../src/adapters/toml.js'
 import { parseYaml } from '../../src/adapters/yaml.js'
 
@@ -47,6 +48,8 @@ describe('format-ingestion fixtures (xx.hocon)', () => {
     switch (c.format) {
       case 'jsonc':
         return parseJsonc(text, c.id)
+      case 'properties':
+        return parsePropertiesConfig(text, c.id)
       case 'toml':
         return parseTomlConfig(text, c.id)
       case 'yaml':


### PR DESCRIPTION
Preparation for a new fixture group in xx.hocon.

The shared `format-ingestion` corpus is gaining `properties` cases — needed because F2.9 (`__proto__`, `constructor`, `prototype` survive as ordinary keys) **cannot be expressed through the env format**: `__proto__` begins and ends with the `__` separator, so it maps to empty segments in all four implementations.

This runner throws on an unknown format and the Makefile pins `TESTDATA_REF := main`, so the arm lands first. Until the fixtures merge it is unused.

`pnpm typecheck` clean; the conformance suite passes 16/16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)