### PR TITLE
fix(adapters/env)!: filter by prefix before validating, and check the name (F1.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,12 @@ four implementations behaving identically by accident
   `OTHER__=x` was never checked at all. `load`'s contract already said which
   way this goes ("entries outside the prefix are never inspected", the F1.1
   principle); the two functions disagreeing was the actual inconsistency.
-- **`export` may be followed by any whitespace.** Matching the literal
+- **`export` may be followed by spaces or tabs.** Matching the literal
   `export ` missed a tab, so `export<TAB>FOO=bar` became the variable
-  `export<TAB>foo` — a key nothing would ever look up, produced silently. A
-  name that merely begins with `export` is still a name.
+  `export<TAB>foo` — a key nothing would ever look up, produced silently. Space
+  and tab specifically, matching what this dialect already trims on the value
+  side; anything else leaves `export` part of the name, where the rule below
+  refuses it. A name that merely begins with `export` is still a name.
 - **A name containing whitespace or `#` is an error.** F1.7's rule for values —
   an error naming the fix rather than a guess about the author's intent —
   applies to names too; both characters mean the line was mis-parsed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — `.env`: the prefix filter runs first, and names are validated (F1.7)
+
+**BREAKING both ways**: a line the prefix discards is no longer validated (so a
+`.env` that used to fail may now load), and a name containing whitespace or `#`
+is now refused (so one that used to load may now fail).
+
+Three things, all pinned by an amended spec F1.7 after cross-checking found all
+four implementations behaving identically by accident
+([xx.hocon#78](https://github.com/o3co/xx.hocon/issues/78)):
+
+- **The prefix filter moves ahead of validation.** The value was parsed before
+  the filter and the path mapped after it, so one check landed on each side —
+  `BAD=x # y` failed even when the caller only wanted `APP_*`, while
+  `OTHER__=x` was never checked at all. `load`'s contract already said which
+  way this goes ("entries outside the prefix are never inspected", the F1.1
+  principle); the two functions disagreeing was the actual inconsistency.
+- **`export` may be followed by any whitespace.** Matching the literal
+  `export ` missed a tab, so `export<TAB>FOO=bar` became the variable
+  `export<TAB>foo` — a key nothing would ever look up, produced silently. A
+  name that merely begins with `export` is still a name.
+- **A name containing whitespace or `#` is an error.** F1.7's rule for values —
+  an error naming the fix rather than a guess about the author's intent —
+  applies to names too; both characters mean the line was mis-parsed.
+  `FOO BAR=baz` and `FOO#x=1` used to become the keys `foo bar` and `foo#x`.
+  Deliberately narrower than a POSIX name grammar, which would reject
+  `APP_FOO.BAR` — a name F1.2 documents as valid.
+
 ### Documented — `adapters/jsonc`: accepting an unpaired surrogate is deliberate (F3.5)
 
 No behaviour change. New spec item F3.5 makes an unpaired `\uXXXX` surrogate an

--- a/src/adapters/env.ts
+++ b/src/adapters/env.ts
@@ -107,15 +107,19 @@ export function parseDotEnv(input: string, opts: EnvOptions = {}): Config {
   for (let i = 0; i < lines.length; i++) {
     const raw = (lines[i] ?? '').trim()
     if (raw === '' || raw.startsWith('#')) continue
-    const line = raw.startsWith('export ') ? raw.slice('export '.length) : raw
+    const line = stripExport(raw)
 
     const eq = line.indexOf('=')
     if (eq === -1) throw new ConfigError(`${origin}:${i + 1}: expected NAME=value`, '')
     const name = line.slice(0, eq).trim()
+    // The two checks before the filter are about the *line* rather than the
+    // entry: a line with no `=` is not a NAME=value pair at all, and an empty
+    // name gives nothing to compare the prefix against.
     if (name === '') throw new ConfigError(`${origin}:${i + 1}: empty variable name`, '')
-    const value = dotEnvValue(line.slice(eq + 1).replace(/^[ \t]+/, ''), origin, i + 1, name)
-
     if (!name.startsWith(prefix)) continue
+
+    checkName(name, origin, i + 1)
+    const value = dotEnvValue(line.slice(eq + 1).replace(/^[ \t]+/, ''), origin, i + 1, name)
     pairs.push([toPath(name.slice(prefix.length)), value])
   }
 
@@ -202,4 +206,40 @@ function dotEnvValue(v: string, origin: string, line: number, name: string): str
     fail(`ambiguous value "${trimmed}": trailing comments are not supported, so quote the value if the # belongs to it`)
   }
   return trimmed
+}
+
+/**
+ * Drop a leading `export` and the whitespace after it (spec F1.7).
+ *
+ * Matching the literal `'export '` missed a tab, so `export\tFOO=bar` became
+ * the variable `export\tfoo` — a key nothing would ever look up, produced
+ * silently. A name that merely *begins* with `export` (`exportFOO=1`) is still
+ * a name, so the whitespace is what makes it the keyword.
+ */
+function stripExport(line: string): string {
+  const m = /^export[ \t]+/.exec(line)
+  return m ? line.slice(m[0].length) : line
+}
+
+/**
+ * Refuse a name that cannot have been meant (spec F1.7).
+ *
+ * F1.7's rule for values is an error naming the fix rather than a guess about
+ * the author's intent; names get the same treatment. Whitespace or `#` inside
+ * one means the line was mis-parsed — `FOO BAR=baz` and `FOO#x=1` used to
+ * become the keys `foo bar` and `foo#x`.
+ *
+ * Deliberately narrower than a POSIX name grammar, which would reject
+ * `APP_FOO.BAR` — a name F1.2 documents as valid and the fixtures exercise.
+ */
+function checkName(name: string, origin: string, line: number): void {
+  const bad = /\s|#/.exec(name)
+  if (bad) {
+    const what = bad[0] === '#' ? "'#'" : 'whitespace'
+    throw new ConfigError(
+      `${origin}:${line}: variable name "${name}" contains ${what}; ` +
+        `the line is not NAME=value (spec F1.7)`,
+      name,
+    )
+  }
 }

--- a/src/adapters/env.ts
+++ b/src/adapters/env.ts
@@ -209,12 +209,17 @@ function dotEnvValue(v: string, origin: string, line: number, name: string): str
 }
 
 /**
- * Drop a leading `export` and the whitespace after it (spec F1.7).
+ * Drop a leading `export` and the spaces or tabs after it (spec F1.7).
  *
  * Matching the literal `'export '` missed a tab, so `export\tFOO=bar` became
  * the variable `export\tfoo` — a key nothing would ever look up, produced
  * silently. A name that merely *begins* with `export` (`exportFOO=1`) is still
  * a name, so the whitespace is what makes it the keyword.
+ *
+ * Space and tab specifically, not `\s`: that is what this dialect already trims
+ * on the value side. Leaving the rest out is also the better outcome —
+ * `export\fFOO=bar` is then a *name* of `export\fFOO`, which `checkName`
+ * refuses, rather than a keyword line producing a silently odd key.
  */
 function stripExport(line: string): string {
   const m = /^export[ \t]+/.exec(line)

--- a/tests/adapters/adapters.test.ts
+++ b/tests/adapters/adapters.test.ts
@@ -618,3 +618,48 @@ describe('jsonc lone surrogates (F3.5 divergence)', () => {
     expect(parseJsonc('{"a":"\\ud83d\\ude00"}').getString('a')).toBe('\u{1f600}')
   })
 })
