### PR TITLE
fix(adapters/env): pin F1.7 name whitespace to Unicode White_Space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,6 +143,25 @@ nothing. The spec is now published at
 there ([xx.hocon#81](https://github.com/o3co/xx.hocon/issues/81)). Error text is
 unchanged; only the pointers move.
 
+### Fixed — `.env`: "whitespace" in a name is the Unicode `White_Space` property (F1.7)
+
+`checkName` used `/\s/`, which is **not** the `White_Space` property:
+enumerated over the whole codepoint space, `\s` is `White_Space` minus U+0085
+(NEL) plus U+FEFF. So `FOO<NEL>BAR=baz` produced the key `foo<NEL>bar` here and
+raised in the other three implementations, whose `unicode.IsSpace` /
+`char::is_whitespace` / `str.isspace` all have NEL.
+
+Whether a name is refused must not depend on which helper an implementation
+reached for; this is the same argument F1.3 makes for ASCII-only case folding.
+The spec now pins the property
+([xx.hocon#81](https://github.com/o3co/xx.hocon/issues/81)) and `checkName` uses
+`/\p{White_Space}/u`. Two changes, in opposite directions: a name containing
+U+0085 now throws, and a name containing U+FEFF no longer does — F0.9 already
+removes the realistic BOM case, and the property is what the spec cites.
+
+The behaviour being corrected has not been released; the name rule itself
+arrived in this same unreleased window.
+
 ## [1.11.0] - 2026-07-26
 
 ### Changed (behavior) — read this before upgrading

--- a/src/adapters/env.ts
+++ b/src/adapters/env.ts
@@ -236,9 +236,17 @@ function stripExport(line: string): string {
  *
  * Deliberately narrower than a POSIX name grammar, which would reject
  * `APP_FOO.BAR` — a name F1.2 documents as valid and the fixtures exercise.
+ *
+ * `\p{White_Space}` rather than `\s`, because the two are not the same set and
+ * F1.7 pins the Unicode property. Enumerated over the whole codepoint space
+ * (2026-07-31), `\s` is `White_Space` minus U+0085 (NEL) plus U+FEFF, so `\s`
+ * let a NEL through as an ordinary name character — Go, Rust and Python all
+ * refused it — and refused U+FEFF, which the property does not call space.
+ * Whether a name is refused must not depend on which helper the implementation
+ * reached for; same argument F1.3 makes for ASCII-only case folding.
  */
 function checkName(name: string, origin: string, line: number): void {
-  const bad = /\s|#/.exec(name)
+  const bad = /\p{White_Space}|#/u.exec(name)
   if (bad) {
     const what = bad[0] === '#' ? "'#'" : 'whitespace'
     throw new ConfigError(

--- a/tests/adapters/adapters.test.ts
+++ b/tests/adapters/adapters.test.ts
@@ -660,6 +660,25 @@ describe('dotenv name and filter rules (F1.7)', () => {
     expect(() => parseDotEnv(src)).toThrow(/F1\.7/)
   })
 
+  // F1.7 pins "whitespace" in a name to the Unicode White_Space property rather
+  // than to whichever predicate a stdlib offers, because the four do not agree.
+  // Enumerated over the whole codepoint space on 2026-07-31:
+  //
+  //   Go   unicode.IsSpace     == White_Space
+  //   Rust char::is_whitespace == White_Space
+  //   Py   str.isspace         == White_Space + U+001C..U+001F
+  //   JS   regex \s            == White_Space - U+0085 + U+FEFF
+  //
+  // JS is the outlier that accepted too much, so U+0085 is the case that
+  // changes here: it used to become an ordinary name character.
+  it('treats name whitespace as the Unicode White_Space property', () => {
+    // U+0085 NEL is White_Space, so the name is a mis-parse and refused.
+    expect(() => parseDotEnv('FOO\u0085BAR=baz\n')).toThrow(/F1\.7/)
+    // U+FEFF is not White_Space, whatever `\s` says — F0.9 already removes the
+    // realistic case, a leading BOM.
+    expect(parseDotEnv('FOO\uFEFFBAR=baz\n').getString('"foo\uFEFFbar"')).toBe('baz')
+  })
+
   // Deliberately narrower than a POSIX name grammar, which would reject this —
   // a name F1.2 documents as valid (one key `"foo.bar"`, not nesting).
   it('still accepts a dotted name', () => {

--- a/tests/conformance/format-ingestion.test.ts
+++ b/tests/conformance/format-ingestion.test.ts
@@ -26,6 +26,8 @@ type Case = {
   format: string
   input: string
   kind?: string
+  /** dotenv only; an env-vars input names its prefix inside the JSON document. */
+  prefix?: string
   expect: 'ok' | 'error'
   expected?: string
   cites?: string
@@ -55,7 +57,8 @@ describe('format-ingestion fixtures (xx.hocon)', () => {
       case 'yaml':
         return parseYaml(text, c.id)
       case 'env': {
-        if (c.kind === 'dotenv') return parseDotEnv(text, { originDescription: c.id })
+        if (c.kind === 'dotenv')
+          return parseDotEnv(text, { prefix: c.prefix ?? '', originDescription: c.id })
         const f = JSON.parse(text) as { prefix: string; vars: Record<string, string> }
         return loadEnv({ prefix: f.prefix, env: f.vars, originDescription: c.id })
       }


### PR DESCRIPTION
## What the cross-check found

The four `.env` name checks each used their host stdlib's whitespace predicate. Enumerated over the whole codepoint space (2026-07-31), those four are **not the same set**:

| implementation | predicate | set |
|---|---|---|
| go.hocon | `unicode.IsSpace` | `White_Space` |
| rs.hocon | `char::is_whitespace` | `White_Space` |
| py.hocon | `str.isspace` | `White_Space` **+ U+001C–U+001F** |
| ts.hocon | `/\s/` | `White_Space` **− U+0085** **+ U+FEFF** |

So the same `.env` got different answers:

- `FOO<NEL>BAR=baz` — an error in go / rs / py, the key `foo<NEL>bar` in ts.
- `FOO<US>BAR=baz` — an error in py only.

F1.7 said "a name containing whitespace … is an error" without saying what whitespace is, which is exactly the hole F1.3 exists to close for case folding: **whether a name is refused must not depend on which stdlib helper the implementation reached for.**

## The fix

F1.7 now pins the Unicode `White_Space` property (spec amended in the sibling xx.hocon PR). U+FEFF is deliberately *not* whitespace — F0.9 already removes the realistic case, a leading BOM, and a citable definition beats hand-listing invisible codepoints.

**This is not a released behaviour.** The name rule itself landed in this same unreleased 1.12.0 window, so pinning its edge now costs users nothing; after the tag it would be a second breaking change.

## Also here

The fixture runner now reads a `dotenv` case's optional `prefix`. xx.hocon's new `fi18-dotenv-prefix` needs it, and a runner that ignores it **fails** that case rather than passing it vacuously — the line the case expects to be filtered away is one the dialect otherwise refuses.

## ts specifically

**This repo is the outlier that accepts too much**, and the change moves in both directions:

- a name containing **U+0085** now throws (it used to become an ordinary key character — the divergence that started this)
- a name containing **U+FEFF** no longer throws, because the property does not call it space

`checkName` now uses `/\p{White_Space}|#/u` instead of `/\s|#/`.

Related: this also corrects a factual claim in xx.hocon's `extra-spec-conventions.md` E1, which asserted that ECMAScript `\s` includes NEL. It does not.

## Test plan

- `pnpm typecheck` clean, `pnpm build` clean
- `pnpm vitest run tests/adapters` — 81 passed
- fixture runner against the unmerged xx.hocon fixtures (copied in locally, then reverted) — 28 cases pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)