### PR TITLE
docs(adapters/jsonc): pin accepting an unpaired surrogate as deliberate (F3.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Documented — `adapters/jsonc`: accepting an unpaired surrogate is deliberate (F3.5)
+
+No behaviour change. New spec item F3.5 makes an unpaired `\uXXXX` surrogate an
+error in the JSON family, and go.hocon, py.hocon and rs.hocon now refuse one
+([xx.hocon#75](https://github.com/o3co/xx.hocon/issues/75)). **This
+implementation keeps accepting it**, and that is recorded here and pinned by a
+test so it is not mistaken for an oversight.
+
+A JavaScript string is UTF-16, like Java's: it holds a lone surrogate natively
+and round-trips it. A Go or Rust string cannot hold one at all — go.hocon was
+silently substituting U+FFFD — and a Python `str` can hold one but cannot encode
+it as UTF-8, so all three refuse rather than defer the failure. Refusing here
+would be the spec overriding the host language rather than protecting anyone;
+the properties adapter already carries the same divergence under F2.8, and
+S1.2.6 is the class.
+
 ### Fixed — deeply nested input threw `RangeError`, outside the documented error contract
 
 **BREAKING** for one of the two halves (a mapped path over 64 segments is now

--- a/src/adapters/jsonc.ts
+++ b/src/adapters/jsonc.ts
@@ -24,6 +24,16 @@ import { depthError, guardStackDepth } from '../internal/depth.js'
  * the JS number model, as they do for HOCON's own literals, so read large
  * identifiers with `getString`.
  *
+ * **An unpaired `\uXXXX` surrogate is accepted here and refused by go.hocon,
+ * py.hocon and rs.hocon** (F3.5). That is deliberate, and the same divergence
+ * the properties adapter already carries under F2.8: a JavaScript string is
+ * UTF-16, like Java's, so it holds a lone surrogate natively and round-trips it.
+ * A Go or Rust string cannot hold one at all — Go silently substituted U+FFFD
+ * until F3.5 — and a Python `str` can hold one but cannot encode it as UTF-8,
+ * so all three refuse rather than defer the failure. Refusing here would mean
+ * this spec overriding the host language rather than protecting the user; see
+ * S1.2.6 for the class.
+ *
  * See docs/specs/format-ingestion-mapping.md items F3.x in the hocon scope.
  */
 export function parseJsonc(input: string, originDescription?: string): Config {

--- a/tests/adapters/adapters.test.ts
+++ b/tests/adapters/adapters.test.ts
@@ -600,3 +600,21 @@ describe('depth limits', () => {
     expect(() => guardStackDepth(() => (1.5).toFixed(101), depthError)).not.toThrow(ConfigError)
   })
 })
+
+// F3.5 — an unpaired surrogate is refused by go.hocon, py.hocon and rs.hocon,
+// and accepted here. Deliberate, and the same divergence the properties adapter
+// already carries under F2.8: a JavaScript string is UTF-16 like Java's and
+// holds a lone surrogate natively, so refusing would be the spec overriding the
+// host language rather than protecting anyone. Pinned so the next person to
+// read F3.5 does not "fix" it.
+describe('jsonc lone surrogates (F3.5 divergence)', () => {
+  it('keeps an unpaired surrogate, where the three siblings refuse it', () => {
+    expect(parseJsonc('{"a":"\\ud800"}').getString('a')).toBe('\ud800')
+    expect(parseJsonc('{"a":"\\udc00"}').getString('a')).toBe('\udc00')
+    expect(parseJsonc('{"\\ud800":1}').keys()).toEqual(['\ud800'])
+  })
+
+  it('still combines a valid pair into one astral codepoint', () => {
+    expect(parseJsonc('{"a":"\\ud83d\\ude00"}').getString('a')).toBe('\u{1f600}')
+  })
+})


### PR DESCRIPTION
Refs o3co/xx.hocon#75 — sibling of o3co/go.hocon#178 and o3co/py.hocon#29. Pinned as spec F3.5 in the hocon scope.

## Measured before pinning

| impl | `{"a":"\ud800"}` before | after |
|---|---|---|
| **go.hocon** | parses, value is **U+FFFD** — no error | F3.5 error |
| **py.hocon** | parses, keeps the lone surrogate; fails later at encode time | F3.5 error |
| rs.hocon | already refused (serde_json does) | unchanged |
| ts.hocon | parses, keeps it | **unchanged, deliberately** |

go.hocon's was the worst: the config held a character the document never
contained and nothing failed — the plausible-but-wrong output this spec ranks as
its worst failure mode.

## The rule (spec F3.5)

An unpaired `\uXXXX` surrogate in a JSON/JSONC document is an error, mirroring
F2.8 for `.properties` — the reasoning transfers verbatim and neither stdlib
decoder does it for us. Valid **pairs** still combine into the astral codepoint.
Keys are checked as well as values: a key no lookup can match is worse than a
value, not better.

**ts.hocon accepts and stays that way.** A JavaScript string is UTF-16 like
Java's and holds a lone surrogate natively; a Go or Rust string cannot hold one
at all, and a Python `str` can hold one but cannot encode it as UTF-8. Refusing
in ts would be the spec overriding the host language rather than protecting
anyone — the same S1.2.6-class divergence F2.8 already records for the
properties adapter.

Whether the **core parser** follows is deliberately out of scope: that is HOCON
source text, so an S-item, and the four disagree there too (py.hocon's core
accepts a lone surrogate *and* does not combine valid pairs).

## What changed here

**Nothing behavioural.** This is the implementation F3.5 exempts, and the PR
exists so that stays a decision rather than an accident: the module doc says
why, and a test pins the accepting behaviour so the next person to read F3.5 and
diff the four does not "fix" it.

Verified: `pnpm test` (1378 passed), `pnpm typecheck`.
