### PR TITLE
fix(resolver): S13a.12 — resolve prefix self-refs against below

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **BREAKING (spec fix, S13a.12): a substitution whose target lies inside the
+  field being defined (`foo : ${foo.a}`) now resolves against the field's
+  "below" value — the merge of the stack beneath the substitution — instead of
+  the final tree.** The spec example `foo:{a:{c:1}}; foo:${foo.a}; foo:{a:2}`
+  now yields `{a:2, c:1}` (was `{a:2}`, dropping `c`), and the two-layer form
+  `foo:{a:{c:1}}; foo:${foo.a}` now resolves to `{a:{c:1}, c:1}` (was an
+  unresolved-substitution error). A required prefix self-ref with nothing
+  below at the navigated path errors with the undefined classification
+  (`could not resolve substitution`); an optional one vanishes transparently,
+  leaving the below layer as the surviving prior. Found by a cross-impl probe
+  — all four sibling implementations shared the gap (the recorded ts ✅ was a
+  stale-pointer misclassification), and the fixes land in lockstep.
+
 - **BREAKING (spec fix, S3.4)**: an unbraced root followed by an unbalanced
   `}` — e.g. `a = 1` on one line and a stray `}` on the next — now raises
   `ParseError` instead of being silently accepted with the trailing tokens

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -442,8 +442,16 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
   tests: tests/resolver.test.ts:227
   status: ✅
 - **S13a.12** Self-ref in path expression `${foo.a}` resolves to "below" — §Self-Referential (L791)