+
+// F1.7 — the prefix filter runs first, and only what survives it is validated.
+//
+// A .env shared with tools that support trailing comments has to stay loadable
+// when the caller wants one namespace out of it. `loadEnv` already worked that
+// way ("entries outside the prefix are never inspected", F1.1); `parseDotEnv`
+// disagreeing with its sibling in the same module was the actual
+// inconsistency, and all four implementations had the same accidental split.
+describe('dotenv name and filter rules (F1.7)', () => {
+  it.each([
+    ['an ambiguous value', 'BAD=x # y\n'],
+    ['a name the rule refuses', 'BAD NAME=x\n'],
+    ['an empty path segment', 'OTHER__=x\n'],
+  ])('does not inspect %s the prefix discards', (_name, src) => {
+    expect(parseDotEnv(src, { prefix: 'APP_' }).keys()).toEqual([])
+  })
+
+  it('still validates what the prefix keeps', () => {
+    expect(() => parseDotEnv('APP_BAD=x # y\n', { prefix: 'APP_' })).toThrow(/quote the value/)
+    expect(() => parseDotEnv('APP___=x\n', { prefix: 'APP_' })).toThrow(/empty path segment/)
+  })
+
+  // `'export '` matched a single space only, so `export\tFOO=bar` became the
+  // variable `export\tfoo` — a key nothing would look up, produced silently.
+  it('accepts any whitespace after export', () => {
+    for (const src of ['export FOO=bar\n', 'export\tFOO=bar\n', 'export  FOO=bar\n']) {
+      expect(parseDotEnv(src).getString('foo')).toBe('bar')
+    }
+    // …and a name that merely begins with `export` is still a name.
+    expect(parseDotEnv('exportFOO=bar\n').getString('exportfoo')).toBe('bar')
+  })
+
+  it.each([
+    ['whitespace', 'FOO BAR=baz\n'],
+    ['a hash', 'FOO#x=1\n'],
+  ])('refuses a name containing %s', (_what, src) => {
+    expect(() => parseDotEnv(src)).toThrow(/F1\.7/)
+  })
+
+  // Deliberately narrower than a POSIX name grammar, which would reject this —
+  // a name F1.2 documents as valid (one key `"foo.bar"`, not nesting).
+  it('still accepts a dotted name', () => {
+    expect(parseDotEnv('FOO.BAR=v\n').getString('"foo.bar"')).toBe('v')
+  })
+})

