### PR TITLE
fix(s19,s21): align the unit table exactly with Lightbend — kB case / PB-YB / bare alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **BREAKING (spec fix, S21.2–S21.4): byte units now match the Lightbend
+  reference exactly.** The kilo-decimal spelling is `kB` — `KB`, `kb` and
+  every other case variant the old case-insensitive fallback accepted
+  (`Megabytes`, `mB`, `kiB`, …) are now errors, matching typesafe-config's
+  case-sensitive table (probe 2026-08-18). The table also extends through
+  `PB`–`YB`, `Pi`/`PiB`–`Yi`/`YiB` (+ long forms) and single-letter `Z`/`z`/
+  `Y`/`y`; magnitudes at or above 2^53 bytes still raise the documented
+  overflow guard. Part of the four-impl units audit.
+- `getDuration` now accepts the bare `nano`/`nanos`, `micro`/`micros`, and
+  `milli`/`millis` unit aliases (S19.1–S19.3) — part of the spec's unit lists
+  and accepted by Lightbend, previously missing from the table.
+
 - **BREAKING (spec fix, S9.2): a triple-quoted string whose content starts
   with a newline now preserves it** (`"""<LF>hello"""` → `"\nhello"`, was
   `"hello"`). The lexer stripped the leading newline; the Lightbend reference

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -728,14 +728,14 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
 ## S19. Duration format
 
 - **S19.1** `ns` / `nano` / `nanos` / `nanosecond` / `nanoseconds` — §Duration format (L1307)
-  tests: tests/config.test.ts:264
-  status: ✅
+  tests: tests/config.test.ts:264; tests/s19-s21-lightbend-units.test.ts (bare alias forms)
+  status: ✅ — the bare `nano`/`nanos` aliases were missing from the table (the prior ✅ pinned only the forms that existed); added 2026-08-18 in the four-impl units audit.
 - **S19.2** `us` / `micro` / `micros` / `microsecond` / `microseconds` — §Duration format (L1308)
-  tests: tests/config.test.ts:269
-  status: ✅
+  tests: tests/config.test.ts:269; tests/s19-s21-lightbend-units.test.ts (bare alias forms)
+  status: ✅ — the bare `micro`/`micros` aliases were missing; added 2026-08-18.
 - **S19.3** `ms` / `milli` / `millis` / `millisecond` / `milliseconds` — §Duration format (L1309)
-  tests: tests/config.test.ts:259
-  status: ✅
+  tests: tests/config.test.ts:259; tests/s19-s21-lightbend-units.test.ts (bare alias forms)
+  status: ✅ — the bare `milli`/`millis` aliases were missing; added 2026-08-18.
 - **S19.4** `s` / `second` / `seconds` — §Duration format (L1310)
   tests: tests/config.test.ts:239; tests/config.test.ts:274
   status: ✅
@@ -781,14 +781,14 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
   tests: tests/config.test.ts:313
   status: ✅
 - **S21.2** Powers of 10 (kB, MB, GB, TB, PB, EB, ZB, YB + long forms) — §Size in bytes format (L1365)
-  tests: tests/config.test.ts:318; tests/config.test.ts:328
-  status: ✅
+  tests: tests/config.test.ts:318; tests/config.test.ts:328; tests/s19-s21-lightbend-units.test.ts (PB–YB, case-sensitivity)
+  status: ✅ — the prior ✅ over-claimed: the table stopped at TB, was keyed `KB`, and a case-insensitive fallback accepted spellings Lightbend rejects. Aligned 2026-08-18 to the exact Lightbend set (probe): `kB` is the one kilo-decimal spelling (`KB`/`kb` are errors), decimals run through `YB`, long forms are lowercase only. EB+ magnitudes at count ≥1 exceed the 2^53 guard, so those rows pin unit recognition with fractional counts.
 - **S21.3** Powers of 2 (K/Ki/KiB, M/Mi/MiB, ...) — §Size in bytes format (L1376)
