### PR TITLE
fix(adapters/yaml)!: refuse sibling keys that coincide, instead of last-wins (F5.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed — `adapters/yaml`: coinciding sibling keys were last-wins, not an error
 
-**BREAKING** (input previously accepted is now refused; quote the key you mean
-to keep distinct).
+**BREAKING** (input previously accepted is now refused; rename one of the two
+keys — quoting only helps where it changes the key text, as `0x10` → `"0x10"`
+does and `1` → `"1"` does not).
 
 `parseYaml("1: a\n'1': b\n")` returned `{"1":"b"}`. The integer key and the
 string key are distinct in YAML but have the same string form, so writing the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — `adapters/yaml`: coinciding sibling keys were last-wins, not an error
+
+**BREAKING** (input previously accepted is now refused; quote the key you mean
+to keep distinct).
+
+`parseYaml("1: a\n'1': b\n")` returned `{"1":"b"}`. The integer key and the
+string key are distinct in YAML but have the same string form, so writing the
+second dropped the first's value with nothing to show for it — the silent loss
+F5.3 exists to prevent. The same held for `~`/`"null"`, `true`/`"true"` and
+`0x10`/`"16"`, and for a `Map` handed to `fromYamlValue`
+([#171](https://github.com/o3co/ts.hocon/issues/171)).
+
+The document is now decoded with `mapAsMap`, so both keys survive the decode
+and one collision check covers the parse path and the injected-tree path
+alike. Which forms coincide is still the library's business — `1.0` resolves to
+the number `1` here and so does not meet the string `"1.0"`.
+
+**A null key now spells itself `"null"` rather than `""`**, which is what
+go.hocon, rs.hocon and py.hocon produce; `mapAsMap` keeps the key as `null`
+instead of the empty string the object form substitutes.
+
 ### Fixed — documentation that had drifted away from the code
 
 Nothing was checking the README's factual claims, so they aged with each

--- a/src/adapters/yaml.ts
+++ b/src/adapters/yaml.ts
@@ -64,7 +64,14 @@ export function parseYaml(input: string, originDescription?: string): Config {
     throw new ConfigError(`yaml: ${doc.errors[0]?.message ?? 'parse error'}`, '')
   }
 
-  return fromYamlValue(doc.toJS({ mapAsMap: false }), originDescription)
+  // mapAsMap, because F5.3 cannot be enforced on a plain object: `1:` and
+  // `"1":` are distinct YAML keys that both stringify to "1", and an object
+  // has already kept one of them by the time this function sees it — the other
+  // value is gone with nothing left to notice. A Map keeps both, so the
+  // collision is still there to be reported. It also keeps a null key as
+  // `null`; the object form turns it into "" rather than "null", which is the
+  // key the sibling implementations produce.
+  return fromYamlValue(doc.toJS({ mapAsMap: true }), originDescription)
 }
 
 /**
@@ -103,8 +110,10 @@ function convert(v: unknown, atPath: string): unknown {
     return v.toISOString()
   }
   if (v instanceof Map) {
-    // eemeli's mapAsMap shape; scalar keys stringify per F5.3.
+    // eemeli's mapAsMap shape, and the shape `parseYaml` asks for; scalar keys
+    // stringify per F5.3.
     const entries: [string, unknown][] = []
+    const seen = new Map<string, unknown>()
     for (const [k, e] of v) {
       if (k !== null && typeof k === 'object') {
         throw new ConfigError(
@@ -113,6 +122,21 @@ function convert(v: unknown, atPath: string): unknown {
         )
       }
       const key = String(k)
+      if (seen.has(key)) {
+        // Two source keys, one object key: the int 1 and the string "1", ~ and
+        // "null", 0x10 and "16". Writing the second would drop the first's
+        // value with nothing to show for it, so neither wins (spec F5.3). A Map
+        // iterates in insertion order, so this reports the same pair every run
+        // and names the keys in the order they were written.
+        throw new ConfigError(
+          `yaml: sibling mapping keys ${keyForm(seen.get(key))} and ${keyForm(k)} ` +
+            `both give the key "${key}"${atPath === '' ? '' : ` at "${atPath}"`}; ` +
+            `quote the one you mean to keep distinct, because one of the two ` +
+            `values would otherwise be lost (spec F5.3)`,
+          atPath,
+        )
+      }
+      seen.set(key, k)
       entries.push([key, convert(e, atPath === '' ? key : `${atPath}.${key}`)])
     }
     return Object.fromEntries(entries)
@@ -170,6 +194,16 @@ function bytesToBase64(bytes: Uint8Array): string {
     binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK))
   }
   return btoa(binary)
+}
+
+/**
+ * Render a source key for the F5.3 collision error: a string is quoted, every
+ * other scalar shows its type, so the int `1` and the string `"1"` stay apart
+ * in the message the way they failed to in the mapping.
+ */
+function keyForm(k: unknown): string {
+  if (typeof k === 'string') return JSON.stringify(k)
+  return `${String(k)} (${k === null ? 'null' : typeof k})`
 }
 
 const MAX_SAFE = BigInt(Number.MAX_SAFE_INTEGER)

--- a/src/adapters/yaml.ts
+++ b/src/adapters/yaml.ts
@@ -131,8 +131,9 @@ function convert(v: unknown, atPath: string): unknown {
         throw new ConfigError(
           `yaml: sibling mapping keys ${keyForm(seen.get(key))} and ${keyForm(k)} ` +
             `both give the key "${key}"${atPath === '' ? '' : ` at "${atPath}"`}; ` +
-            `quote the one you mean to keep distinct, because one of the two ` +
-            `values would otherwise be lost (spec F5.3)`,
+            `rename one of them, because one of the two values would otherwise ` +
+            `be lost. Quoting a non-string key helps only where that changes ` +
+            `the key text, as 0x10 does and 1 does not (spec F5.3)`,
           atPath,
         )
       }

--- a/tests/adapters/adapters.test.ts
+++ b/tests/adapters/adapters.test.ts
@@ -441,6 +441,12 @@ describe('yaml adapter', () => {
     expect(() => parseYaml(src)).toThrow(new RegExp(`both give the key ${key}`))
   })
 
+  it('does not tell the reader to quote a key when that cannot help (F5.3)', () => {
+    // Quoting turns `1:` into `'1':`, which gives the same key and so becomes a
+    // duplicate-key error instead. Renaming is the advice that always works.
+    expect(() => parseYaml("1: a\n'1': b\n")).toThrow(/rename one of them/)
+  })
+
   it('reports the path of a nested collision (F5.3)', () => {
     expect(() => parseYaml("outer:\n  1: a\n  '1': b\n")).toThrow(/at "outer"/)
   })

--- a/tests/adapters/adapters.test.ts
+++ b/tests/adapters/adapters.test.ts
@@ -424,6 +424,50 @@ describe('yaml adapter', () => {
     expect(fromYamlValue({ n: 42n }).getNumber('n')).toBe(42)
     expect(() => fromYamlValue({ huge: 9223372036854775808n })).toThrow(/int64/)
   })
+
+  // F5.3 — two source keys with one string form used to be last-wins, and the
+  // loser's value was gone with nothing to show for it. Which forms actually
+  // coincide is the library's business (`1.0` resolves to the number 1 here, so
+  // it does *not* meet the string "1.0"); what this pins is that a coincidence
+  // is an error rather than a silent loss.
+  it.each([
+    ['int and string', "1: a\n'1': b\n", '"1"'],
+    ['string and int', "'1': b\n1: a\n", '"1"'],
+    ['null and "null"', "~: a\n'null': b\n", '"null"'],
+    ['bool and "true"', "true: a\n'true': b\n", '"true"'],
+    ['hex and its decimal string', "0x10: a\n'16': b\n", '"16"'],
+  ])('refuses sibling keys that coincide — %s (F5.3)', (_name, src, key) => {
+    expect(() => parseYaml(src)).toThrow(/F5\.3/)
+    expect(() => parseYaml(src)).toThrow(new RegExp(`both give the key ${key}`))
+  })
+
+  it('reports the path of a nested collision (F5.3)', () => {
+    expect(() => parseYaml("outer:\n  1: a\n  '1': b\n")).toThrow(/at "outer"/)
+  })
+
+  // The other half: a key that only *looks* like it might collide still parses,
+  // and a non-string scalar key keeps its string form.
+  it('stringifies lone non-string keys instead of refusing them (F5.3)', () => {
+    expect(parseYaml('1: a\n').getString('"1"')).toBe('a')
+    expect(parseYaml('~: a\n').getString('"null"')).toBe('a')
+    expect(parseYaml('true: a\n').getString('"true"')).toBe('a')
+  })
+
+  // A null key used to reach the config as "" — the object form of toJS spells
+  // it that way — where go.hocon, rs.hocon and py.hocon all produce "null".
+  it('spells a null key "null", as the sibling implementations do (F5.3)', () => {
+    expect(parseYaml('~: a\n').keys()).toEqual(['null'])
+  })
+
+  it('detects a collision in an injected Map tree too (F5.3)', async () => {
+    const { fromYamlValue } = await import('../../src/adapters/yaml.js')
+    expect(() => fromYamlValue(new Map<unknown, unknown>([[1, 'a'], ['1', 'b']]))).toThrow(/F5\.3/)
+    // A Map whose keys have distinct string forms is still fine.
+    expect(fromYamlValue(new Map<unknown, unknown>([[1, 'a'], [2, 'b']])).keys().sort()).toEqual([
+      '1',
+      '2',
+    ])
+  })
 })
 
 describe('use as a substitution source under HOCON', () => {


### PR DESCRIPTION
Closes #171.

## The bug

`parseYaml("1: a\n'1': b\n")` returned `{"1":"b"}`. The integer key and the
string key are distinct in YAML but share a string form, so writing the second
dropped the first's value with nothing left to notice — the silent loss F5.3
exists to prevent.

## Which forms the `yaml` package actually collapses

The issue asked for this to be measured before choosing a fix shape. Under
`version: '1.2', merge: true, intAsBigInt: true`:

| document | before | after |
|---|---|---|
| `1: a` / `'1': b` | `{"1":"b"}` | F5.3 error |
| `'1': b` / `1: a` | `{"1":"a"}` | F5.3 error |
| `~: a` / `'null': b` | `{"":"a","null":"b"}` | F5.3 error |
| `true: a` / `'true': b` | `{"true":"b"}` | F5.3 error |
| `0x10: a` / `'16': b` | `{"16":"b"}` | F5.3 error |
| `1.0: a` / `'1.0': b` | `{"1":"a","1.0":"b"}` | unchanged — `1.0` resolves to the number `1`, which does not meet `"1.0"` |

Which forms coincide stays the library's answer (F5.1); what this pins is that
a coincidence is an error rather than a loss.

## Shape of the fix

`doc.toJS({ mapAsMap: true })` instead of `mapAsMap: false`. That is what makes
the check possible at all — a plain object has already kept one of the two keys
by the time `convert` sees it, which is why go.hocon had to walk the document
AST (o3co/go.hocon#165). A `Map` still holds both, so **one check covers the
parse path and the injected-tree path together**, and the "easier half" the
issue mentions is not a separate mechanism.

**Side effect worth calling out: a null key now spells itself `"null"`, not
`""`.** eemeli's object form of `toJS` substitutes the empty string for a null
key; go.hocon, rs.hocon and py.hocon all produce `"null"`. This closes that
divergence, and it is also what makes the `~` / `"null"` collision detectable.

## Cross-implementation check

The same seven documents were run against go.hocon, rs.hocon and py.hocon:

| document | go | rs | py | ts (after) |
|---|---|---|---|---|
| `1:` / `"1":` | error | **last-wins** | **last-wins** | error |
| `~:` / `"null":` | error | **last-wins** | **last-wins** | error |
| `0x10:` / `"16":` | error | **last-wins** | **last-wins** | error |
| nested | error | **last-wins** | **last-wins** | error |

So rs.hocon and py.hocon carry the same defect; both are filed separately and
fixed against this reading of F5.3. go.hocon is already correct.

Verified: `pnpm test` (1366 passed), `pnpm typecheck`, `pnpm build`.

## SemVer

`BREAKING` in the CHANGELOG under a minor: input previously accepted is now
refused. The workaround is to quote the key you mean to keep distinct.