--- a/tests/adapters/adapters.test.ts
+++ b/tests/adapters/adapters.test.ts
@@ -642,12 +642,15 @@ describe('dotenv name and filter rules (F1.7)', () => {
 
   // `'export '` matched a single space only, so `export\tFOO=bar` became the
   // variable `export\tfoo` — a key nothing would look up, produced silently.
-  it('accepts any whitespace after export', () => {
+  it('accepts spaces and tabs after export, and nothing else', () => {
     for (const src of ['export FOO=bar\n', 'export\tFOO=bar\n', 'export  FOO=bar\n']) {
       expect(parseDotEnv(src).getString('foo')).toBe('bar')
     }
     // …and a name that merely begins with `export` is still a name.
     expect(parseDotEnv('exportFOO=bar\n').getString('exportfoo')).toBe('bar')
+    // A form feed is not one of the two, so `export` stays part of the name and
+    // the F1.7 name rule rejects it. That is the intended outcome, not a gap.
+    expect(() => parseDotEnv('export\fFOO=bar\n')).toThrow(/F1\.7/)
   })
 
   it.each([


### PR DESCRIPTION
One of four sibling PRs. Closes the code half of o3co/xx.hocon#78 and parts 1–2
of o3co/py.hocon#19; spec F1.7 is amended in the hocon scope.

## Why this needed a decision rather than a fix

Cross-checking parts 1 and 2 of py.hocon#19 found **all four implementations
behaving identically**: the value parsed *before* the prefix filter, the path
mapped *after* it. Neither placement was chosen — the split was an accident, and
the same accident everywhere. Fixing one implementation would have manufactured
a divergence rather than removing one.

| input | all four, before | all four, after |
|---|---|---|
| `parse_dotenv("BAD=x # y\n", prefix="APP_")` | raises | accepted, discarded |
| `parse_dotenv("BAD NAME=x\n", prefix="APP_")` | key `bad name` | discarded |
| `parse_dotenv("OTHER__=x\n", prefix="APP_")` | accepted, unchecked | accepted, discarded |
| `parse_dotenv("APP_BAD=x # y\n", prefix="APP_")` | raises | raises |
| `parse_dotenv("export\tFOO=bar\n")` | key `export\tfoo` | key `foo` |
| `parse_dotenv("FOO BAR=baz\n")` | key `foo bar` | F1.7 error |
| `parse_dotenv("FOO#x=1\n")` | key `foo#x` | F1.7 error |
| `parse_dotenv("FOO.BAR=v\n")` | key `foo.bar` | unchanged |

## The three rules

**Filter first.** A `.env` shared with tools that support trailing comments must
stay loadable when you want one namespace out of it. `load`'s own contract
already said which way this goes — *"entries outside the prefix are never
inspected"*, the F1.1 principle — so `parse_dotenv` disagreeing with its sibling
in the same module was the real inconsistency. Two checks stay ahead of the
filter, because they are about the *line* rather than the entry: a line with no
`=` is not a `NAME=value` pair at all, and an empty name gives nothing to
compare the prefix against.

**`export` takes any whitespace.** Matching the literal `export ` missed a tab,
so `export<TAB>FOO=bar` became the variable `export<TAB>foo` — silently. A name
that merely *begins* with `export` (`exportFOO=1`) is still a name.

**A name with whitespace or `#` is an error.** F1.7's stated rule for values is
an error naming the fix rather than a guess about the author's intent; names had
been getting the guess. Deliberately narrower than a POSIX name grammar
(`[A-Za-z_][A-Za-z0-9_]*`), which would reject `APP_FOO.BAR` — a name F1.2
documents as valid and which the shared fixtures exercise.

## SemVer

`BREAKING` **in both directions**, and the CHANGELOG says so: a `.env` that used
to fail may now load (the filter discards it before validation), and one that
used to load may now fail (the name rule). Minor, per the spec-correction rule.