-  tests: tests/config.test.ts:323; tests/config.test.ts:333
-  status: ✅
+  tests: tests/config.test.ts:323; tests/config.test.ts:333; tests/s19-s21-lightbend-units.test.ts (Pi–Yi, `kiB`/`ki` rejected)
+  status: ✅ — extended 2026-08-18 through `Yi`/`YiB` + long forms; binary prefixes are capital-first exactly (`Ki`, never `ki`).
 - **S21.4** Single-letter abbreviations → powers of 2 (java -Xmx convention) — §Size in bytes format (L1385)
-  tests: tests/spec-s21-4-single-letter-bytes.test.ts; tests/conformance/byte-single-letter.test.ts; tests/config.test.ts (S21.4 block); tests/s18-units-default.test.ts (ub05)
-  status: ✅
+  tests: tests/spec-s21-4-single-letter-bytes.test.ts; tests/conformance/byte-single-letter.test.ts; tests/config.test.ts (S21.4 block); tests/s18-units-default.test.ts (ub05); tests/s19-s21-lightbend-units.test.ts (Z/z/Y/y)
+  status: ✅ — the ladder now runs through `Z`/`Y` (both cases, matching Lightbend); the old "Z/Y deferred" note is resolved via fractional-count pins under the 2^53 guard.
   notes: Fixed in Phase 6 #3h. `BYTE_UNITS` in `src/coerce.ts` now includes K/k/M/m/G/g/T/t/P/p/E/e
   as powers-of-two per HOCON.md L1385 (Lightbend typesafe-config 1.4.3 verified). Values exceeding
   `Number.MAX_SAFE_INTEGER` (e.g. 1E = 2^60) throw `RangeError`. Z/Y deferred (overflow BigInt scope).

--- a/docs/spec-compliance.md
+++ b/docs/spec-compliance.md
@@ -789,9 +789,10 @@ Section headings (S1–S26) match the template exactly for cross-impl matrix ali
 - **S21.4** Single-letter abbreviations → powers of 2 (java -Xmx convention) — §Size in bytes format (L1385)
   tests: tests/spec-s21-4-single-letter-bytes.test.ts; tests/conformance/byte-single-letter.test.ts; tests/config.test.ts (S21.4 block); tests/s18-units-default.test.ts (ub05); tests/s19-s21-lightbend-units.test.ts (Z/z/Y/y)
   status: ✅ — the ladder now runs through `Z`/`Y` (both cases, matching Lightbend); the old "Z/Y deferred" note is resolved via fractional-count pins under the 2^53 guard.
-  notes: Fixed in Phase 6 #3h. `BYTE_UNITS` in `src/coerce.ts` now includes K/k/M/m/G/g/T/t/P/p/E/e
-  as powers-of-two per HOCON.md L1385 (Lightbend typesafe-config 1.4.3 verified). Values exceeding
-  `Number.MAX_SAFE_INTEGER` (e.g. 1E = 2^60) throw `RangeError`. Z/Y deferred (overflow BigInt scope).
+  notes: Fixed in Phase 6 #3h; completed 2026-08-18. `BYTE_UNITS` in `src/coerce.ts` includes the
+  full single-letter ladder K/k…Y/y as powers-of-two per HOCON.md L1385. Values exceeding
+  `Number.MAX_SAFE_INTEGER` (e.g. 1E = 2^60, any count ≥ 1 of Z/Y) throw `RangeError`; Z/z/Y/y are
+  recognised units whose valid uses are fractional counts under the guard.
 - **S21.5** Fractional values supported (`0.5M`) — §Units format (L1281-1294) + §Size in bytes (L1335-1342)
   tests: tests/config.test.ts:384
   status: ✅

