### PR TITLE
fix(parser): S3.4 — turn an unbalanced } after an unbraced root into a ParseError (reaching in-scope 100%)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **BREAKING (spec fix, S3.4)**: an unbraced root followed by an unbalanced
+  `}` — e.g. `a = 1` on one line and a stray `}` on the next — now raises
+  `ParseError` instead of being silently accepted with the trailing tokens
+  ignored (#55). The braced-root and array-root paths already rejected this;
+  only the unbraced-root path skipped the end-of-input check. A document that
+  relied on the old behaviour has an unbalanced brace to delete.
+- Spec-compliance bookkeeping: S13a.3 was recorded as ⚠️ from a stale
+  2026-05-13 probe, but the #120 self-reference widening had already routed
+  `a = ${a}` (no prior value) to the spec's "undefined" classification
+  (`could not resolve substitution`), distinct from a genuine cycle's
+  `circular substitution`. Both classifications are now pinned by tests, and
+  with S3.4 fixed the in-scope compliance rate is **100.0%** (spec-total
+  90.0%). `tests/docs.test.ts` now also gates README.ja.md's compliance
+  table, which had drifted 15+ points.
+
 ## [1.12.0] - 2026-07-31
 
 Cross-impl release, coordinated to land at v1.12.0 across go.hocon / ts.hocon /

--- a/README.ja.md
+++ b/README.ja.md
@@ -193,18 +193,17 @@ description = """
 
 ## 仕様準拠
 
-[Lightbend HOCON 仕様](https://github.com/lightbend/config/blob/main/HOCON.md) への準拠状況は [`docs/spec-compliance.md`](docs/spec-compliance.md) に項目単位で記載しています。以下の表は 2026-05-13 時点のスナップショットです — 最新値は [`xx.hocon/docs/compliance-matrix.md`](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) を参照してください。
+[Lightbend HOCON 仕様](https://github.com/lightbend/config/blob/main/HOCON.md) への準拠状況は [`docs/spec-compliance.md`](docs/spec-compliance.md) に項目単位で記載しており、以下の表はそこから計算されます — `tests/docs.test.ts` が再計算し、表がずれるとビルドが fail します。実装横断のロールアップは [`xx.hocon/docs/compliance-matrix.md`](https://github.com/o3co/xx.hocon/blob/main/docs/compliance-matrix.md) を参照してください。
 
 | 指標                                   | 状況          |
 | -------------------------------------- | ------------- |
-| 仕様全体（out-of-scope を含む）        | **74.2%**     |
-| In-scope のみ                          | **83.3%**     |
+| 仕様全体（out-of-scope を含む）        | **90.0%**     |
+| In-scope のみ                          | **100.0%**    |
 | Lightbend `test01`–`test13` テスト群   | 13/13 合格    |
 
-v0.1.0 で未対応の機能:
+未対応の機能:
 - `include url(...)`
 - `include classpath(...)`
-- `.properties` ファイルのパース
 
 ## パフォーマンス
 

--- a/README.md
+++ b/README.md
@@ -269,8 +269,8 @@ Conformance against the [Lightbend HOCON specification](https://github.com/light
 
 | Metric                                | Status        |
 | ------------------------------------- | ------------- |
-| Spec total (incl. out-of-scope)       | **89.3%**     |
-| In-scope only                         | **99.2%**     |
+| Spec total (incl. out-of-scope)       | **90.0%**     |
+| In-scope only                         | **100.0%**    |
 | Lightbend `test01`–`test13` suite     | 13/13 passing |
 
 **Extra-spec conventions (E-series) — implementation status:**

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -84,8 +84,11 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
   tests: tests/lightbend/testdata/equiv01/no-root-braces.conf (fixture)
   status: ✅
 - **S3.4** Unbalanced trailing `}` without opening `{` is invalid — §Omit root braces (L138)
-  tests: tests/parser.test.ts:234
-  status: ❌ ([#55](https://github.com/o3co/ts.hocon/issues/55)) — related test passes but specific case (unbraced root + stray `}`) is not covered
+  tests: tests/parser.test.ts (S3.4 test group)
+  status: ✅ — Fixed 2026-08-17 ([#55](https://github.com/o3co/ts.hocon/issues/55)): the
+  unbraced-root parse path now verifies all tokens were consumed, so a stray `}` (or any
+  other trailing token) after unbraced root content is a ParseError. The braced-root and
+  array-root paths already validated this.
 - **S3.5** Array-root document is valid syntax; object-rooted parse API rejects with a type error — §Include semantics: merging (L989-991)
   tests: tests/spec-s3-5-array-root.test.ts; tests/conformance/array-root.test.ts (ar01–ar03 `.error` sidecars)
   status: ✅ — Added 2026-07-23. `Parser.parse()` accepts `[` at root and parses the array
@@ -400,13 +403,13 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
   status: ✅
 - **S13a.3** Self-ref before any prior value → undefined → error — §Self-Referential (L767)
   tests: tests/resolver.test.ts (S13a.3 describe block)
-  status: ⚠️
-  notes: `a = ${a}` (no prior value) raises `ResolveError("circular substitution: a")`.
-  An error is raised (correct), but spec L767-773 says this case should be treated as
-  "undefined" (i.e. a missing-substitution error), not an "intractable cycle" error.
-  The distinction matters for error messages and for `${?a}` handling (which the impl
-  already handles correctly via separate detection). Behavior (error) is correct;
-  error classification is off-spec.
+  status: ✅ — the ⚠️ recorded here was stale: a 2026-05-13 probe observed
+  `circular substitution: a`, but the #120 self-reference widening (isOwner +
+  containsSubstByPath short-circuit, cross-impl with rs.hocon v1.5.1) has since routed
+  `a = ${a}` (no prior value) to `could not resolve substitution: ${a}` — the "undefined"
+  classification the spec asks for. A genuine two-step cycle (`a = ${b}, b = ${a}`) still
+  reports `circular substitution` (S13a.8). Both classifications are now pinned by tests
+  (2026-08-17) so a regression to the cycle message fails the suite.
 - **S13a.4** Optional self-ref `${?foo}` disappears silently — §Self-Referential (L776)
   tests: tests/resolver.test.ts:291
   status: ✅

--- a/src/internal/parser/parser.ts
+++ b/src/internal/parser/parser.ts
@@ -66,7 +66,16 @@ class Parser {
       // at the bracket that opened the array root.
       return { ...arr, pos: { line: t.line, col: t.col } }
     }
-    return this.parseObject(false)
+    // S3.4 (HOCON.md L138): an unbraced root ends at EOF. parseObject(false)
+    // stops at a stray `}` (it has no opening brace to match), so any token
+    // left over here is unbalanced trailing content, not root content.
+    const root = this.parseObject(false)
+    this.skip('newline')
+    const remaining = this.peek()
+    if (remaining.kind !== 'eof') {
+      throw new ParseError(`Unexpected token '${remaining.value}' after root content`, remaining.line, remaining.col)
+    }
+    return root
   }
 
   private peek(offset = 0): Token { return this.tokens[this.pos + offset] ?? EOF_TOKEN }

--- a/tests/docs.test.ts
+++ b/tests/docs.test.ts
@@ -133,6 +133,29 @@ describe('docs consistency', () => {
     expect(inScope).toBe(rate(counts, SPEC_ITEM_TOTAL - counts.outOfScope))
   })
 
+  // README.ja.md was not covered by this gate and drifted 15+ points (found
+  // 2026-08-17 still showing the 2026-05-13 snapshot). Same recomputation,
+  // Japanese table labels.
+  it('README.ja compliance rates match docs/spec-compliance.md', () => {
+    const counts = countCompliance()
+    const readme = read('README.ja.md')
+    const specTotal = findOne(
+      'README.ja.md',
+      readme,
+      /\| 仕様全体（out-of-scope を含む） +\| \*\*([0-9.]+)%\*\* +\|/,
+      'spec-total compliance rate (ja)',
+    )
+    const inScope = findOne(
+      'README.ja.md',
+      readme,
+      /\| In-scope のみ +\| \*\*([0-9.]+)%\*\* +\|/,
+      'in-scope compliance rate (ja)',
+    )
+
+    expect(specTotal).toBe(rate(counts, SPEC_ITEM_TOTAL))
+    expect(inScope).toBe(rate(counts, SPEC_ITEM_TOTAL - counts.outOfScope))
+  })
+
   it('README minimum Node version matches package.json engines', () => {
     const engines = findOne(
       'package.json',

--- a/tests/parser.test.ts
+++ b/tests/parser.test.ts
@@ -236,6 +236,28 @@ describe('parseTokens', () => {
     expect(() => parseTokens(tokenize('{ a = 1 } }'))).toThrow()
   })
 
+  // S3.4 (HOCON.md L138, ts#55): an unbraced root followed by an unbalanced
+  // `}` used to be silently accepted (parseObject(false) stops at `}` and the
+  // leftover token was never checked).
+  it('S3.4: should error on stray } after unbraced root', () => {
+    expect(() => parseTokens(tokenize('a = 1\n}'))).toThrow(/Unexpected token/)
+  })
+
+  it('S3.4: should error on stray } on the same line as unbraced root content', () => {
+    expect(() => parseTokens(tokenize('a = 1 }'))).toThrow(/Unexpected token/)
+  })
+
+  it('S3.4: should error on stray ] after unbraced root', () => {
+    // rejected on a different path (`]` cannot start a key) — message differs,
+    // but the trailing token is refused either way
+    expect(() => parseTokens(tokenize('a = 1\n]'))).toThrow()
+  })
+
+  it('S3.4: unbraced root with trailing newlines still parses', () => {
+    const node = parseTokens(tokenize('a = 1\n\n'))
+    expect(node.kind).toBe('object')
+  })
+
   it('should error on include url() with "not supported" message', () => {
     expect(() => parseTokens(tokenize('include url("http://example.com")'))).toThrow(/not supported/)
   })

--- a/tests/resolver.test.ts
+++ b/tests/resolver.test.ts
@@ -972,23 +972,23 @@ describe('S14a.7 - whitespace/newlines allowed between include and resource name
 // black-box public API; structural reason: the spec rule constrains resolver internals,
 // not the observable output for any valid input program).
 
-// S13a.3 — self-ref before any prior value → error (HOCON spec L767)
-// Probe (2026-05-13): resolveStr('a = ${a}') throws ResolveError "circular substitution: a".
-// Spec L767-773: error should be treated as "undefined" (missing subst) rather than
-// "intractable cycle". Both lead to an error, but the error message differs.
-// Classification: ⚠️ — error is raised (correct), but as a cycle error rather than a
-// missing-substitution error; the spec wants "undefined" semantics for this case.
-describe('S13a.3 - self-ref with no prior value → error (HOCON spec L767)', () => {
-  it('S13a.3: a = ${a} with no prior value for a raises an error', () => {
-    // Spec: treated as "undefined" — same outcome as required substitution not found.
-    // Impl raises ResolveError("circular substitution: a") instead of a missing-path error,
-    // but an error IS raised either way. ⚠️ wrong error message, correct behavior.
+// S13a.3 — self-ref before any prior value → undefined → error (HOCON spec L767)
+// A 2026-05-13 probe found this raised "circular substitution"; the #120
+// self-reference widening (isOwner + containsSubstByPath short-circuit) has
+// since routed it to the undefined classification the spec asks for. These
+// tests pin the classification so it cannot silently regress to a cycle error.
+describe('S13a.3 - self-ref with no prior value → undefined → error (HOCON spec L767)', () => {
+  it('S13a.3: a = ${a} with no prior value is an undefined substitution, not a cycle', () => {
+    // Spec L767-773: treated as "undefined" — same classification as a
+    // required substitution whose path does not exist.
     expect(() => resolveStr('a = ${a}')).toThrow(ResolveError)
+    expect(() => resolveStr('a = ${a}')).toThrow(/could not resolve substitution/)
+    expect(() => resolveStr('a = ${a}')).not.toThrow(/circular/)
   })
 
-  it('S13a.3: a = ${a} is distinct from a two-step cycle (both error, but different cause)', () => {
-    // Two-step cycle — also an error, per S13a.8
+  it('S13a.3: a two-step cycle stays classified as circular (S13a.8)', () => {
     expect(() => resolveStr('a = ${b}\nb = ${a}')).toThrow(ResolveError)
+    expect(() => resolveStr('a = ${b}\nb = ${a}')).toThrow(/circular substitution/)
   })
 })
 


### PR DESCRIPTION
## Summary

Priority 4 of the UX evaluation (2026-08-17). Clears the remaining S3.4 ❌ and S13a.3 ⚠️, reaching **in-scope 100.0% / spec-total 90.0%**.

## S3.4 (#55) — the actual fix

Only the unbraced-root parse path lacked trailing-token validation, so a stray `}` on the line after `a = 1` was silently ignored. The braced-root / array-root paths already validated, so the same EOF validation was added to the fallback path.

**BREAKING (spec fix)**: previously accepted invalid input now raises `ParseError`. The CHANGELOG already carries the BREAKING label + workaround (delete the extra brace). Shipping this in a minor follows the S19.8 precedent.

## S13a.3 — turned out to be already fixed (doc correction + test pinning)

At the time of the probe (2026-05-13), `a = ${a}` was `circular substitution`, but the self-reference widening in #120 (isOwner + containsSubstByPath short-circuit) had already corrected it to the undefined classification the spec requires (`could not resolve substitution`). The basis for the ⚠️ was stale, so it is corrected to ✅, and **the classification — self-ref = undefined / 2-step cycle = circular — is pinned by tests** (so a regression will fail).

## Doc rot found along the way

The compliance-rate table in README.ja.md was still the 2026-05-13 snapshot (74.2% / 83.3%), **off by more than 15pp** (the "unsupported in v0.1.0: .properties" note also lingered). Updated it to the current values, and **extended the rate gate in `tests/docs.test.ts` to README.ja.md** to structurally prevent recurrence.

## Verification

- 1394 passed / typecheck / build all green
- The initial 71 failures were only because the fresh worktree lacked the CI-fetched fixtures (all green after `make testdata`). **No contamination of tracked fixtures** (verified via git status)
- The compliance numbers are recomputed by docs.test.ts from the glyphs in spec-compliance.md and cross-checked (both en/ja)

Fixes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)