-  tests: tests/resolver.test.ts:93
-  status: ✅
+  tests: tests/s13a12-prefix-self-ref.test.ts
+  status: ✅ — Fixed 2026-08-18. The previous ✅ was a misclassification (stale test
+  pointer): a 2026-08-18 cross-impl probe showed the spec example
+  `foo:{a:{c:1}}; foo:${foo.a}; foo:{a:2}` yielded `{a:2}` (c lost) in all four
+  siblings — the prefix direction (`foo` ⊏ `foo.a`) was missing from self-reference
+  detection, so the substitution resolved against the final tree ("above") instead of
+  the stack "below". Fixed in the fold (prefix self-refs fold at prior-save time,
+  standalone occurrences forming a merge layer) and in resolveSubst (standing prefix
+  self-refs resolve via the field's prior + remainder navigation; a miss takes the
+  undefined classification). Non-self-ref delayed merge was always correct.
 - **S13a.13** `a = ${?a}foo` resolves to `"foo"` (look-back undefined) — §Self-Referential (L841)
   tests: tests/resolver.test.ts:766, tests/s13a13-self-ref-lookback.test.ts (sr01–sr11)
   status: ✅ Fix landed in cluster 3f via resolver short-circuit when no prior value exists (see #84).

--- a/src/internal/resolver/fold-self-ref.ts
+++ b/src/internal/resolver/fold-self-ref.ts
@@ -174,25 +174,36 @@ function mergeResObjLayers(base: ResObj, top: ResObj): ResObj {
  * Concat / Append / ResObj / HoconValue array / HoconValue object — all six
  * wrapping shapes that can carry a substitution placeholder post-parse. */
 export function containsSelfRef(v: ResolverValue, fullKey: string): boolean {
+  return containsSelfRefInner(v, fullKey, true)
+}
+
+/** `allowPrefix` narrows the S13a.12 prefix rule to value-stack positions: it
+ * stays true through concat nodes and array elements (the value chain of the
+ * field itself) but turns false when descending into object interiors — a
+ * substitution nested inside an object literal that references a sibling
+ * branch of the same field (`a = { x = ${a.p.v} }`) is a lazy final-tree
+ * lookup (S13a.14), NOT a below-lookback. */
+function containsSelfRefInner(v: ResolverValue, fullKey: string, allowPrefix: boolean): boolean {
   if (isSubst(v))
     return (
       !v.knownAbsent &&
-      (substFullKey(v) === fullKey || prefixSelfRefRemainder(v, fullKey) !== null)
+      (substFullKey(v) === fullKey ||
+        (allowPrefix && prefixSelfRefRemainder(v, fullKey) !== null))
     )
-  if (isConcat(v)) return v.nodes.some(n => containsSelfRef(n, fullKey))
+  if (isConcat(v)) return v.nodes.some(n => containsSelfRefInner(n, fullKey, allowPrefix))
   if (isResObj(v)) {
     for (const f of v.fields.values()) {
-      if (containsSelfRef(f, fullKey)) return true
+      if (containsSelfRefInner(f, fullKey, false)) return true
     }
     return false
   }
   const hv = v as HoconValue
   if (hv.kind === 'array') {
-    return hv.items.some(item => containsSelfRef(item as ResolverValue, fullKey))
+    return hv.items.some(item => containsSelfRefInner(item as ResolverValue, fullKey, allowPrefix))
   }
   if (hv.kind === 'object') {
     for (const f of hv.fields.values()) {
-      if (containsSelfRef(f as ResolverValue, fullKey)) return true
+      if (containsSelfRefInner(f as ResolverValue, fullKey, false)) return true
     }
     return false
   }
@@ -209,16 +220,28 @@ export function foldSelfRef(
   fullKey: string,
   replacement: ResolverValue,
 ): ResolverValue {
+  return foldSelfRefInner(v, fullKey, replacement, true)
+}
+
+/** See `containsSelfRefInner` for the `allowPrefix` narrowing rule. */
+function foldSelfRefInner(
+  v: ResolverValue,
+  fullKey: string,
+  replacement: ResolverValue,
+  allowPrefix: boolean,
+): ResolverValue {
   if (isSubst(v)) {
     if (substFullKey(v) === fullKey) return replacement
-    const remainder = prefixSelfRefRemainder(v, fullKey)
-    if (remainder !== null) return foldPrefixSelfRef(v, replacement, remainder)
+    if (allowPrefix) {
+      const remainder = prefixSelfRefRemainder(v, fullKey)
+      if (remainder !== null) return foldPrefixSelfRef(v, replacement, remainder)
+    }
     return v
   }
   if (isConcat(v)) {
     return {
       _kind: 'concat-placeholder',
-      nodes: v.nodes.map(n => foldSelfRef(n, fullKey, replacement)),
+      nodes: v.nodes.map(n => foldSelfRefInner(n, fullKey, replacement, allowPrefix)),
       line: v.line,
       col: v.col,
     } satisfies ConcatPlaceholder
@@ -226,7 +249,7 @@ export function foldSelfRef(
   if (isResObj(v)) {
     const newFields = new Map<string, ResolverValue>()
     for (const [k, val] of v.fields) {
-      newFields.set(k, foldSelfRef(val, fullKey, replacement))
+      newFields.set(k, foldSelfRefInner(val, fullKey, replacement, false))
     }
     // Preserve priorValues from the original so per-object look-back continues
     // to find them post-fold.
@@ -236,13 +259,15 @@ export function foldSelfRef(
   if (hv.kind === 'array') {
     return {
       kind: 'array',
-      items: hv.items.map(item => foldSelfRef(item as ResolverValue, fullKey, replacement) as HoconValue),
+      items: hv.items.map(
+        item => foldSelfRefInner(item as ResolverValue, fullKey, replacement, allowPrefix) as HoconValue,
+      ),
     }
   }
   if (hv.kind === 'object') {
     const newFields = new Map<string, HoconValue>()
     for (const [k, val] of hv.fields) {
-      newFields.set(k, foldSelfRef(val as ResolverValue, fullKey, replacement) as HoconValue)
+      newFields.set(k, foldSelfRefInner(val as ResolverValue, fullKey, replacement, false) as HoconValue)
     }
     return { kind: 'object', fields: newFields }
   }
@@ -354,7 +379,20 @@ export function foldOrSkipPrior(
 }
 
 function foldOptionalSelfRefAbsent(v: ResolverValue, fullKey: string): ResolverValue | undefined {
-  if (isSubst(v) && (substFullKey(v) === fullKey || prefixSelfRefRemainder(v, fullKey) !== null)) {
+  return foldOptionalSelfRefAbsentInner(v, fullKey, true)
+}
+
+/** See `containsSelfRefInner` for the `allowPrefix` narrowing rule. */
+function foldOptionalSelfRefAbsentInner(
+  v: ResolverValue,
+  fullKey: string,
+  allowPrefix: boolean,
+): ResolverValue | undefined {
+  if (
+    isSubst(v) &&
+    (substFullKey(v) === fullKey ||
+      (allowPrefix && prefixSelfRefRemainder(v, fullKey) !== null))
+  ) {
     if (!v.optional) return undefined
     return {
       _kind: 'subst-placeholder',
@@ -370,7 +408,7 @@ function foldOptionalSelfRefAbsent(v: ResolverValue, fullKey: string): ResolverV
   if (isConcat(v)) {
     const nodes: ResolverValue[] = []
     for (const node of v.nodes) {
-      const folded = foldOptionalSelfRefAbsent(node, fullKey)
+      const folded = foldOptionalSelfRefAbsentInner(node, fullKey, allowPrefix)
       if (folded === undefined) return undefined
       nodes.push(folded)
     }
@@ -379,7 +417,7 @@ function foldOptionalSelfRefAbsent(v: ResolverValue, fullKey: string): ResolverV
   if (isResObj(v)) {
     const fields = new Map<string, ResolverValue>()
     for (const [key, value] of v.fields) {
-      const folded = foldOptionalSelfRefAbsent(value, fullKey)
+      const folded = foldOptionalSelfRefAbsentInner(value, fullKey, false)
       if (folded === undefined) return undefined
       fields.set(key, folded)
     }
@@ -389,7 +427,7 @@ function foldOptionalSelfRefAbsent(v: ResolverValue, fullKey: string): ResolverV
   if (hv.kind === 'array') {
     const items: HoconValue[] = []
     for (const item of hv.items) {
-      const folded = foldOptionalSelfRefAbsent(item as ResolverValue, fullKey)
+      const folded = foldOptionalSelfRefAbsentInner(item as ResolverValue, fullKey, allowPrefix)
       if (folded === undefined) return undefined
       items.push(folded as HoconValue)
     }
@@ -398,7 +436,7 @@ function foldOptionalSelfRefAbsent(v: ResolverValue, fullKey: string): ResolverV
   if (hv.kind === 'object') {
     const fields = new Map<string, HoconValue>()
     for (const [key, value] of hv.fields) {
-      const folded = foldOptionalSelfRefAbsent(value as ResolverValue, fullKey)
+      const folded = foldOptionalSelfRefAbsentInner(value as ResolverValue, fullKey, false)
       if (folded === undefined) return undefined
       fields.set(key, folded as HoconValue)
     }

--- a/src/internal/resolver/fold-self-ref.ts
+++ b/src/internal/resolver/fold-self-ref.ts
@@ -35,6 +35,7 @@ import type { HoconValue } from '../../value.js'
 import type { Segment } from '../lexer/token.js'
 import {
   type ConcatPlaceholder,
+  type ResObj,
   type ResolverValue,
   type SubstPlaceholder,
   isConcat,
@@ -67,12 +68,117 @@ export function stringSegmentsToKey(segments: string[]): string {
     .join('.')
 }
 
+/** S13a.12: remainder segment texts when `fullKey` is a PROPER segment-wise
+ * prefix of the subst's path (`foo` ⊏ `foo.a` → `["a"]`), else null.
+ *
+ * The boundary check works on the dotted keys because both sides use the same
+ * quoting (`stringSegmentsToKey`): a literal dotted segment renders quoted
+ * (`"foo.a"`), so it can never string-prefix `foo.` — only a genuine segment
+ * boundary matches. The remainder is recovered by finding the segment count
+ * whose prefix key equals `fullKey`. */
+export function prefixSelfRefRemainder(s: SubstPlaceholder, fullKey: string): string[] | null {
+  const texts = s.segments.map(seg => seg.text)
+  if (!stringSegmentsToKey(texts).startsWith(fullKey + '.')) return null
+  for (let n = 1; n < texts.length; n++) {
+    if (stringSegmentsToKey(texts.slice(0, n)) === fullKey) return texts.slice(n)
+  }
+  return null
+}
+
+/** Structural navigation of `remainder` into a resolver value, following
+ * ResObj fields and already-resolved object fields.
+ *
+ * Returns the reached node, `undefined` when a segment is missing (or the
+ * walk dead-ends in a scalar/array — path semantics treat both as absent),
+ * and `null` when it hits a node it cannot see through structurally
+ * (a substitution or concat placeholder). */
+export function navigateResolverValue(
+  v: ResolverValue,
+  remainder: string[],
+): ResolverValue | undefined | null {
+  let cur: ResolverValue = v
+  for (const seg of remainder) {
+    if (isSubst(cur) || isConcat(cur)) return null
+    if (isResObj(cur)) {
+      const next = cur.fields.get(seg)
+      if (next === undefined) return undefined
+      cur = next
+      continue
+    }
+    const hv = cur as HoconValue
+    if (hv.kind === 'object') {
+      const next = hv.fields.get(seg)
+      if (next === undefined) return undefined
+      cur = next as ResolverValue
+      continue
+    }
+    return undefined
+  }
+  return cur
+}
+
+/** Fold one prefix self-reference (`${fullKey.rest}`) against the below value:
+ * navigate `rest` into `replacement`. A missing path folds to the undefined
+ * classification — a `knownAbsent` placeholder that disappears when optional
+ * and errors at resolve time when required. An unnavigable path (a live
+ * substitution mid-walk) leaves the subst unchanged; the resolve-time guard
+ * covers it. */
+function foldPrefixSelfRef(
+  s: SubstPlaceholder,
+  replacement: ResolverValue,
+  remainder: string[],
+): ResolverValue {
+  const navigated = navigateResolverValue(replacement, remainder)
+  if (navigated === null) return s
+  if (navigated === undefined) {
+    return {
+      _kind: 'subst-placeholder',
+      segments: s.segments.map(seg => ({ text: seg.text, line: seg.line, col: seg.col })),
+      optional: s.optional,
+      knownAbsent: true,
+      listSuffix: s.listSuffix,
+      line: s.line,
+      col: s.col,
+      prefixLen: s.prefixLen,
+    } satisfies SubstPlaceholder
+  }
+  return cloneResolverValue(navigated)
+}
+
+/** Prior-layer object merge for the standalone-prefix-self-ref save case
+ * (S13a.12): the below layer as base, the navigated value on top. A local,
+ * bookkeeping-free merge — deliberately NOT utils.deepMergeResObjInto, which
+ * would create an import cycle and re-run prior-save logic that has already
+ * happened for these (cloned) layers. */
+function mergeResObjLayers(base: ResObj, top: ResObj): ResObj {
+  const fields = new Map(base.fields)
+  for (const [k, tv] of top.fields) {
+    const bv = fields.get(k)
+    if (bv !== undefined && isResObj(bv) && isResObj(tv)) {
+      fields.set(k, mergeResObjLayers(bv, tv))
+    } else {
+      fields.set(k, tv)
+    }
+  }
+  return {
+    _kind: 'res-obj',
+    fields,
+    priorValues: new Map(base.priorValues),
+    resetKeys: new Set(base.resetKeys),
+  }
+}
+
 /** Returns true if `v` contains at least one `Subst` whose dotted-path key
- * equals `fullKey`. Walks Subst / Concat / Append / ResObj / HoconValue
- * array / HoconValue object — all six wrapping shapes that can carry a
- * substitution placeholder post-parse. */
+ * equals `fullKey` — or, per S13a.12, whose path has `fullKey` as a proper
+ * segment-wise prefix (`${foo.a}` inside the stack of `foo`). Walks Subst /
+ * Concat / Append / ResObj / HoconValue array / HoconValue object — all six
+ * wrapping shapes that can carry a substitution placeholder post-parse. */
 export function containsSelfRef(v: ResolverValue, fullKey: string): boolean {
-  if (isSubst(v)) return !v.knownAbsent && substFullKey(v) === fullKey
+  if (isSubst(v))
+    return (
+      !v.knownAbsent &&
+      (substFullKey(v) === fullKey || prefixSelfRefRemainder(v, fullKey) !== null)
+    )
   if (isConcat(v)) return v.nodes.some(n => containsSelfRef(n, fullKey))
   if (isResObj(v)) {
     for (const f of v.fields.values()) {
@@ -104,7 +210,10 @@ export function foldSelfRef(
   replacement: ResolverValue,
 ): ResolverValue {
   if (isSubst(v)) {
-    return substFullKey(v) === fullKey ? replacement : v
+    if (substFullKey(v) === fullKey) return replacement
+    const remainder = prefixSelfRefRemainder(v, fullKey)
+    if (remainder !== null) return foldPrefixSelfRef(v, replacement, remainder)
+    return v
   }
   if (isConcat(v)) {
     return {
@@ -216,6 +325,28 @@ export function foldOrSkipPrior(
 ): ResolverValue | undefined {
   if (!containsSelfRef(prior, fullKey)) return cloneResolverValue(prior)
   if (old === undefined) return foldOptionalSelfRefAbsent(prior, fullKey)
+  // S13a.12: a STANDALONE prefix self-ref in field-value position is a merge
+  // LAYER — an object it navigates to merges over the stack below it, so the
+  // saved prior must keep the below layer's other keys (`foo:{a:{c:1},keep:9};
+  // foo:${foo.a}` → prior {a:{c:1},keep:9,c:1}, not just {c:1}). Nested
+  // occurrences (inside concat/array/object) substitute in place instead —
+  // they are not merge layers — and take the generic fold below.
+  if (isSubst(prior)) {
+    const remainder = prefixSelfRefRemainder(prior, fullKey)
+    if (remainder !== null) {
+      const navigated = navigateResolverValue(old, remainder)
+      // Optional prefix self-ref with nothing below at the navigated path:
+      // the layer vanishes, and a vanished layer is transparent — the below
+      // layer itself is the surviving prior.
+      if (navigated === undefined && prior.optional) return cloneResolverValue(old)
+      if (navigated !== null && navigated !== undefined && isResObj(navigated) && isResObj(old)) {
+        return mergeResObjLayers(
+          cloneResolverValue(old) as ResObj,
+          cloneResolverValue(navigated) as ResObj,
+        )
+      }
+    }
+  }
   // foldSelfRef already constructs new ResObj/array/object/Concat nodes
   // along the path it traverses, so the result is a fresh tree wherever
   // mutation could matter. No additional clone needed.
@@ -223,7 +354,7 @@ export function foldOrSkipPrior(
 }
 
 function foldOptionalSelfRefAbsent(v: ResolverValue, fullKey: string): ResolverValue | undefined {
-  if (isSubst(v) && substFullKey(v) === fullKey) {
+  if (isSubst(v) && (substFullKey(v) === fullKey || prefixSelfRefRemainder(v, fullKey) !== null)) {
     if (!v.optional) return undefined
     return {
       _kind: 'subst-placeholder',

--- a/src/internal/resolver/fold-self-ref.ts
+++ b/src/internal/resolver/fold-self-ref.ts
@@ -160,11 +160,18 @@ function mergeResObjLayers(base: ResObj, top: ResObj): ResObj {
       fields.set(k, tv)
     }
   }
+  // Carry BOTH layers' bookkeeping: top's priorValues (its keys' own
+  // delayed-merge chains) win per key over base's, and resetKeys union so
+  // reset markers from either layer survive the splice.
+  const priorValues = new Map(base.priorValues)
+  for (const [k, pv] of top.priorValues) priorValues.set(k, pv)
+  const resetKeys = new Set(base.resetKeys)
+  for (const k of top.resetKeys) resetKeys.add(k)
   return {
     _kind: 'res-obj',
     fields,
-    priorValues: new Map(base.priorValues),
-    resetKeys: new Set(base.resetKeys),
+    priorValues,
+    resetKeys,
   }
 }
 

--- a/src/internal/resolver/substitution-resolver.ts
+++ b/src/internal/resolver/substitution-resolver.ts
@@ -54,6 +54,13 @@ export class SubstitutionResolver {
   // same prefix-match semantics).
   private resolvingFieldPath: string[] = []
 
+  // S13a.12 recursion guard: field keys whose prior is currently being
+  // resolved through the prefix-self-ref branch. Saved priors are
+  // prefix-self-ref-free by the fold invariant, so re-entry only happens on
+  // a shape the fold could not see through (a live subst mid-navigation) —
+  // report it as a cycle instead of recursing forever.
+  private resolvingPrefixPriors = new Set<string>()
+
   constructor(
     private root: ResObj,
     private opts: ResolveOptions,
@@ -71,53 +78,74 @@ export class SubstitutionResolver {
   private resolveResObj(obj: ResObj): HoconValue {
     const result = new Map<string, HoconValue>()
     for (const [key, val] of obj.fields) {
+      // The push/pop span covers BOTH the value resolution and the
+      // prior-chain resolution below: a prior belongs to this field's value
+      // stack, so a substitution inside it must see the full field path.
+      // With the field popped, a prior's reference into a sibling of this
+      // field (`a`'s prior holding `${bar.nested.x}` while resolving
+      // `bar.nested.a`) would satisfy the S13a.12 prefix-self-ref test
+      // against the truncated path [bar, nested] and mis-route to the
+      // prior of `nested` instead of the final tree.
       this.resolvingFieldPath.push(key)
       const fullCacheKey = stringSegmentsToKey(this.resolvingFieldPath)
       this.cache.delete(fullCacheKey)
-      let resolved: HoconValue | undefined
       try {
-        resolved = this.resolveVal(val, obj)
-      } finally {
-        this.resolvingFieldPath.pop()
-      }
-      if (resolved !== undefined) {
-        // Delayed merge: if both current and prior resolve to objects, deep merge
-        if (resolved.kind === 'object') {
+        const resolved = this.resolveVal(val, obj)
+        if (resolved !== undefined) {
+          // Delayed merge: if both current and prior resolve to objects, deep merge
+          if (resolved.kind === 'object') {
+            const prior = obj.priorValues.get(key)
+            if (prior !== undefined) {
+              const priorResolved = this.resolveVal(prior, obj)
+              if (
+                priorResolved !== undefined &&
+                priorResolved.kind === 'object'
+              ) {
+                const finalValue = deepMergeHoconValues(
+                  priorResolved as HoconValue & { kind: 'object' },
+                  resolved as HoconValue & { kind: 'object' },
+                )
+                result.set(key, finalValue)
+                this.cache.set(fullCacheKey, finalValue)
+                this.cacheDescendants(fullCacheKey, finalValue)
+                continue
+              }
+            }
+          }
+          result.set(key, resolved)
+          this.cache.set(fullCacheKey, resolved)
+          this.cacheDescendants(fullCacheKey, resolved)
+        } else {
+          // Unresolved optional substitution: fall back to prior value per HOCON spec
           const prior = obj.priorValues.get(key)
           if (prior !== undefined) {
             const priorResolved = this.resolveVal(prior, obj)
-            if (
-              priorResolved !== undefined &&
-              priorResolved.kind === 'object'
-            ) {
-              const finalValue = deepMergeHoconValues(
-                priorResolved as HoconValue & { kind: 'object' },
-                resolved as HoconValue & { kind: 'object' },
-              )
-              result.set(key, finalValue)
-              this.cache.set(fullCacheKey, finalValue)
-              this.cacheDescendants(fullCacheKey, finalValue)
-              continue
+            if (priorResolved !== undefined) {
+              result.set(key, priorResolved)
+              this.cache.set(fullCacheKey, priorResolved)
+              this.cacheDescendants(fullCacheKey, priorResolved)
             }
           }
         }
-        result.set(key, resolved)
-        this.cache.set(fullCacheKey, resolved)
-        this.cacheDescendants(fullCacheKey, resolved)
-      } else {
-        // Unresolved optional substitution: fall back to prior value per HOCON spec
-        const prior = obj.priorValues.get(key)
-        if (prior !== undefined) {
-          const priorResolved = this.resolveVal(prior, obj)
-          if (priorResolved !== undefined) {
-            result.set(key, priorResolved)
-            this.cache.set(fullCacheKey, priorResolved)
-            this.cacheDescendants(fullCacheKey, priorResolved)
-          }
-        }
+      } finally {
+        // `continue` routes through here too — every exit pops.
+        this.resolvingFieldPath.pop()
       }
     }
     return { kind: 'object', fields: result }
+  }
+
+  /** S13a.12: walk resolved-object fields by segment text. A missing segment
+   * or a walk into a scalar/array is path-absent → undefined. */
+  private navigateResolved(v: HoconValue, remainder: string[]): HoconValue | undefined {
+    let cur: HoconValue = v
+    for (const seg of remainder) {
+      if (cur.kind !== 'object') return undefined
+      const next = cur.fields.get(seg)
+      if (next === undefined) return undefined
+      cur = next
+    }
+    return cur
   }
 
   private cacheDescendants(prefix: string, value: HoconValue): void {
@@ -162,7 +190,63 @@ export class SubstitutionResolver {
     s: SubstPlaceholder,
     scope: ResObj,
   ): HoconValue | undefined {
-    if (s.knownAbsent) return undefined
+    if (s.knownAbsent) {
+      // A required substitution folded to knownAbsent (S13a.12 prefix fold
+      // with no below value at the navigated path) is the spec's "undefined"
+      // classification — an error, not a silent disappearance. The `+=`
+      // chain-bottom sentinel (go.hocon#134) is always `${?…}` and keeps the
+      // silent path.
+      if (!s.optional) {
+        const k = segmentsToKey(s.segments)
+        throw new ResolveError(
+          `${this.originPrefix()}could not resolve substitution: \${${k}}`,
+          k,
+          s.line,
+          s.col,
+        )
+      }
+      return undefined
+    }
+
+    // S13a.12 (HOCON.md L791): a substitution whose target lies INSIDE the
+    // field currently being resolved (the field path is a proper prefix of
+    // the target path, e.g. `foo : ${foo.a}` while resolving `foo`) is
+    // self-referential and resolves against the field's "below" value — its
+    // saved prior — never the final tree, which would see the layers ABOVE
+    // the substitution. The exact-key case (`foo : ${foo}`) keeps its
+    // existing prior machinery further down.
+    {
+      const rfp = this.resolvingFieldPath
+      const sTexts = s.segments.map(seg => seg.text)
+      if (
+        rfp.length > 0 &&
+        rfp.length < sTexts.length &&
+        stringSegmentsToKey(sTexts.slice(0, rfp.length)) === stringSegmentsToKey(rfp)
+      ) {
+        const guardKey = stringSegmentsToKey(rfp)
+        const prior = scope.priorValues.get(rfp[rfp.length - 1]!)
+        if (prior !== undefined && !this.resolvingPrefixPriors.has(guardKey)) {
+          this.resolvingPrefixPriors.add(guardKey)
+          try {
+            const priorResolved = this.resolveVal(prior, scope)
+            if (priorResolved !== undefined) {
+              const navigated = this.navigateResolved(priorResolved, sTexts.slice(rfp.length))
+              if (navigated !== undefined) return navigated
+            }
+          } finally {
+            this.resolvingPrefixPriors.delete(guardKey)
+          }
+        }
+        if (s.optional) return undefined
+        const k = segmentsToKey(s.segments)
+        throw new ResolveError(
+          `${this.originPrefix()}could not resolve substitution: \${${k}}`,
+          k,
+          s.line,
+          s.col,
+        )
+      }
+    }
 
     // Cache key includes listSuffix to prevent `${X}` and `${X[]}` collisions:
     // both resolve via different code paths (scalar fallback vs resolveEnvList)

--- a/src/internal/resolver/substitution-resolver.ts
+++ b/src/internal/resolver/substitution-resolver.ts
@@ -195,9 +195,14 @@ export class SubstitutionResolver {
       // with no below value at the navigated path) is the spec's "undefined"
       // classification — an error, not a silent disappearance. The `+=`
       // chain-bottom sentinel (go.hocon#134) is always `${?…}` and keeps the
-      // silent path.
+      // silent path. allowUnresolved leaves the placeholder in place, and the
+      // key keeps the `[]` suffix so `${X[]}` reports (and, under
+      // allowUnresolved, occupies) its own path.
       if (!s.optional) {
-        const k = segmentsToKey(s.segments)
+        if (this.opts.allowUnresolved) return s as unknown as HoconValue
+        const k = s.listSuffix
+          ? `${segmentsToKey(s.segments)}[]`
+          : segmentsToKey(s.segments)
         throw new ResolveError(
           `${this.originPrefix()}could not resolve substitution: \${${k}}`,
           k,
@@ -238,7 +243,10 @@ export class SubstitutionResolver {
           }
         }
         if (s.optional) return undefined
-        const k = segmentsToKey(s.segments)
+        if (this.opts.allowUnresolved) return s as unknown as HoconValue
+        const k = s.listSuffix
+          ? `${segmentsToKey(s.segments)}[]`
+          : segmentsToKey(s.segments)
         throw new ResolveError(
           `${this.originPrefix()}could not resolve substitution: \${${k}}`,
           k,

--- a/tests/fold-self-ref-unit.test.ts
+++ b/tests/fold-self-ref-unit.test.ts
@@ -1,50 +1,32 @@
-// Copyright 2026 1o1 Co. Ltd.
+// Unit contract tests for fold-self-ref's plain-HoconValue handling (S13a.12).
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
+// The parser always builds object literals as ResObj, so the plain
+// `{kind:'object'}` arms of navigateResolverValue / foldSelfRefInner are not
+// reachable from `parse()` today — they exist for already-resolved values
+// (the documented contract: hoconValueToResObj leaves objects inside arrays
+// plain, and resolved priors are plain HoconValues). Pin the contract
+// directly so a future wiring that feeds resolved values through the fold
+// keeps working.
 
-/**
- * Unit tests for foldOptionalSelfRefAbsent branch coverage.
- *
- * foldOptionalSelfRefAbsent is private; exercised via foldOrSkipPrior with
- * old = undefined (the path that calls foldOptionalSelfRefAbsent).
- *
- * Covers review #136 item (c): Append / ResObj / HoconArray / HoconObject /
- * fallback branches that previously had no fixture coverage.
- *
- * Each test constructs a ResolverValue containing an optional self-ref to the
- * key "a", then calls foldOrSkipPrior(prior, "a", undefined) and asserts the
- * returned value has the self-ref replaced with a knownAbsent-marked sentinel
- * (or that undefined is returned when the self-ref is required).
- */
+import { describe, expect, it } from 'vitest'
 
-import { describe, it, expect } from 'vitest'
+import type { Segment } from '../src/internal/lexer/token'
 import {
-  foldOrSkipPrior,
-} from '../src/internal/resolver/fold-self-ref.js'
-import type {
-  ConcatPlaceholder,
-  ResObj,
-  SubstPlaceholder,
-} from '../src/internal/resolver/types.js'
-import type { HoconValue } from '../src/value.js'
+  foldSelfRef,
+  navigateResolverValue,
+} from '../src/internal/resolver/fold-self-ref'
+import { makeResObj } from '../src/internal/resolver/types'
+import type { ResolverValue, SubstPlaceholder } from '../src/internal/resolver/types'
+import type { HoconValue } from '../src/value'
 
-// ---------------------------------------------------------------------------
-// Helpers: build placeholder values without embedding ${ in a string literal
-// ---------------------------------------------------------------------------
-
-/** Builds a minimal Segment array for a dotted path like "a" or "foo.a". */
-function seg(text: string): { text: string; line: number; col: number } {
+function seg(text: string): Segment {
   return { text, line: 1, col: 1 }
 }
 
-function makeSubst(key: string, optional: boolean): SubstPlaceholder {
+function subst(path: string[], optional = false): SubstPlaceholder {
   return {
     _kind: 'subst-placeholder',
-    segments: [seg(key)],
+    segments: path.map(seg),
     optional,
     knownAbsent: false,
     listSuffix: false,
@@ -54,235 +36,60 @@ function makeSubst(key: string, optional: boolean): SubstPlaceholder {
   }
 }
 
-function makeConcat(nodes: SubstPlaceholder[]): ConcatPlaceholder {
-  return { _kind: 'concat-placeholder', nodes, line: 1, col: 1 }
+function scalar(raw: string): HoconValue {
+  return { kind: 'scalar', raw, valueType: 'number' }
 }
 
-function makeResObj(fields: Record<string, SubstPlaceholder>): ResObj {
-  return {
-    _kind: 'res-obj',
-    fields: new Map(Object.entries(fields)),
-    priorValues: new Map(),
-    resetKeys: new Set(),
-  }
+function plainObj(fields: Record<string, HoconValue>): HoconValue & { kind: 'object' } {
+  return { kind: 'object', fields: new Map(Object.entries(fields)) }
 }
 
-function makeHoconArray(items: SubstPlaceholder[]): HoconValue {
-  return { kind: 'array', items: items as unknown as HoconValue[] }
-}
-
-function makeHoconObject(fields: Record<string, SubstPlaceholder>): HoconValue {
-  return { kind: 'object', fields: new Map(Object.entries(fields)) as Map<string, HoconValue> }
-}
-
-// ---------------------------------------------------------------------------
-// Subst branch (already covered by sr01/sr15 fixtures, included for baseline)
-// ---------------------------------------------------------------------------
-
-describe('foldOptionalSelfRefAbsent — Subst branch (baseline)', () => {
-  it('optional self-ref Subst → returns Subst with knownAbsent=true', () => {
-    const subst = makeSubst('a', true)
-    const result = foldOrSkipPrior(subst, 'a', undefined)
-    expect(result).not.toBeUndefined()
-    const r = result as SubstPlaceholder
-    expect(r._kind).toBe('subst-placeholder')
-    expect(r.knownAbsent).toBe(true)
-    expect(r.optional).toBe(true)
+describe('navigateResolverValue — plain already-resolved object steps', () => {
+  it('walks through a plain object field and dead-ends in its scalar (path-absent)', () => {
+    // ResObj → plain object → scalar: the mid-walk step follows the plain
+    // object's field, then the scalar leaf makes the remaining segment absent.
+    const root = makeResObj()
+    root.fields.set('a', plainObj({ b: scalar('1') }))
+    expect(navigateResolverValue(root, ['a', 'b'])).toEqual(scalar('1'))
+    expect(navigateResolverValue(root, ['a', 'b', 'c'])).toBeUndefined()
   })
 
-  it('required self-ref Subst → returns undefined (skip save)', () => {
-    const subst = makeSubst('a', false)
-    const result = foldOrSkipPrior(subst, 'a', undefined)
-    expect(result).toBeUndefined()
+  it('reports a missing key on a plain object as path-absent', () => {
+    const root = makeResObj()
+    root.fields.set('a', plainObj({ b: scalar('1') }))
+    expect(navigateResolverValue(root, ['a', 'nope'])).toBeUndefined()
   })
 })
 
-// ---------------------------------------------------------------------------
-// ResObj branch — NEW coverage
-// ---------------------------------------------------------------------------
-
-describe('foldOptionalSelfRefAbsent — ResObj branch', () => {
-  it('ResObj with a field containing optional self-ref → field folded to knownAbsent', () => {
-    // Represents an object like { history = ${?a} } saved as prior for key "a"
-    const resObj = makeResObj({ history: makeSubst('a', true) })
-    const result = foldOrSkipPrior(resObj, 'a', undefined)
-    expect(result).not.toBeUndefined()
-    const r = result as ResObj
-    expect(r._kind).toBe('res-obj')
-    const history = r.fields.get('history') as SubstPlaceholder
-    expect(history._kind).toBe('subst-placeholder')
-    expect(history.knownAbsent).toBe(true)
-  })
-
-  it('ResObj with a field containing required self-ref → returns undefined', () => {
-    const resObj = makeResObj({ history: makeSubst('a', false) })
-    const result = foldOrSkipPrior(resObj, 'a', undefined)
-    expect(result).toBeUndefined()
-  })
-
-  it('ResObj with no self-ref field → returned unchanged (cloned)', () => {
-    // Field references an unrelated key "b" — no self-ref to "a"
-    const resObj = makeResObj({ x: makeSubst('b', true) })
-    const result = foldOrSkipPrior(resObj, 'a', undefined)
-    expect(result).not.toBeUndefined()
-    const r = result as ResObj
-    expect(r._kind).toBe('res-obj')
-    // containsSelfRef("a") is false → foldOrSkipPrior takes cloneResolverValue path
-    // (not foldOptionalSelfRefAbsent), but ResObj branch is still traversed by clone
-    const x = r.fields.get('x') as SubstPlaceholder
-    expect(x.knownAbsent).toBe(false)
-  })
-
-  it('ResObj with multiple fields — only the self-ref field is folded', () => {
-    const resObj: ResObj = {
-      _kind: 'res-obj',
-      fields: new Map([
-        ['history', makeSubst('a', true)],
-        ['other', makeSubst('b', true)],
+describe('foldSelfRef — plain already-resolved object interiors', () => {
+  it('rewrites an exact self-ref inside a plain object interior, leaving other fields', () => {
+    // A plain object whose field holds a live substitution — the shape an
+    // already-resolved value takes after partial resolution. The interior
+    // walk runs with the prefix rule off, so only the exact self-ref folds.
+    const interior = {
+      kind: 'object',
+      fields: new Map<string, HoconValue>([
+        ['h', subst(['foo']) as unknown as HoconValue],
+        ['keep', scalar('7')],
       ]),
-      priorValues: new Map(),
-    }
-    const result = foldOrSkipPrior(resObj, 'a', undefined)
-    expect(result).not.toBeUndefined()
-    const r = result as ResObj
-    const history = r.fields.get('history') as SubstPlaceholder
-    const other = r.fields.get('other') as SubstPlaceholder
-    expect(history.knownAbsent).toBe(true)
-    expect(other.knownAbsent).toBe(false)
-  })
-})
-
-// ---------------------------------------------------------------------------
-// HoconArray branch — NEW coverage
-// ---------------------------------------------------------------------------
-
-describe('foldOptionalSelfRefAbsent — HoconArray branch', () => {
-  it('HoconArray with optional self-ref item → item folded to knownAbsent', () => {
-    // Represents array value [${?a}, "x"] saved as prior for key "a"
-    const scalarStr: HoconValue = { kind: 'scalar', raw: 'x', valueType: 'string' }
-    const arr: HoconValue = {
-      kind: 'array',
-      items: [makeSubst('a', true) as unknown as HoconValue, scalarStr],
-    }
-    const result = foldOrSkipPrior(arr, 'a', undefined)
-    expect(result).not.toBeUndefined()
-    const r = result as HoconValue
-    expect(r.kind).toBe('array')
-    if (r.kind === 'array') {
-      const first = r.items[0] as unknown as SubstPlaceholder
-      expect(first._kind).toBe('subst-placeholder')
-      expect(first.knownAbsent).toBe(true)
-    }
+    } satisfies HoconValue
+    const replacement = plainObj({ x: scalar('1') })
+    const folded = foldSelfRef(interior as ResolverValue, 'foo', replacement)
+    expect(folded).toEqual(plainObj({ h: replacement, keep: scalar('7') }))
   })
 
-  it('HoconArray with required self-ref item → returns undefined', () => {
-    const arr = makeHoconArray([makeSubst('a', false)])
-    const result = foldOrSkipPrior(arr, 'a', undefined)
-    expect(result).toBeUndefined()
-  })
-
-  it('HoconArray with no self-ref items → returned (cloned, items unchanged)', () => {
-    const arr = makeHoconArray([makeSubst('b', true)])
-    const result = foldOrSkipPrior(arr, 'a', undefined)
-    expect(result).not.toBeUndefined()
-    const r = result as HoconValue
-    expect(r.kind).toBe('array')
-    if (r.kind === 'array') {
-      const first = r.items[0] as unknown as SubstPlaceholder
-      expect(first.knownAbsent).toBe(false)
-    }
-  })
-})
-
-// ---------------------------------------------------------------------------
-// HoconObject branch — NEW coverage
-// ---------------------------------------------------------------------------
-
-describe('foldOptionalSelfRefAbsent — HoconObject branch', () => {
-  it('HoconObject with optional self-ref field → field folded to knownAbsent', () => {
-    const obj = makeHoconObject({ history: makeSubst('a', true) })
-    const result = foldOrSkipPrior(obj, 'a', undefined)
-    expect(result).not.toBeUndefined()
-    const r = result as HoconValue
-    expect(r.kind).toBe('object')
-    if (r.kind === 'object') {
-      const history = r.fields.get('history') as unknown as SubstPlaceholder
-      expect(history._kind).toBe('subst-placeholder')
-      expect(history.knownAbsent).toBe(true)
-    }
-  })
-
-  it('HoconObject with required self-ref field → returns undefined', () => {
-    const obj = makeHoconObject({ history: makeSubst('a', false) })
-    const result = foldOrSkipPrior(obj, 'a', undefined)
-    expect(result).toBeUndefined()
-  })
-
-  it('HoconObject with no self-ref field → returned unchanged (cloned)', () => {
-    const obj = makeHoconObject({ x: makeSubst('b', true) })
-    const result = foldOrSkipPrior(obj, 'a', undefined)
-    expect(result).not.toBeUndefined()
-    const r = result as HoconValue
-    expect(r.kind).toBe('object')
-    if (r.kind === 'object') {
-      const x = r.fields.get('x') as unknown as SubstPlaceholder
-      expect(x.knownAbsent).toBe(false)
-    }
-  })
-})
-
-// ---------------------------------------------------------------------------
-// Fallback branch — NEW coverage
-// Scalar HoconValues (string/number/boolean/null) contain no substitution
-// placeholders.  containsSelfRef returns false, so foldOrSkipPrior takes
-// the cloneResolverValue path rather than foldOptionalSelfRefAbsent.
-// We verify that scalars pass through correctly (regression guard).
-// ---------------------------------------------------------------------------
-
-describe('foldOptionalSelfRefAbsent — fallback/scalar branch', () => {
-  it('scalar string value with no self-ref → cloned and returned', () => {
-    const scalar: HoconValue = { kind: 'scalar', raw: 'hello', valueType: 'string' }
-    const result = foldOrSkipPrior(scalar, 'a', undefined)
-    expect(result).not.toBeUndefined()
-    const r = result as HoconValue
-    expect(r.kind).toBe('scalar')
-    if (r.kind === 'scalar') {
-      expect(r.raw).toBe('hello')
-      expect(r.valueType).toBe('string')
-    }
-  })
-
-  it('scalar number value with no self-ref → cloned and returned', () => {
-    const scalar: HoconValue = { kind: 'scalar', raw: '42', valueType: 'number' }
-    const result = foldOrSkipPrior(scalar, 'a', undefined)
-    expect(result).not.toBeUndefined()
-    const r = result as HoconValue
-    expect(r.kind).toBe('scalar')
-    if (r.kind === 'scalar') {
-      expect(r.raw).toBe('42')
-    }
-  })
-})
-
-// ---------------------------------------------------------------------------
-// Concat branch — already covered by sr01/sr15 fixtures; included here for
-// completeness as a unit test to confirm the branch works in isolation.
-// ---------------------------------------------------------------------------
-
-describe('foldOptionalSelfRefAbsent — Concat branch (unit, complements sr fixtures)', () => {
-  it('Concat with optional self-ref node → node folded to knownAbsent', () => {
-    const concat = makeConcat([makeSubst('a', true)])
-    const result = foldOrSkipPrior(concat, 'a', undefined)
-    expect(result).not.toBeUndefined()
-    const r = result as ConcatPlaceholder
-    expect(r._kind).toBe('concat-placeholder')
-    const node = r.nodes[0] as SubstPlaceholder
-    expect(node.knownAbsent).toBe(true)
-  })
-
-  it('Concat with required self-ref node → returns undefined', () => {
-    const concat = makeConcat([makeSubst('a', false)])
-    const result = foldOrSkipPrior(concat, 'a', undefined)
-    expect(result).toBeUndefined()
+  it('leaves a prefix self-ref inside a plain object interior standing (allowPrefix off)', () => {
+    // Object interiors are S13a.14 territory: ${foo.a} nested inside must NOT
+    // fold to the below value even though `foo` prefixes it.
+    const inner = subst(['foo', 'a'])
+    const interior = {
+      kind: 'object',
+      fields: new Map<string, HoconValue>([['h', inner as unknown as HoconValue]]),
+    } satisfies HoconValue
+    const folded = foldSelfRef(interior as ResolverValue, 'foo', plainObj({ a: scalar('2') }))
+    expect(folded).toEqual({
+      kind: 'object',
+      fields: new Map<string, HoconValue>([['h', inner as unknown as HoconValue]]),
+    })
   })
 })

--- a/tests/fold-self-ref-unit.test.ts
+++ b/tests/fold-self-ref-unit.test.ts
@@ -1,32 +1,52 @@
-// Unit contract tests for fold-self-ref's plain-HoconValue handling (S13a.12).
+// Copyright 2026 1o1 Co. Ltd.
 //
-// The parser always builds object literals as ResObj, so the plain
-// `{kind:'object'}` arms of navigateResolverValue / foldSelfRefInner are not
-// reachable from `parse()` today — they exist for already-resolved values
-// (the documented contract: hoconValueToResObj leaves objects inside arrays
-// plain, and resolved priors are plain HoconValues). Pin the contract
-// directly so a future wiring that feeds resolved values through the fold
-// keeps working.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
 
-import { describe, expect, it } from 'vitest'
+/**
+ * Unit tests for foldOptionalSelfRefAbsent branch coverage.
+ *
+ * foldOptionalSelfRefAbsent is private; exercised via foldOrSkipPrior with
+ * old = undefined (the path that calls foldOptionalSelfRefAbsent).
+ *
+ * Covers review #136 item (c): Append / ResObj / HoconArray / HoconObject /
+ * fallback branches that previously had no fixture coverage.
+ *
+ * Each test constructs a ResolverValue containing an optional self-ref to the
+ * key "a", then calls foldOrSkipPrior(prior, "a", undefined) and asserts the
+ * returned value has the self-ref replaced with a knownAbsent-marked sentinel
+ * (or that undefined is returned when the self-ref is required).
+ */
 
-import type { Segment } from '../src/internal/lexer/token'
+import { describe, it, expect } from 'vitest'
 import {
+  foldOrSkipPrior,
   foldSelfRef,
   navigateResolverValue,
-} from '../src/internal/resolver/fold-self-ref'
-import { makeResObj } from '../src/internal/resolver/types'
-import type { ResolverValue, SubstPlaceholder } from '../src/internal/resolver/types'
-import type { HoconValue } from '../src/value'
+} from '../src/internal/resolver/fold-self-ref.js'
+import type {
+  ConcatPlaceholder,
+  ResObj,
+  SubstPlaceholder,
+} from '../src/internal/resolver/types.js'
+import type { HoconValue } from '../src/value.js'
 
-function seg(text: string): Segment {
+// ---------------------------------------------------------------------------
+// Helpers: build placeholder values without embedding ${ in a string literal
+// ---------------------------------------------------------------------------
+
+/** Builds a minimal Segment array for a dotted path like "a" or "foo.a". */
+function seg(text: string): { text: string; line: number; col: number } {
   return { text, line: 1, col: 1 }
 }
 
-function subst(path: string[], optional = false): SubstPlaceholder {
+function makeSubst(key: string, optional: boolean): SubstPlaceholder {
   return {
     _kind: 'subst-placeholder',
-    segments: path.map(seg),
+    segments: [seg(key)],
     optional,
     knownAbsent: false,
     listSuffix: false,
@@ -36,7 +56,251 @@ function subst(path: string[], optional = false): SubstPlaceholder {
   }
 }
 
-function scalar(raw: string): HoconValue {
+function makeConcat(nodes: SubstPlaceholder[]): ConcatPlaceholder {
+  return { _kind: 'concat-placeholder', nodes, line: 1, col: 1 }
+}
+
+function makeResObj(fields: Record<string, SubstPlaceholder>): ResObj {
+  return {
+    _kind: 'res-obj',
+    fields: new Map(Object.entries(fields)),
+    priorValues: new Map(),
+    resetKeys: new Set(),
+  }
+}
+
+function makeHoconArray(items: SubstPlaceholder[]): HoconValue {
+  return { kind: 'array', items: items as unknown as HoconValue[] }
+}
+
+function makeHoconObject(fields: Record<string, SubstPlaceholder>): HoconValue {
+  return { kind: 'object', fields: new Map(Object.entries(fields)) as Map<string, HoconValue> }
+}
+
+// ---------------------------------------------------------------------------
+// Subst branch (already covered by sr01/sr15 fixtures, included for baseline)
+// ---------------------------------------------------------------------------
+
+describe('foldOptionalSelfRefAbsent — Subst branch (baseline)', () => {
+  it('optional self-ref Subst → returns Subst with knownAbsent=true', () => {
+    const subst = makeSubst('a', true)
+    const result = foldOrSkipPrior(subst, 'a', undefined)
+    expect(result).not.toBeUndefined()
+    const r = result as SubstPlaceholder
+    expect(r._kind).toBe('subst-placeholder')
+    expect(r.knownAbsent).toBe(true)
+    expect(r.optional).toBe(true)
+  })
+
+  it('required self-ref Subst → returns undefined (skip save)', () => {
+    const subst = makeSubst('a', false)
+    const result = foldOrSkipPrior(subst, 'a', undefined)
+    expect(result).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// ResObj branch — NEW coverage
+// ---------------------------------------------------------------------------
+
+describe('foldOptionalSelfRefAbsent — ResObj branch', () => {
+  it('ResObj with a field containing optional self-ref → field folded to knownAbsent', () => {
+    // Represents an object like { history = ${?a} } saved as prior for key "a"
+    const resObj = makeResObj({ history: makeSubst('a', true) })
+    const result = foldOrSkipPrior(resObj, 'a', undefined)
+    expect(result).not.toBeUndefined()
+    const r = result as ResObj
+    expect(r._kind).toBe('res-obj')
+    const history = r.fields.get('history') as SubstPlaceholder
+    expect(history._kind).toBe('subst-placeholder')
+    expect(history.knownAbsent).toBe(true)
+  })
+
+  it('ResObj with a field containing required self-ref → returns undefined', () => {
+    const resObj = makeResObj({ history: makeSubst('a', false) })
+    const result = foldOrSkipPrior(resObj, 'a', undefined)
+    expect(result).toBeUndefined()
+  })
+
+  it('ResObj with no self-ref field → returned unchanged (cloned)', () => {
+    // Field references an unrelated key "b" — no self-ref to "a"
+    const resObj = makeResObj({ x: makeSubst('b', true) })
+    const result = foldOrSkipPrior(resObj, 'a', undefined)
+    expect(result).not.toBeUndefined()
+    const r = result as ResObj
+    expect(r._kind).toBe('res-obj')
+    // containsSelfRef("a") is false → foldOrSkipPrior takes cloneResolverValue path
+    // (not foldOptionalSelfRefAbsent), but ResObj branch is still traversed by clone
+    const x = r.fields.get('x') as SubstPlaceholder
+    expect(x.knownAbsent).toBe(false)
+  })
+
+  it('ResObj with multiple fields — only the self-ref field is folded', () => {
+    const resObj: ResObj = {
+      _kind: 'res-obj',
+      fields: new Map([
+        ['history', makeSubst('a', true)],
+        ['other', makeSubst('b', true)],
+      ]),
+      priorValues: new Map(),
+    }
+    const result = foldOrSkipPrior(resObj, 'a', undefined)
+    expect(result).not.toBeUndefined()
+    const r = result as ResObj
+    const history = r.fields.get('history') as SubstPlaceholder
+    const other = r.fields.get('other') as SubstPlaceholder
+    expect(history.knownAbsent).toBe(true)
+    expect(other.knownAbsent).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// HoconArray branch — NEW coverage
+// ---------------------------------------------------------------------------
+
+describe('foldOptionalSelfRefAbsent — HoconArray branch', () => {
+  it('HoconArray with optional self-ref item → item folded to knownAbsent', () => {
+    // Represents array value [${?a}, "x"] saved as prior for key "a"
+    const scalarStr: HoconValue = { kind: 'scalar', raw: 'x', valueType: 'string' }
+    const arr: HoconValue = {
+      kind: 'array',
+      items: [makeSubst('a', true) as unknown as HoconValue, scalarStr],
+    }
+    const result = foldOrSkipPrior(arr, 'a', undefined)
+    expect(result).not.toBeUndefined()
+    const r = result as HoconValue
+    expect(r.kind).toBe('array')
+    if (r.kind === 'array') {
+      const first = r.items[0] as unknown as SubstPlaceholder
+      expect(first._kind).toBe('subst-placeholder')
+      expect(first.knownAbsent).toBe(true)
+    }
+  })
+
+  it('HoconArray with required self-ref item → returns undefined', () => {
+    const arr = makeHoconArray([makeSubst('a', false)])
+    const result = foldOrSkipPrior(arr, 'a', undefined)
+    expect(result).toBeUndefined()
+  })
+
+  it('HoconArray with no self-ref items → returned (cloned, items unchanged)', () => {
+    const arr = makeHoconArray([makeSubst('b', true)])
+    const result = foldOrSkipPrior(arr, 'a', undefined)
+    expect(result).not.toBeUndefined()
+    const r = result as HoconValue
+    expect(r.kind).toBe('array')
+    if (r.kind === 'array') {
+      const first = r.items[0] as unknown as SubstPlaceholder
+      expect(first.knownAbsent).toBe(false)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// HoconObject branch — NEW coverage
+// ---------------------------------------------------------------------------
+
+describe('foldOptionalSelfRefAbsent — HoconObject branch', () => {
+  it('HoconObject with optional self-ref field → field folded to knownAbsent', () => {
+    const obj = makeHoconObject({ history: makeSubst('a', true) })
+    const result = foldOrSkipPrior(obj, 'a', undefined)
+    expect(result).not.toBeUndefined()
+    const r = result as HoconValue
+    expect(r.kind).toBe('object')
+    if (r.kind === 'object') {
+      const history = r.fields.get('history') as unknown as SubstPlaceholder
+      expect(history._kind).toBe('subst-placeholder')
+      expect(history.knownAbsent).toBe(true)
+    }
+  })
+
+  it('HoconObject with required self-ref field → returns undefined', () => {
+    const obj = makeHoconObject({ history: makeSubst('a', false) })
+    const result = foldOrSkipPrior(obj, 'a', undefined)
+    expect(result).toBeUndefined()
+  })
+
+  it('HoconObject with no self-ref field → returned unchanged (cloned)', () => {
+    const obj = makeHoconObject({ x: makeSubst('b', true) })
+    const result = foldOrSkipPrior(obj, 'a', undefined)
+    expect(result).not.toBeUndefined()
+    const r = result as HoconValue
+    expect(r.kind).toBe('object')
+    if (r.kind === 'object') {
+      const x = r.fields.get('x') as unknown as SubstPlaceholder
+      expect(x.knownAbsent).toBe(false)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Fallback branch — NEW coverage
+// Scalar HoconValues (string/number/boolean/null) contain no substitution
+// placeholders.  containsSelfRef returns false, so foldOrSkipPrior takes
+// the cloneResolverValue path rather than foldOptionalSelfRefAbsent.
+// We verify that scalars pass through correctly (regression guard).
+// ---------------------------------------------------------------------------
+
+describe('foldOptionalSelfRefAbsent — fallback/scalar branch', () => {
+  it('scalar string value with no self-ref → cloned and returned', () => {
+    const scalar: HoconValue = { kind: 'scalar', raw: 'hello', valueType: 'string' }
+    const result = foldOrSkipPrior(scalar, 'a', undefined)
+    expect(result).not.toBeUndefined()
+    const r = result as HoconValue
+    expect(r.kind).toBe('scalar')
+    if (r.kind === 'scalar') {
+      expect(r.raw).toBe('hello')
+      expect(r.valueType).toBe('string')
+    }
+  })
+
+  it('scalar number value with no self-ref → cloned and returned', () => {
+    const scalar: HoconValue = { kind: 'scalar', raw: '42', valueType: 'number' }
+    const result = foldOrSkipPrior(scalar, 'a', undefined)
+    expect(result).not.toBeUndefined()
+    const r = result as HoconValue
+    expect(r.kind).toBe('scalar')
+    if (r.kind === 'scalar') {
+      expect(r.raw).toBe('42')
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Concat branch — already covered by sr01/sr15 fixtures; included here for
+// completeness as a unit test to confirm the branch works in isolation.
+// ---------------------------------------------------------------------------
+
+describe('foldOptionalSelfRefAbsent — Concat branch (unit, complements sr fixtures)', () => {
+  it('Concat with optional self-ref node → node folded to knownAbsent', () => {
+    const concat = makeConcat([makeSubst('a', true)])
+    const result = foldOrSkipPrior(concat, 'a', undefined)
+    expect(result).not.toBeUndefined()
+    const r = result as ConcatPlaceholder
+    expect(r._kind).toBe('concat-placeholder')
+    const node = r.nodes[0] as SubstPlaceholder
+    expect(node.knownAbsent).toBe(true)
+  })
+
+  it('Concat with required self-ref node → returns undefined', () => {
+    const concat = makeConcat([makeSubst('a', false)])
+    const result = foldOrSkipPrior(concat, 'a', undefined)
+    expect(result).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// S13a.12 — plain already-resolved HoconValue arms.
+//
+// The parser always builds object literals as ResObj, so the plain
+// `{kind:'object'}` arms of navigateResolverValue / the fold walk are not
+// reachable from `parse()` today — they exist for already-resolved values
+// (resolved priors are plain HoconValues, and hoconValueToResObj leaves
+// objects inside arrays plain). Pin the contract directly so a future wiring
+// that feeds resolved values through the fold keeps working.
+// ---------------------------------------------------------------------------
+
+function scalarNum(raw: string): HoconValue {
   return { kind: 'scalar', raw, valueType: 'number' }
 }
 
@@ -44,52 +308,53 @@ function plainObj(fields: Record<string, HoconValue>): HoconValue & { kind: 'obj
   return { kind: 'object', fields: new Map(Object.entries(fields)) }
 }
 
+function makeSubstPath(texts: string[]): SubstPlaceholder {
+  return {
+    _kind: 'subst-placeholder',
+    segments: texts.map(seg),
+    optional: false,
+    knownAbsent: false,
+    listSuffix: false,
+    line: 1,
+    col: 1,
+    prefixLen: 0,
+  }
+}
+
 describe('navigateResolverValue — plain already-resolved object steps', () => {
   it('walks through a plain object field and dead-ends in its scalar (path-absent)', () => {
     // ResObj → plain object → scalar: the mid-walk step follows the plain
     // object's field, then the scalar leaf makes the remaining segment absent.
-    const root = makeResObj()
-    root.fields.set('a', plainObj({ b: scalar('1') }))
-    expect(navigateResolverValue(root, ['a', 'b'])).toEqual(scalar('1'))
+    const root = makeResObj({})
+    root.fields.set('a', plainObj({ b: scalarNum('1') }))
+    expect(navigateResolverValue(root, ['a', 'b'])).toEqual(scalarNum('1'))
     expect(navigateResolverValue(root, ['a', 'b', 'c'])).toBeUndefined()
   })
 
   it('reports a missing key on a plain object as path-absent', () => {
-    const root = makeResObj()
-    root.fields.set('a', plainObj({ b: scalar('1') }))
+    const root = makeResObj({})
+    root.fields.set('a', plainObj({ b: scalarNum('1') }))
     expect(navigateResolverValue(root, ['a', 'nope'])).toBeUndefined()
   })
 })
 
 describe('foldSelfRef — plain already-resolved object interiors', () => {
   it('rewrites an exact self-ref inside a plain object interior, leaving other fields', () => {
-    // A plain object whose field holds a live substitution — the shape an
-    // already-resolved value takes after partial resolution. The interior
-    // walk runs with the prefix rule off, so only the exact self-ref folds.
-    const interior = {
-      kind: 'object',
-      fields: new Map<string, HoconValue>([
-        ['h', subst(['foo']) as unknown as HoconValue],
-        ['keep', scalar('7')],
-      ]),
-    } satisfies HoconValue
-    const replacement = plainObj({ x: scalar('1') })
-    const folded = foldSelfRef(interior as ResolverValue, 'foo', replacement)
-    expect(folded).toEqual(plainObj({ h: replacement, keep: scalar('7') }))
+    const interior = plainObj({
+      h: makeSubst('foo', false) as unknown as HoconValue,
+      keep: scalarNum('7'),
+    })
+    const replacement = plainObj({ x: scalarNum('1') })
+    const folded = foldSelfRef(interior, 'foo', replacement)
+    expect(folded).toEqual(plainObj({ h: replacement, keep: scalarNum('7') }))
   })
 
   it('leaves a prefix self-ref inside a plain object interior standing (allowPrefix off)', () => {
     // Object interiors are S13a.14 territory: ${foo.a} nested inside must NOT
     // fold to the below value even though `foo` prefixes it.
-    const inner = subst(['foo', 'a'])
-    const interior = {
-      kind: 'object',
-      fields: new Map<string, HoconValue>([['h', inner as unknown as HoconValue]]),
-    } satisfies HoconValue
-    const folded = foldSelfRef(interior as ResolverValue, 'foo', plainObj({ a: scalar('2') }))
-    expect(folded).toEqual({
-      kind: 'object',
-      fields: new Map<string, HoconValue>([['h', inner as unknown as HoconValue]]),
-    })
+    const inner = makeSubstPath(['foo', 'a'])
+    const interior = plainObj({ h: inner as unknown as HoconValue })
+    const folded = foldSelfRef(interior, 'foo', plainObj({ a: scalarNum('2') }))
+    expect(folded).toEqual(plainObj({ h: inner as unknown as HoconValue }))
   })
 })

--- a/tests/s13a12-prefix-self-ref.test.ts
+++ b/tests/s13a12-prefix-self-ref.test.ts
@@ -20,7 +20,7 @@
 
 import { describe, expect, it } from 'vitest'
 
-import { parse, ResolveError } from '../src/index'
+import { parse, parseStringWithOptions, ResolveError } from '../src/index'
 
 // '$' via charcode to avoid IDE template-string lint on ${...} literals.
 const D = String.fromCharCode(36)
@@ -141,5 +141,105 @@ describe('S13a.12 — prefix self-reference resolves to "below"', () => {
       'bar { nested { x = { q: 10 }\na = ' + D + '{bar.nested.x}\na = { c: 3 } } }',
     ).toObject() as Record<string, Record<string, Record<string, unknown>>>
     expect(v['bar']!['nested']!['a']).toEqual({ q: 10, c: 3 })
+  })
+})
+
+describe('S13a.12 — bookkeeping, dead-ends, and lenient contract', () => {
+  it('layer merge carries BOTH layers priorValues (delayed-merge chains survive the splice)', () => {
+    // Two object layers below the sandwich: the navigated `a` carries its own
+    // delayed-merge chain (c:1 under c:2) and the below layer carries chains
+    // for a/k. Expected values verified against py.hocon (post-#37/#38).
+    expect(
+      foo(
+        'foo : { a : { c : 1 }, k : 1 }\nfoo : { a : { c : 2 }, k : 2 }\nfoo : ' +
+          D +
+          '{foo.a}\nfoo : { z : 9 }',
+      ),
+    ).toEqual({ a: { c: 2 }, k: 2, c: 2, z: 9 })
+  })
+
+  it("the navigated layer's own delayed-merge chains survive the splice", () => {
+    // The navigated `a` carries a priorValues chain of its own (c: {d:1} under
+    // ${x}) — the layer merge must carry it so the delayed merge still fires
+    // inside `a`, while the spliced top-level `c` keeps only the navigated
+    // side. Matches py.hocon (post-#37/#38) on the same input.
+    expect(
+      foo(
+        'foo : { a : { c : { d : 1 } } }\nfoo : { a : { c : ' +
+          D +
+          '{x} } }\nfoo : ' +
+          D +
+          '{foo.a}\nfoo : { z : 9 }\nx : { e : 5 }',
+      ),
+    ).toEqual({ a: { c: { d: 1, e: 5 } }, c: { e: 5 }, z: 9 })
+  })
+
+  it('fold-side walk that dead-ends in a scalar mid-path takes the undefined classification', () => {
+    expect(() => foo('foo : { a : 5 }\nfoo : ' + D + '{foo.a.b}\nfoo : { c : 1 }')).toThrow(
+      /could not resolve substitution/,
+    )
+  })
+
+  it('resolve-side walk that dead-ends in a scalar mid-path takes the undefined classification', () => {
+    expect(() => foo('foo : { a : 1 }\nfoo : ' + D + '{foo.a.b}')).toThrow(
+      /could not resolve substitution/,
+    )
+  })
+
+  it("resolve-side prior that itself fails to resolve propagates the prior's error", () => {
+    expect(() => foo('foo : { a : ' + D + '{zz} }\nfoo : ' + D + '{foo.a}')).toThrow(
+      /could not resolve substitution.*zz/,
+    )
+  })
+
+  it("optional final layer that vanishes falls back to the prior, and the prior's undefined classification still errors", () => {
+    expect(() =>
+      foo('foo : { a : 1 }\nfoo : ' + D + '{foo.b}\nfoo : ' + D + '{?zz}'),
+    ).toThrow(/could not resolve substitution/)
+  })
+
+  it('unrelated substitution inside a folded prior is left untouched', () => {
+    // The prior object holds an exact self-ref AND an unrelated ${bar} — the
+    // fold rewrites only the former. The self-ref sees the below-merge with
+    // its own occurrence unfolded one step ({x:1, h:{x:1}, o:9}), matching
+    // py.hocon (post-#37/#38) on the same input.
+    expect(
+      foo(
+        'foo : { x : 1 }\nfoo : { h : ' + D + '{foo}, o : ' + D + '{bar} }\nfoo : { z : 2 }\nbar : 9',
+      ),
+    ).toEqual({ x: 1, h: { x: 1, h: { x: 1 }, o: 9 }, o: 9, z: 2 })
+  })
+
+  it('self-ref inside an object literal inside an array folds against the below layer', () => {
+    // The array item is a plain object interior — the fold walks it with the
+    // prefix rule off, so only the exact self-ref rewrites. The optional final
+    // layer misses (an array is not navigable) and falls back to the prior.
+    expect(
+      foo('foo : { x : 1 }\nfoo : [ { h : ' + D + '{foo} } ]\nfoo : ' + D + '{?foo.q}'),
+    ).toEqual([{ h: { x: 1 } }])
+  })
+
+  it('allowUnresolved keeps a required prefix self-ref placeholder on the resolve side', () => {
+    const cfg = parseStringWithOptions('foo : { a : 1 }\nfoo : ' + D + '{foo.b}', {
+      resolveSubstitutions: false,
+    })
+    const out = cfg.resolve({ allowUnresolved: true })
+    expect(out.isResolved()).toBe(false)
+  })
+
+  it('allowUnresolved drops a poisoned prior from the delayed merge on the fold side', () => {
+    // The knownAbsent sentinel saved at the prior-save site resolves to a
+    // placeholder under allowUnresolved; not being an object, it is dropped
+    // from the delayed merge and the top layer resolves alone. The top layer
+    // carries its own substitution so the resolver actually visits the field
+    // (a placeholder-free tree takes the fast path). The strict-mode
+    // counterpart is the fold-side dead-end case above.
+    const cfg = parseStringWithOptions(
+      'foo : { a : 5 }\nfoo : ' + D + '{foo.a.b}\nfoo : { c : ' + D + '{x} }\nx : 1',
+      { resolveSubstitutions: false },
+    )
+    const out = cfg.resolve({ allowUnresolved: true })
+    expect(out.isResolved()).toBe(true)
+    expect((out.toObject() as Record<string, unknown>)['foo']).toEqual({ c: 1 })
   })
 })

--- a/tests/s13a12-prefix-self-ref.test.ts
+++ b/tests/s13a12-prefix-self-ref.test.ts
@@ -112,6 +112,17 @@ describe('S13a.12 — prefix self-reference resolves to "below"', () => {
     expect(foo('foo : { a : 1 }\nfoo : ' + D + '{?foo.nope}')).toEqual({ a: 1 })
   })
 
+  it('interior sibling reference stays a lazy final-tree lookup', () => {
+    // ${a.p.v} sits INSIDE a's object literal — an object-interior sibling
+    // reference, not a value-stack layer. It must keep S13a.14 lazy final-tree
+    // semantics (the allowPrefix narrowing), not fold to a below value.
+    const v = parse('a = { p : { v : 1 }, x : ' + D + '{a.p.v} }\na = { y : 2 }').toObject() as Record<
+      string,
+      unknown
+    >
+    expect(v['a']).toEqual({ p: { v: 1 }, x: 1, y: 2 })
+  })
+
   it('regression: non-self-ref delayed merge sandwich is unchanged', () => {
     expect(
       foo(

--- a/tests/s13a12-prefix-self-ref.test.ts
+++ b/tests/s13a12-prefix-self-ref.test.ts
@@ -81,6 +81,37 @@ describe('S13a.12 — prefix self-reference resolves to "below"', () => {
     expect(v['srv']!['foo']).toEqual({ a: 2, c: 1 })
   })
 
+  it('unnavigable below (live subst mid-walk): optional variant stays resolvable', () => {
+    // navigate([a, b]) hits the unresolved ${x} inside the below layer — the
+    // fold leaves the subst live and the resolve-time guard catches the
+    // re-entry; the optional form vanishes instead of erroring.
+    expect(
+      foo(
+        'foo : { a : ' + D + '{x} }\nfoo : ' + D + '{?foo.a.b}\nfoo : { z : 1 }\nx : { b : 7 }',
+      ),
+    ).toEqual({ z: 1 })
+  })
+
+  it('layer merge recurses into shared object keys', () => {
+    expect(
+      foo(
+        'foo : { shared : { p : 1 }, a : { shared : { q : 2 } } }\nfoo : ' +
+          D +
+          '{foo.a}\nfoo : { z : 0 }',
+      ),
+    ).toEqual({ shared: { p: 1, q: 2 }, a: { shared: { q: 2 } }, z: 0 })
+  })
+
+  it('two layers, required miss: undefined-substitution error', () => {
+    expect(() => foo('foo : { a : 1 }\nfoo : ' + D + '{foo.nope}')).toThrow(
+      /could not resolve substitution/,
+    )
+  })
+
+  it('two layers, optional miss: prior survives', () => {
+    expect(foo('foo : { a : 1 }\nfoo : ' + D + '{?foo.nope}')).toEqual({ a: 1 })
+  })
+
   it('regression: non-self-ref delayed merge sandwich is unchanged', () => {
     expect(
       foo(

--- a/tests/s13a12-prefix-self-ref.test.ts
+++ b/tests/s13a12-prefix-self-ref.test.ts
@@ -1,0 +1,103 @@
+// S13a.12 (HOCON.md L791) — a substitution whose target lies INSIDE the field
+// being defined (`foo : ${foo.a}`) resolves against the field's "below" value
+// (the merge of the stack beneath the substitution), never the final tree.
+//
+// Found 2026-08-18 by probing all four sibling implementations: every one
+// resolved the spec example against the final tree ("above"), yielding {a:2}
+// instead of {a:2, c:1}. The recorded ts ✅ was a misclassification (stale
+// test pointer); rs's cited lightbend_test06 cannot discriminate (its later
+// object overrides every key the substitution contributes). Root cause was a
+// missing prefix-direction case in self-reference detection: isOwner required
+// the resolving-field path to be at least as LONG as the target path, which
+// excludes `foo` ⊏ `foo.a`.
+//
+// The fix has two halves, mirrored across the siblings:
+//  - fold-self-ref: prefix self-refs fold at prior-save time (navigate the
+//    remainder into the old prior; standalone occurrences form a merge LAYER
+//    that keeps the below layer's other keys).
+//  - resolveSubst: a standing prefix self-ref resolves via the field's saved
+//    prior + remainder navigation, with undefined semantics on a miss.
+
+import { describe, expect, it } from 'vitest'
+
+import { parse, ResolveError } from '../src/index'
+
+// '$' via charcode to avoid IDE template-string lint on ${...} literals.
+const D = String.fromCharCode(36)
+
+function foo(src: string): unknown {
+  return (parse(src).toObject() as Record<string, unknown>)['foo']
+}
+
+describe('S13a.12 — prefix self-reference resolves to "below"', () => {
+  it('spec L791 example: foo:{a:{c:1}}; foo:${foo.a}; foo:{a:2} → {a:2, c:1}', () => {
+    expect(
+      foo('foo : { a : { c : 1 } }\nfoo : ' + D + '{foo.a}\nfoo : { a : 2 }'),
+    ).toEqual({ a: 2, c: 1 })
+  })
+
+  it('two layers, substitution last: merges the navigated object over the below', () => {
+    expect(foo('foo : { a : { c : 1 } }\nfoo : ' + D + '{foo.a}')).toEqual({
+      a: { c: 1 },
+      c: 1,
+    })
+  })
+
+  it('below layer keys not touched by the sandwich survive', () => {
+    expect(
+      foo(
+        'foo : { a : { c : 1 }, keep : 9 }\nfoo : ' + D + '{foo.a}\nfoo : { a : 2 }',
+      ),
+    ).toEqual({ a: 2, keep: 9, c: 1 })
+  })
+
+  it('navigating to a scalar resets the stack (later object wins alone)', () => {
+    expect(foo('foo : { a : 5 }\nfoo : ' + D + '{foo.a}\nfoo : { b : 2 }')).toEqual({
+      b: 2,
+    })
+  })
+
+  it('optional prefix self-ref with nothing below vanishes transparently', () => {
+    expect(
+      foo('foo : { a : 1 }\nfoo : ' + D + '{?foo.nope}\nfoo : { b : 2 }'),
+    ).toEqual({ a: 1, b: 2 })
+  })
+
+  it('required prefix self-ref with nothing below is an undefined-substitution error', () => {
+    expect(() =>
+      foo('foo : { a : 1 }\nfoo : ' + D + '{foo.nope}\nfoo : { b : 2 }'),
+    ).toThrow(ResolveError)
+    expect(() =>
+      foo('foo : { a : 1 }\nfoo : ' + D + '{foo.nope}\nfoo : { b : 2 }'),
+    ).toThrow(/could not resolve substitution/)
+  })
+
+  it('works on nested paths (prior lives on the parent scope)', () => {
+    const v = parse(
+      'srv : { foo : { a : { c : 1 } } }\nsrv : { foo : ' +
+        D +
+        '{srv.foo.a} }\nsrv : { foo : { a : 2 } }',
+    ).toObject() as Record<string, Record<string, unknown>>
+    expect(v['srv']!['foo']).toEqual({ a: 2, c: 1 })
+  })
+
+  it('regression: non-self-ref delayed merge sandwich is unchanged', () => {
+    expect(
+      foo(
+        'd = { x : { c : 1 } }\nfoo : { a : { c : 9 } }\nfoo : ' +
+          D +
+          '{d.x}\nfoo : { a : 2 }',
+      ),
+    ).toEqual({ c: 1, a: 2 })
+  })
+
+  it("regression: a sibling reference in a deeper field's prior still sees the final tree", () => {
+    // `a`'s prior holds ${bar.nested.x} — NOT a self-ref of a — and must
+    // resolve via the final tree even though [bar, nested] prefixes the
+    // target. Guarded by the rfp push/pop span covering prior resolution.
+    const v = parse(
+      'bar { nested { x = { q: 10 }\na = ' + D + '{bar.nested.x}\na = { c: 3 } } }',
+    ).toObject() as Record<string, Record<string, Record<string, unknown>>>
+    expect(v['bar']!['nested']!['a']).toEqual({ q: 10, c: 3 })
+  })
+})


### PR DESCRIPTION
## Summary

First of the same-window fixes across the 4 implementations (S13a.12, as reclassified in [xx#89](https://github.com/o3co/xx.hocon/pull/89)).

A substitution that has the path of the field being defined **as a proper prefix** (`foo : ${foo.a}`) was not detected as a self-ref and resolved against the final tree (above). The root cause: `isOwner` rejected the prefix direction with `rfp.length >= segments.length`.

| Input | before | after (= spec) |
|---|---|---|
| `foo:{a:{c:1}}; foo:${foo.a}; foo:{a:2}` (the spec L791 example) | `{a:2}` (c lost) | **`{a:2, c:1}`** |
| `foo:{a:{c:1}}; foo:${foo.a}` | unresolved error | **`{a:{c:1}, c:1}`** |
| other keys in below (`keep:9`) | — | **preserved** (layer merge) |
| `${?foo.nope}` (optional, absent in below) | — | the layer vanishes transparently |
| `${foo.nope}` (required, absent in below) | — | error with the undefined classification |

## Implementation

- **fold-self-ref**: prefix self-refs are folded when the prior is saved (navigating the remainder into the old prior). A standalone occurrence is a merge LAYER, preserving the other keys of the below layer via `mergeResObjLayers`
- **resolveSubst**: a standing prefix self-ref is resolved via the field's saved prior + remainder navigation (with a re-entrancy guard). The knownAbsent branch now respects optionality (the `+=` sentinel is always optional, so behavior is unchanged)
- **resolveResObj**: widened the rfp push/pop span to cover prior resolution — resolving the prior after the pop makes sibling references (`${bar.nested.x}`) prefix-false-hit against the shortened rfp (regression test included)

## Tests

- 9 dedicated cases (spec example / two layers / keep preservation / scalar reset / optional transparency / required error / nested path / non-self-ref regression / sibling-in-prior regression)
- full suite **1403 passed** (no regressions across sr01–11 / dr01–30 / the issue118 chain cases), typecheck / build green
- BREAKING (in the direction of values changing / errors going away) recorded in the CHANGELOG

The same fix for py / go / rs goes out next, in the same window. The discriminating fixtures in xx will be added after all 4 implementations merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
