### PR TITLE
docs(adapters): cite the F-item spec at its public location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,17 @@ workflow — a stale README fails the cut.
 - The node-config comparison now names the version it was checked against
   (v4.4.2) and drops the editorializing lead-in.
 
+### Fixed — the F-item spec citations pointed at a document readers cannot open
+
+Three adapter doc comments and the fixture manifest cited
+`docs/specs/format-ingestion-mapping.md`, which is not in this repository — it
+lived in a private working scope. The adapters raise errors that name items from
+it (`(spec F0.5)`, `(spec F1.6)`), so anyone following a citation reached
+nothing. The spec is now published at
+[`xx.hocon/docs/format-ingestion-mapping.md`](https://github.com/o3co/xx.hocon/blob/main/docs/format-ingestion-mapping.md) and every citation points
+there ([xx.hocon#81](https://github.com/o3co/xx.hocon/issues/81)). Error text is
+unchanged; only the pointers move.
+
 ## [1.11.0] - 2026-07-26
 
 ### Changed (behavior) — read this before upgrading

--- a/src/adapters/jsonc.ts
+++ b/src/adapters/jsonc.ts
@@ -34,7 +34,8 @@ import { depthError, guardStackDepth } from '../internal/depth.js'
  * this spec overriding the host language rather than protecting the user; see
  * S1.2.6 for the class.
  *
- * See docs/specs/format-ingestion-mapping.md items F3.x in the hocon scope.
+ * See the F3.x items in the format-ingestion mapping spec:
+ * https://github.com/o3co/xx.hocon/blob/main/docs/format-ingestion-mapping.md
  */
 export function parseJsonc(input: string, originDescription?: string): Config {
   // JSON.parse recurses per level and gives out before anything here does, so

--- a/src/adapters/toml.ts
+++ b/src/adapters/toml.ts
@@ -16,7 +16,8 @@ import { depthError, guardStackDepth } from '../internal/depth.js'
  * the safe-integer range is an error here rather than silently rounded — go's
  * adapter accepts those, its int64 being wide enough (spec F0.5).
  *
- * See docs/specs/format-ingestion-mapping.md items F4.x in the hocon scope.
+ * See the F4.x items in the format-ingestion mapping spec:
+ * https://github.com/o3co/xx.hocon/blob/main/docs/format-ingestion-mapping.md
  */
 export function parseTomlConfig(input: string, originDescription?: string): Config {
   const doc = parseToml(stripBom(input)) as Record<string, unknown>

--- a/src/adapters/yaml.ts
+++ b/src/adapters/yaml.ts
@@ -34,7 +34,8 @@ import { depthError, guardStackDepth } from '../internal/depth.js'
  * than rounded. `getNumber` and `toObject` still apply the JS number model, so
  * read large identifiers with `getString`.
  *
- * See docs/specs/format-ingestion-mapping.md items F5.x in the hocon scope.
+ * See the F5.x items in the format-ingestion mapping spec:
+ * https://github.com/o3co/xx.hocon/blob/main/docs/format-ingestion-mapping.md
  */
 export function parseYaml(input: string, originDescription?: string): Config {
   // version is declared rather than defaulted. The same library returns 8 for

--- a/tests/lightbend/testdata/format-ingestion/manifest.json
+++ b/tests/lightbend/testdata/format-ingestion/manifest.json
@@ -1,6 +1,6 @@
 {
   "about": [
-    "Fixtures for the format adapters (docs/specs/format-ingestion-mapping.md, F-items).",
+    "Fixtures for the format adapters (docs/format-ingestion-mapping.md, F-items).",
     "",
     "Unlike expected/hocon/, these expectations are NOT generated from Lightbend.",
     "Lightbend has no equivalent of these adapters, so there is no oracle: the",


### PR DESCRIPTION
Part of o3co/xx.hocon#81. Depends on o3co/xx.hocon#82 — the URL resolves once that is on `main`.

**The problem**: these citations pointed at `docs/specs/format-ingestion-mapping.md`, which is **not in this repository**. It lived only in a private working scope, and the `in the hocon scope` qualifier named a place the reader still could not reach. The adapters raise errors that cite items from it — `(spec F0.5)`, `(spec F1.6)`, `(spec F3.5)` — so following one led nowhere.

**The change**: every citation now points at <https://github.com/o3co/xx.hocon/blob/main/docs/format-ingestion-mapping.md>.

**Error text is unchanged** — items were always cited by number, never by path, so nothing user-visible moves except where the number resolves.

Four places: the `jsonc` / `toml` / `yaml` adapter doc comments, and `tests/lightbend/testdata/format-ingestion/manifest.json`. The manifest's `about` line is set to the same relative path xx.hocon now uses, so it matches what the testdata sync will fetch rather than drifting back.

## Test plan

- `pnpm typecheck` — clean
- `pnpm build` — clean
- `pnpm vitest run tests/adapters tests/docs.test.ts` — 84 passed

The full `pnpm test` needs the downloaded conformance fixtures, which a fresh worktree does not have; unaffected by this change and green in CI, which syncs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)