--- a/src/coerce.ts
+++ b/src/coerce.ts
@@ -50,9 +50,12 @@ export function coerceNumber(value: string): number | undefined {
 }
 
 const DURATION_UNITS: Record<string, number> = {
-  ns: 1e-6, nanosecond: 1e-6, nanoseconds: 1e-6,
-  us: 1e-3, microsecond: 1e-3, microseconds: 1e-3,
-  ms: 1, millisecond: 1, milliseconds: 1,
+  // S19.1–S19.3: the bare nano/micro/milli (+plural) aliases are part of the
+  // spec's unit lists (HOCON.md L1307–L1309) and accepted by Lightbend
+  // (typesafe-config 1.4.6 probe, 2026-08-18); they were missing here.
+  ns: 1e-6, nano: 1e-6, nanos: 1e-6, nanosecond: 1e-6, nanoseconds: 1e-6,
+  us: 1e-3, micro: 1e-3, micros: 1e-3, microsecond: 1e-3, microseconds: 1e-3,
+  ms: 1, milli: 1, millis: 1, millisecond: 1, milliseconds: 1,
   s: 1_000, second: 1_000, seconds: 1_000,
   m: 60_000, minute: 60_000, minutes: 60_000,
   h: 3_600_000, hour: 3_600_000, hours: 3_600_000,
@@ -92,31 +95,41 @@ export function parseDuration(value: string, outputUnit: DurationUnit = 'ms'): n
 }
 
 const BYTE_UNITS: Record<string, number> = {
-  B: 1, byte: 1, bytes: 1,
-  KB: 1_000, kilobyte: 1_000, kilobytes: 1_000,
-  KiB: 1_024, kibibyte: 1_024, kibibytes: 1_024,
+  // S21.1–S21.4 — the EXACT Lightbend/typesafe-config unit set (1.4.6 probe,
+  // 2026-08-18). Multi-letter units are case-sensitive: the SI decimal short
+  // form is `kB` (NOT `KB`/`kb` — Lightbend rejects both), higher decimals
+  // are `MB`…`YB`, binary prefixes are `Ki`/`KiB`…`Yi`/`YiB` with capital
+  // first letter, and long forms are lowercase only (`kilobyte`, never
+  // `Kilobyte`). Only the bare byte unit (`B`/`b`) and the single-letter
+  // -Xmx forms accept both cases. The old case-insensitive fallback and the
+  // lowercase alias rows accepted spellings Lightbend rejects — removed.
+  B: 1, b: 1, byte: 1, bytes: 1,
+  kB: 1_000, kilobyte: 1_000, kilobytes: 1_000,
   MB: 1_000_000, megabyte: 1_000_000, megabytes: 1_000_000,
-  MiB: 1_048_576, mebibyte: 1_048_576, mebibytes: 1_048_576,
   GB: 1_000_000_000, gigabyte: 1_000_000_000, gigabytes: 1_000_000_000,
-  GiB: 1_073_741_824, gibibyte: 1_073_741_824, gibibytes: 1_073_741_824,
   TB: 1_000_000_000_000, terabyte: 1_000_000_000_000, terabytes: 1_000_000_000_000,
-  TiB: 1_099_511_627_776, tebibyte: 1_099_511_627_776, tebibytes: 1_099_511_627_776,
-  // S21.4 — HOCON.md L1385: single-letter abbreviations → powers of two (java -Xmx convention).
-  // Lightbend typesafe-config 1.4.3 verified: 1K=1024, 1M=1048576, etc.
-  // Both upper- and lowercase accepted per Lightbend behaviour.
-  // Z/Y (2^70/2^80) are deferred — they overflow MAX_SAFE_INTEGER and require BigInt accessor.
+  PB: 1e15, petabyte: 1e15, petabytes: 1e15,
+  EB: 1e18, exabyte: 1e18, exabytes: 1e18,
+  ZB: 1e21, zettabyte: 1e21, zettabytes: 1e21,
+  YB: 1e24, yottabyte: 1e24, yottabytes: 1e24,
+  Ki: 1_024, KiB: 1_024, kibibyte: 1_024, kibibytes: 1_024,
+  Mi: 1_048_576, MiB: 1_048_576, mebibyte: 1_048_576, mebibytes: 1_048_576,
+  Gi: 1_073_741_824, GiB: 1_073_741_824, gibibyte: 1_073_741_824, gibibytes: 1_073_741_824,
+  Ti: 1_099_511_627_776, TiB: 1_099_511_627_776, tebibyte: 1_099_511_627_776, tebibytes: 1_099_511_627_776,
+  Pi: 1_024 ** 5, PiB: 1_024 ** 5, pebibyte: 1_024 ** 5, pebibytes: 1_024 ** 5,
+  Ei: 1_024 ** 6, EiB: 1_024 ** 6, exbibyte: 1_024 ** 6, exbibytes: 1_024 ** 6,
+  Zi: 1_024 ** 7, ZiB: 1_024 ** 7, zebibyte: 1_024 ** 7, zebibytes: 1_024 ** 7,
+  Yi: 1_024 ** 8, YiB: 1_024 ** 8, yobibyte: 1_024 ** 8, yobibytes: 1_024 ** 8,
+  // S21.4 — single-letter abbreviations → powers of two (java -Xmx
+  // convention); Lightbend accepts BOTH cases here, through the full ladder.
   K: 1_024, k: 1_024,
   M: 1_024 ** 2, m: 1_024 ** 2,
   G: 1_024 ** 3, g: 1_024 ** 3,
   T: 1_024 ** 4, t: 1_024 ** 4,
   P: 1_024 ** 5, p: 1_024 ** 5,
   E: 1_024 ** 6, e: 1_024 ** 6,
-  // lowercase short-form aliases
-  b: 1,
-  kb: 1_000, kib: 1_024,
-  mb: 1_000_000, mib: 1_048_576,
-  gb: 1_000_000_000, gib: 1_073_741_824,
-  tb: 1_000_000_000_000, tib: 1_099_511_627_776,
+  Z: 1_024 ** 7, z: 1_024 ** 7,
+  Y: 1_024 ** 8, y: 1_024 ** 8,
 }
 
 const OUTPUT_BYTE_UNITS: Record<string, number> = {
@@ -153,12 +166,9 @@ export function parseBytes(value: string, outputUnit: ByteUnit = 'B'): number {
     }
     return bytes / divisor
   }
