### PR TITLE
fix(s9.2,s13.12): Lightbend conformance — preserve the triple-quote leading newline + omit undefined optional array elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **BREAKING (spec fix, S9.2): a triple-quoted string whose content starts
+  with a newline now preserves it** (`"""<LF>hello"""` → `"\nhello"`, was
+  `"hello"`). The lexer stripped the leading newline; the Lightbend reference
+  preserves every character between the quotes (probe 2026-08-18). Surfaced
+  by the py.hocon spec-verification wave — the same port bug ships in
+  py.hocon and rs.hocon fixes in lockstep.
+- **BREAKING (spec fix, S13.12): an undefined optional substitution in array
+  element position is now omitted** (`[1, ${?missing}, 3]` → `[1, 3]`, was
+  `[1, null, 3]`). Spec HOCON.md L635 and the Lightbend reference both drop
+  the element; a literal `null` element is unaffected. The previous ✅ cited
+  a fixture with no array-element case.
 - **BREAKING (spec fix, S13a.12): a substitution whose target lies inside the
   field being defined (`foo : ${foo.a}`) now resolves against the field's
   "below" value — the merge of the stack beneath the substitution — instead of

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -210,8 +210,8 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
   tests: tests/lexer.test.ts:98; tests/lightbend/testdata/equiv05/triple-quotes.conf (fixture)
   status: ✅
 - **S9.2** Newlines and whitespace preserved literally — §Multi-line strings (L293)
-  tests: tests/lexer.test.ts:98; tests/lightbend/testdata/equiv05/triple-quotes.conf (fixture)
-  status: ✅
+  tests: tests/lexer.test.ts:98; tests/s9-s13-lightbend-conformance.test.ts (leading-newline case); tests/lightbend/testdata/equiv05/triple-quotes.conf (fixture)
+  status: ✅ — the lexer stripped a LEADING newline (spec deviation; Lightbend preserves every character between the quotes — probe 2026-08-18, surfaced by the py.hocon verification wave); fixed 2026-08-18. equiv05 has no leading-newline case, which is how the strip survived the fixture.
 - **S9.3** Unicode escapes NOT interpreted inside triple-quoted — §Multi-line strings (L294)
   tests: tests/lightbend/testdata/equiv05/triple-quotes.conf (fixture)
   status: ✅
@@ -369,8 +369,8 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
   tests: tests/resolver.test.ts:103; tests/lightbend/testdata/equiv04/missing-substitutions.conf (fixture)
   status: ✅
 - **S13.12** Optional undefined in array element → element not added — §Substitutions (L635)
-  tests: tests/lightbend/testdata/equiv04/missing-substitutions.conf (fixture)
-  status: ✅
+  tests: tests/s9-s13-lightbend-conformance.test.ts (element omitted; literal null kept; nested arrays; concat-element remainder)
+  status: ✅ — the previous ✅ was a stale citation: equiv04/missing-substitutions.conf contains no array-element case, and the resolver actually null-filled the element ([1, null, 3]; Lightbend yields [1, 3] — probe 2026-08-18, surfaced by the py.hocon verification wave). Fixed 2026-08-18.
 - **S13.13** Optional undefined in string concat → empty string — §Substitutions (L636)
   tests: tests/resolver.test.ts:737
   status: ✅

--- a/src/internal/lexer/lexer.ts
+++ b/src/internal/lexer/lexer.ts
@@ -168,7 +168,6 @@ class Lexer {
         if (!closed) {
           throw new ParseError('unterminated triple-quoted string', sl, sc)
         }
-        if (value.startsWith('\n')) value = value.slice(1)
         this.push('triple_string', value, sl, sc, true)
         continue
       }

