### PR TITLE
docs: correct stale README/CONTRIBUTING claims and pin them with tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — documentation that had drifted away from the code
+
+Nothing was checking the README's factual claims, so they aged with each
+release. The ones that can be recomputed from a source of truth in this
+repository are now pinned by `tests/docs.test.ts`, which runs in the release
+workflow — a stale README fails the cut.
+
+- **"Stricter than Lightbend — S8.6 leading-hyphen rejection" described behavior
+  retracted in v1.3.0.** `a = -foo`, `a = -`, and (since v1.9.0) `a.-foo = 1`
+  all parse; the section told readers to quote values that need no quoting. The
+  E8 amendment and its retraction are already recorded in the [1.3.0] and
+  [1.9.0] sections, so the section is removed rather than rewritten.
+- **The compliance rates were a 2026-05-13 snapshot** (74.2% / 83.3%) against
+  the current 89.3% / 99.2%. They are now recomputed from the status glyphs in
+  `docs/spec-compliance.md` and compared against the table, so the two cannot
+  diverge again.
+- **`CONTRIBUTING.md` told contributors to release with `npm version`**, which
+  bumps `package.json` — the opposite of this repository's convention, where the
+  tag is the version and `package.json` stays at `0.0.0-snapshot` for CI to
+  overwrite. Following it produced exactly the PR that broke the v1.4.0 publish.
+- The node-config comparison now names the version it was checked against
+  (v4.4.2) and drops the editorializing lead-in.
+
 ## [1.11.0] - 2026-07-26
 
 ### Changed (behavior) — read this before upgrading

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,23 +59,28 @@ pnpm vitest run tests/lightbend/
 
 ## Releasing
 
-Releases are published to npm automatically by CI when a `v*` tag is pushed.
-Use `npm version` to do everything in one command:
+**The tag is the version.** `package.json` stays at `0.0.0-snapshot` on
+`develop`; the release workflow writes the real version from the tag before it
+publishes. Do not bump `package.json` in a PR — a release-prep PR that pre-sets
+it is what broke the v1.4.0 publish, and while the workflow now skips the bump
+when the two already agree, the manifest is still not where a version is
+decided.
+
+Releasing is therefore just a tag on a merged commit:
 
 ```bash
-npm version patch   # or: npm version minor / npm version major
-git push && git push --tags
+git checkout develop && git pull
+git tag v1.4.0
+git push origin v1.4.0
 ```
 
-`npm version` will:
+CI then runs the tests, sets the version from the tag, builds, publishes to npm,
+and creates the GitHub Release from the matching `## [1.4.0]` section of
+`CHANGELOG.md` — so that section has to exist and be committed *before* the tag
+is pushed, or the run fails without publishing.
 