-  // Try exact match first (preserves KB vs KiB distinction)
-  let mult = BYTE_UNITS[unit]
-  // Try lowercase for long-form names (megabytes, Megabytes, MEGABYTES)
-  if (mult === undefined) {
-    mult = BYTE_UNITS[unit.toLowerCase()]
-  }
+  // Exact, case-sensitive match — Lightbend's unit table is case-sensitive
+  // (`kB` parses, `KB`/`kb`/`Megabytes` are errors), so no case folding.
+  const mult = BYTE_UNITS[unit]
   if (mult === undefined) return NaN
   const bytes = num * mult
   // S21.4 overflow guard: JS number is float64 (MAX_SAFE_INTEGER = 2^53-1 ≈ 9.0e15).

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -374,8 +374,8 @@ describe('getBytes', () => {
     expect(c.getBytes('size')).toBe(1024)
   })
 
-  it('parses kilobytes (SI)', () => {
-    const c = parse('size = "10KB"')
+  it('parses kilobytes (SI) — Lightbend spelling kB', () => {
+    const c = parse('size = "10kB"')
     expect(c.getBytes('size')).toBe(10_000)
   })
 
@@ -446,14 +446,14 @@ describe('getBytes', () => {
     expect(c.getBytes('size')).toBe(1_500_000_000)
   })
 
-  it('parses lowercase short units', () => {
-    const c = parse('size = "10kb"')
-    expect(c.getBytes('size')).toBe(10_000)
-  })
-
-  it('parses mixed case units', () => {
-    const c = parse('size = "512mb"')
-    expect(c.getBytes('size')).toBe(512_000_000)
+  it('rejects non-Lightbend unit casings (S21.2 alignment)', () => {
+    // Lightbend's unit table is case-sensitive: kB parses, KB/kb/Kb do not,
+    // and long forms are lowercase only (probe 2026-08-18). The old
+    // case-insensitive fallback accepted spellings the reference rejects.
+    for (const bad of ['10KB', '10kb', '10Kb', '512mb', '1mB', '1Kilobyte', '1MEGABYTES', '1kiB', '1ki']) {
+      const c = parse(`size = "${bad}"`)
+      expect(() => c.getBytes('size'), bad).toThrow()
+    }
   })
 
   it('rounds to integer when output unit is bytes', () => {

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -452,7 +452,7 @@ describe('getBytes', () => {
     // case-insensitive fallback accepted spellings the reference rejects.
     for (const bad of ['10KB', '10kb', '10Kb', '512mb', '1mB', '1Kilobyte', '1MEGABYTES', '1kiB', '1ki']) {
       const c = parse(`size = "${bad}"`)
-      expect(() => c.getBytes('size'), bad).toThrow()
+      expect(() => c.getBytes('size'), bad).toThrow(ConfigError)
     }
   })
 

--- a/tests/s19-s21-lightbend-units.test.ts
+++ b/tests/s19-s21-lightbend-units.test.ts
@@ -1,0 +1,101 @@
+// S19.1–S19.3 / S21.2–S21.4 — unit-table alignment with the Lightbend
+// reference (typesafe-config 1.4.6 probes, 2026-08-18), part of the four-impl
+// units audit the py.hocon verification wave triggered:
+//
+//   - the bare nano/micro/milli (+plural) duration aliases were missing
+//   - the byte table stopped at TiB (spec lists through YB / YiB) and was
+//     keyed `KB` with a case-insensitive fallback — Lightbend's table is
+//     case-sensitive and its kilo-decimal spelling is `kB` (KB/kb are errors)
+//
+// Magnitudes at or above 2^53 bytes hit the documented overflow guard, so the
+// EB+ rows pin unit RECOGNITION with fractional counts — the same shape
+// Lightbend itself needs past its own Java-long ceiling.
+
+import { describe, expect, it } from 'vitest'
+
+import { parseBytes, parseDuration } from '../src/coerce.js'
+
+describe('S19.1–S19.3 — bare duration alias forms', () => {
+  it.each([
+    ['nano', 1e-6],
+    ['nanos', 1e-6],
+    ['micro', 1e-3],
+    ['micros', 1e-3],
+    ['milli', 1],
+    ['millis', 1],
+  ])('accepts 1%s', (unit, ms) => {
+    expect(parseDuration(`1${unit}`)).toBe(ms)
+  })
+
+  it('rejects sec/secs (not in the spec list; Lightbend rejects them)', () => {
+    expect(parseDuration('1sec')).toBeNaN()
+    expect(parseDuration('1secs')).toBeNaN()
+  })
+})
+
+describe('S21.2 — decimal units through YB', () => {
+  it.each([
+    ['1kB', 1e3],
+    ['1MB', 1e6],
+    ['1GB', 1e9],
+    ['1TB', 1e12],
+    ['1PB', 1e15],
+    ['1petabyte', 1e15],
+    ['0.001EB', 1e15],
+    ['0.000001ZB', 1e15],
+    ['0.000000001YB', 1e15],
+    ['0.001exabytes', 1e15],
+    ['0.000001zettabyte', 1e15],
+    ['0.000000001yottabytes', 1e15],
+  ])('parses %s', (text, want) => {
+    expect(parseBytes(text)).toBe(want)
+  })
+
+  it('magnitudes past the 2^53 guard throw', () => {
+    expect(() => parseBytes('1EB')).toThrow(RangeError)
+    expect(() => parseBytes('1ZB')).toThrow(RangeError)
+  })
+})
+
+describe('S21.3 — binary units through Yi/YiB', () => {
+  it.each([
+    ['1Ki', 1024],
+    ['1KiB', 1024],
+    ['1Pi', 1024 ** 5],
+    ['1PiB', 1024 ** 5],
+    ['1pebibytes', 1024 ** 5],
+  ])('parses %s', (text, want) => {
+    expect(parseBytes(text)).toBe(want)
+  })
+
+  it('pins Ei/Zi/Yi recognition with fractional counts', () => {
+    expect(parseBytes('0.001EiB')).toBe(Math.round(1e-3 * 1024 ** 6))
+    expect(parseBytes('0.000001Zi')).toBe(Math.round(1e-6 * 1024 ** 7))
+    expect(parseBytes('0.000000001yobibyte')).toBe(Math.round(1e-9 * 1024 ** 8))
+  })
+})
+
+describe('S21.4 — single letters both cases through Z/Y', () => {
+  it('accepts Z/z/Y/y with fractional counts (count 1 overflows the guard)', () => {
+    expect(parseBytes('0.000001Z')).toBe(Math.round(1e-6 * 1024 ** 7))
+    expect(parseBytes('0.000001z')).toBe(Math.round(1e-6 * 1024 ** 7))
+    expect(parseBytes('0.000000001Y')).toBe(Math.round(1e-9 * 1024 ** 8))
+    expect(parseBytes('0.000000001y')).toBe(Math.round(1e-9 * 1024 ** 8))
+  })
+})
+
+describe('S21 — Lightbend case-sensitivity', () => {
+  it.each(['1KB', '1kb', '1Kb', '1mB', '1Kilobyte', '1MEGABYTES', '1kiB', '1ki', '1Byte'])(
+    'rejects %s',
+    (text) => {
+      expect(parseBytes(text)).toBeNaN()
+    },
+  )
+
+  it('keeps the two-case exceptions: bare byte unit and single letters', () => {
+    expect(parseBytes('1B')).toBe(1)
+    expect(parseBytes('1b')).toBe(1)
+    expect(parseBytes('1K')).toBe(1024)
+    expect(parseBytes('1k')).toBe(1024)
+  })
+})

--- a/tests/spec-s21-4-single-letter-bytes.test.ts
+++ b/tests/spec-s21-4-single-letter-bytes.test.ts
@@ -75,9 +75,9 @@ describe('S21.4 — single-letter byte abbreviations → powers of two (HOCON.md
     expect(() => parseBytes('1e')).toThrow(RangeError)
   })
 
-  // Regression guard: multi-letter units (KB/MB) remain unchanged (SI decimal)
-  it('S21.4 regression: parseBytes("1KB") = 1000 (multi-letter KB stays SI decimal)', () => {
-    expect(parseBytes('1KB')).toBe(1_000)
+  // Regression guard: multi-letter units (kB/MB) remain unchanged (SI decimal)
+  it('S21.4 regression: parseBytes("1kB") = 1000 (multi-letter kB stays SI decimal)', () => {
+    expect(parseBytes('1kB')).toBe(1_000)
   })
 
   it('S21.4 regression: parseBytes("1MB") = 1000000 (multi-letter MB stays SI decimal)', () => {


### PR DESCRIPTION
## Summary

**Units audit across the 4 implementations** — horizontal rollout of the findings from py's verification-pinning wave. With the Lightbend (typesafe-config 1.4.6) JVM probe (2026-08-18) as the authority, bring the duration/byte unit table into exact alignment with the reference.

Lightbend's accepted set (settled by the probe):
- kilo-decimal is **`kB` only** (`KB`/`kb`/`Kb` are errors). Decimal is `MB` through `YB`, and long forms are lowercase only (`Kilobyte` errors)
- binary is capital-first `Ki`/`KiB` through `Yi`/`YiB` (`kiB`/`ki` error)
- both cases are accepted only for the bare byte unit (`B`/`b`) and the single-letter -Xmx forms (`K`/`k` through `Y`/`y`)
- duration has **no week** (`1w` errors; week exists only in the Period format)
- ZB/YB/Zi/Yi are recognized as units, and results exceeding long/int64 are range errors (a count ≥1 always overflows; only fractional counts are valid)

Same window: 4 PRs across go / ts / rs / py. The xx matrix is updated after merge. The BREAKING changes ship with v1.13.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