--- a/src/internal/resolver/substitution-resolver.ts
+++ b/src/internal/resolver/substitution-resolver.ts
@@ -174,14 +174,17 @@ export class SubstitutionResolver {
     if (isResObj(v)) return this.resolveResObj(v)
     const hv = v as HoconValue
     if (hv.kind === 'array') {
-      return {
-        kind: 'array',
-        items: hv.items.map(
-          (item: HoconValue) =>
-            this.resolveVal(item as ResolverValue, scope) ??
-            ({ kind: 'scalar', raw: 'null', valueType: 'null' } satisfies HoconValue),
-        ),
+      // S13.12 (HOCON.md L635): an element that resolves to nothing (an
+      // undefined optional substitution) is NOT added — Lightbend yields
+      // [1, 3] for `[1, ${?missing}, 3]`, never [1, null, 3]. A literal
+      // `null` element resolves to a null scalar (not undefined) and is kept.
+      const items: HoconValue[] = []
+      for (const item of hv.items) {
+        const resolved = this.resolveVal(item as ResolverValue, scope)
+        if (resolved === undefined) continue
+        items.push(resolved)
       }
+      return { kind: 'array', items }
     }
     return hv
   }

--- a/tests/lexer.test.ts
+++ b/tests/lexer.test.ts
@@ -102,9 +102,11 @@ describe('tokenize', () => {
     expect(t.isQuoted).toBe(true)
   })
 
-  it('strips leading newline from triple-quoted strings', () => {
+  it('preserves the leading newline in triple-quoted strings (S9.2)', () => {
+    // Lightbend preserves every character between the quotes (typesafe-config
+    // 1.4.6 probe, 2026-08-18); the old strip was a spec deviation.
     const [t] = tokenize('"""\nhello"""')
-    expect(t.value).toBe('hello')
+    expect(t.value).toBe('\nhello')
   })
 
   it('tokenizes unquoted strings', () => {

--- a/tests/s9-s13-lightbend-conformance.test.ts
+++ b/tests/s9-s13-lightbend-conformance.test.ts
@@ -1,0 +1,46 @@
+// S9.2 + S13.12 — two Lightbend-conformance fixes surfaced by the py.hocon
+// spec-verification wave (2026-08-18). Both were shared ts/py/rs port bugs;
+// go.hocon conformed all along. Expected values verified against the
+// Lightbend oracle (typesafe-config 1.4.6 probes):
+//   - `"""<LF>hello"""` → "\nhello" (every character between the quotes is
+//     preserved; the lexer used to strip a leading newline)
+//   - `[1, ${?missing}, 3]` → [1, 3] (an undefined optional substitution in
+//     element position is NOT added; the resolver used to null-fill it).
+//     The prior ✅ cited equiv04/missing-substitutions.conf, which contains
+//     no array-element case — a stale citation.
+
+import { describe, expect, it } from 'vitest'
+
+import { parse } from '../src/index'
+
+const D = String.fromCharCode(36)
+
+describe('S9.2 — triple-quoted strings preserve every character', () => {
+  it('preserves a leading newline', () => {
+    expect(parse('x = """\nhello"""').toObject()).toEqual({ x: '\nhello' })
+  })
+
+  it('still preserves inner newlines and whitespace', () => {
+    expect(parse('x = """a\n  b"""').toObject()).toEqual({ x: 'a\n  b' })
+  })
+})
+
+describe('S13.12 — undefined optional substitution in array element position', () => {
+  it('omits the element instead of null-filling it', () => {
+    expect(parse('arr = [1, ' + D + '{?missing}, 3]').toObject()).toEqual({ arr: [1, 3] })
+  })
+
+  it('keeps a literal null element', () => {
+    expect(parse('arr = [1, null, 3]').toObject()).toEqual({ arr: [1, null, 3] })
+  })
+
+  it('drops nested-array elements independently', () => {
+    expect(parse('arr = [[' + D + '{?m}], [1]]').toObject()).toEqual({ arr: [[], [1]] })
+  })
+
+  it('a concat element with an undefined optional keeps the literal remainder', () => {
+    // S13.13 semantics inside the element: the optional contributes an empty
+    // string, so the element itself survives as the concatenated remainder.
+    expect(parse('arr = [' + D + '{?m} foo]').toObject()).toEqual({ arr: [' foo'] })
+  })
+})


### PR DESCRIPTION
## Summary

Fixes **2 port bugs shared across ts/py/rs** discovered by py.hocon's verification-pinning wave ([o3co/py.hocon#39](https://github.com/o3co/py.hocon/pull/39)) (go.hocon conforms as-is). Expected values were settled by the Lightbend (typesafe-config 1.4.6) JVM probe (2026-08-18).

1. **S9.2**: the lexer stripped the leading newline of `"""<LF>hello"""` → preserve it (`"\nhello"`). The existing fixture equiv05 contains no leading-newline case, so it could not detect this. **BREAKING**
2. **S13.12**: the resolver null-filled `[1, ${?missing}, 3]` into `[1, null, 3]` → omit the element (`[1, 3]`). The previous ✅ was a stale citation of equiv04, which does **not** include array-element cases (the same shape of miscitation as S13a.12). Literal `null` elements are preserved. **BREAKING**

Same window: for py this is py#39 (lockstep premised on its merge), and the remaining sibling gets a simultaneous PR. As soon as all siblings are merged, discriminating fixtures (triple-quote leading newline + subst array element) and the matrix correction go out to xx.hocon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