-1. Bump the version in `package.json`
-2. Create a commit (`v0.1.4`)
-3. Tag it (`v0.1.4`)
-
-Then `git push --tags` triggers CI, which runs tests, builds, and publishes to npm.
-
-> **Do not** run `pnpm publish` locally — CI handles it and verifies the tag matches `package.json`.
+> **Do not** run `pnpm publish` locally — CI handles it, and npm does not allow
+> republishing a version.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -265,12 +265,12 @@ Supported byte units: `B`, `KB`/`KiB`, `MB`/`MiB`, `GB`/`GiB`, `TB`/`TiB` (and l
 
 ## Spec Compliance
 
-Conformance against the [Lightbend HOCON specification](https://github.com/lightbend/config/blob/main/HOCON.md) is tracked at item granularity in [`docs/spec-compliance.md`](docs/spec-compliance.md). The table below is a snapshot as of 2026-05-13; see [`xx.hocon/docs/compliance-matrix.md`](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) for live cross-impl values.
+Conformance against the [Lightbend HOCON specification](https://github.com/lightbend/config/blob/main/HOCON.md) is tracked at item granularity in [`docs/spec-compliance.md`](docs/spec-compliance.md), which is the source these rates are computed from — `tests/docs.test.ts` recomputes them and fails the build if this table drifts. See [`xx.hocon/docs/compliance-matrix.md`](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) for the cross-implementation roll-up.
 
 | Metric                                | Status        |
 | ------------------------------------- | ------------- |
-| Spec total (incl. out-of-scope)       | **74.2%**     |
-| In-scope only                         | **83.3%**     |
+| Spec total (incl. out-of-scope)       | **89.3%**     |
+| In-scope only                         | **99.2%**     |
 | Lightbend `test01`–`test13` suite     | 13/13 passing |
 
 **Extra-spec conventions (E-series) — implementation status:**
@@ -288,10 +288,6 @@ Not supported:
 Supported since v0.2.0 (P1):
 
 - `.properties` file parsing
-
-### Stricter than Lightbend
-
-- **S8.6 leading-hyphen rejection** (Unreleased): `a = -foo`, `a = -bar`, `a = -` etc. now raise a lex error per HOCON.md L270–276, where Lightbend silently falls back to unquoted strings. Mitigation: quote the value (`a = "-foo"`). See [CHANGELOG](CHANGELOG.md#unreleased) and [`docs/spec-compliance.md`](docs/spec-compliance.md) §S8.6.
 
 ## Performance
 
@@ -325,7 +321,7 @@ For typical application configs (loaded once at startup), the parsing cost is ne
 
 ### Feature Comparison with node-config
 
-ts.hocon provides significantly richer configuration capabilities compared to [node-config](https://github.com/node-config/node-config) (JSON):
+Feature-level comparison with [node-config](https://github.com/node-config/node-config) **v4.4.2** reading JSON config files, as of 2026-07-26:
 
 | Feature | ts.hocon | node-config (JSON) |
 |---|---|---|

--- a/tests/docs.test.ts
+++ b/tests/docs.test.ts
@@ -1,0 +1,143 @@
+// Copyright 2026 1o1 Co. Ltd.
+// SPDX-License-Identifier: Apache-2.0
+//
+// tests/docs.test.ts
+// The README states facts that go stale on their own: the compliance rates, the
+// minimum Node version, and "unreleased" markers left behind after the release
+// that shipped the behavior. Nothing else exercises them, so they only ever
+// drift in one direction. These tests recompute each from the artifact that
+// actually decides it — docs/spec-compliance.md and package.json — and run in
+// the release workflow, so a stale README fails the cut.
+
+import { describe, expect, it } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
+
+const read = (relative: string): string => readFileSync(join(repoRoot, relative), 'utf8')
+
+/**
+ * Number of S-items in the shared spec checklist
+ * (xx.hocon/docs/spec-checklist.md). Both compliance rates use it as the
+ * denominator, so a per-impl doc that drifted away from the checklist would
+ * silently change the rates; the count is asserted rather than derived.
+ */
+const SPEC_ITEM_TOTAL = 210
+
+// An S-item heading: "- **S13a.10** Some rule — §Section (L123)". E-items
+// (extra-spec conventions) use the same block shape but are not part of the
+// checklist, so the heading pattern is what separates them.
+const SPEC_ITEM_HEAD = /^\s*- \*\*(S[0-9A-Za-z._]+)\*\*/
+const OTHER_HEAD = /^\s*- \*\*[0-9A-Za-z._]+\*\*/
+const STATUS_LINE = /^\s*status:/
+
+interface ComplianceCounts {
+  pass: number
+  partial: number
+  fail: number
+  unverified: number
+  outOfScope: number
+}
+
+/**
+ * Tallies the status glyph of every S-item block in docs/spec-compliance.md.
+ * Only the first `status:` line after an S-item heading counts: a block may
+ * carry sub-bullets, and the E-item blocks that follow the S-items must not be
+ * picked up.
+ */
+function countCompliance(): ComplianceCounts {
+  const counts: ComplianceCounts = { pass: 0, partial: 0, fail: 0, unverified: 0, outOfScope: 0 }
+  let inSpecItem = false
+
+  for (const line of read('docs/spec-compliance.md').split('\n')) {
+    if (SPEC_ITEM_HEAD.test(line)) {
+      inSpecItem = true
+    } else if (OTHER_HEAD.test(line)) {
+      inSpecItem = false
+    } else if (inSpecItem && STATUS_LINE.test(line)) {
+      inSpecItem = false
+      if (line.includes('✅')) counts.pass++
+      else if (line.includes('⚠️')) counts.partial++
+      else if (line.includes('❌')) counts.fail++
+      else if (line.includes('🤷')) counts.unverified++
+      else if (line.includes('➖')) counts.outOfScope++
+      else throw new Error(`status line carries no known glyph: ${line.trim()}`)
+    }
+  }
+  return counts
+}
+
+const total = (c: ComplianceCounts): number =>
+  c.pass + c.partial + c.fail + c.unverified + c.outOfScope
+
+/** Rate to one decimal, matching how the README writes it. */
+const rate = (c: ComplianceCounts, denominator: number): string =>
+  (((c.pass + c.partial * 0.5) / denominator) * 100).toFixed(1)
+
+/**
+ * Returns the single capture group of `re`, throwing when the pattern no longer
+ * matches — a README rewrite that drops the claim must fail loudly rather than
+ * silently stop checking it.
+ */
+function findOne(text: string, re: RegExp, what: string): string {
+  const m = re.exec(text)
+  if (m === null) {
+    throw new Error(`${what} not found (pattern ${re}); update the pattern if the doc was restructured`)
+  }
+  return m[1]!
+}
+
+describe('docs consistency', () => {
+  it('docs/spec-compliance.md covers every checklist item', () => {
+    const counts = countCompliance()
+    expect(
+      total(counts),
+      'an item was added, dropped, or its status line is malformed',
+    ).toBe(SPEC_ITEM_TOTAL)
+    expect(counts.unverified, 'every item must be pinned by a test').toBe(0)
+  })
+
+  it('README compliance rates match docs/spec-compliance.md', () => {
+    const counts = countCompliance()
+    const readme = read('README.md')
+
+    const specTotal = findOne(
+      readme,
+      /\| Spec total \(incl\. out-of-scope\) +\| \*\*([0-9.]+)%\*\* +\|/,
+      'spec-total compliance rate',
+    )
+    const inScope = findOne(
+      readme,
+      /\| In-scope only +\| \*\*([0-9.]+)%\*\* +\|/,
+      'in-scope compliance rate',
+    )
+
+    expect(specTotal).toBe(rate(counts, SPEC_ITEM_TOTAL))
+    expect(inScope).toBe(rate(counts, SPEC_ITEM_TOTAL - counts.outOfScope))
+  })
+
+  it('README minimum Node version matches package.json engines', () => {
+    const engines = findOne(
+      read('package.json'),
+      /"node": ">=(\d+)"/,
+      'engines.node',
+    )
+    const claimed = findOne(
+      read('README.md'),
+      /Requires Node\.js (\d+)\+/,
+      'minimum Node version',
+    )
+    expect(claimed, 'a user on the version the README names cannot install this package').toBe(engines)
+  })
+
+  it('README does not mark shipped behavior as unreleased', () => {
+    const offenders = read('README.md')
+      .split('\n')
+      .map((line, i) => [i + 1, line] as const)
+      .filter(([, line]) => line.includes('(Unreleased)'))
+      .map(([n, line]) => `README.md:${n}: ${line.trim()}`)
+    expect(offenders).toEqual([])
+  })
+})


### PR DESCRIPTION
Nothing was checking the docs' factual claims, so they aged with each release.
The ones that can be recomputed from a source of truth in this repository are now
pinned by `tests/docs.test.ts`, which runs in the release workflow — so a stale
README fails the cut instead of shipping.

| Claim | Was | Is |
| --- | --- | --- |
| "Stricter than Lightbend — S8.6" | `a = -foo` is a lex error, quote to work around | Retracted in v1.3.0 (value position) and v1.9.0 (key position); both parse. The section told readers to quote values that need no quoting |
| Compliance rates | 74.2% / 83.3%, snapshot 2026-05-13 | 89.3% / 99.2% |
| `CONTRIBUTING.md` § Releasing | "use `npm version`", which bumps `package.json` | The tag is the version; `package.json` stays `0.0.0-snapshot` and CI writes it. Following the old text produced exactly the PR that broke the v1.4.0 publish |
| node-config comparison | undated, "significantly richer" lead-in | Names the version checked (v4.4.2) and drops the editorializing |

### What the test pins

- **Compliance rates** — recomputed from the status glyphs in `docs/spec-compliance.md`
  using the documented formula, and compared against the README table. The item
  count is asserted at 210 so a per-impl doc that drifts from the shared checklist
  fails rather than silently changing the rates.
- **Minimum Node version** — README claim vs `engines.node`.
- **`(Unreleased)` markers** — rejected outright, which is what would have caught
  the S8.6 section two releases ago.

Each check was mutation-tested: editing the README to reintroduce each drift makes
the corresponding test fail with a message naming both sides.

Companion PRs: o3co/go.hocon#171, and the same guard in rs.hocon and py.hocon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)