### PR TITLE
feat(adapters): json5 — JSON5 1.0.0 ingestion, hand-rolled scanner with zero dependencies (F3.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`adapters/json5` — JSON5 1.0.0 ingestion (spec F3.3).** A new
+  `@o3co/ts.hocon/adapters/json5` subpath exporting `parseJson5`, a port of
+  go.hocon's `adapters/json5` shipping in lockstep with it
+  ([go.hocon#193](https://github.com/o3co/go.hocon/pull/193)) and with the
+  py.hocon / rs.hocon ports. The accepted grammar is JSON5 1.0.0 as defined by
+  the reference implementation (the json5 npm package, the dialect owner) —
+  but JSON5 changes the token grammar itself (unquoted identifier keys,
+  single-quoted strings with line continuations, hex integers, leading and
+  trailing decimal points, an explicit plus sign), so unlike the jsonc adapter
+  this is a hand-rolled scanner and recursive-descent parser. Zero new
+  dependencies. Where the mapping spec is stricter than JSON5, the spec wins:
+  integers — decimal or hex — must fit in int64, carried past 2^53 as lossless
+  digits (F0.5); `Infinity`/`NaN` in every spelling are errors (F0.6); an
+  unpaired `\uXXXX` surrogate escape is an error and a valid pair combines
+  (F3.5 — the scanner is ours here, so unlike `adapters/jsonc` the four
+  implementations agree; a raw lone surrogate code unit in source is still
+  host string data); duplicate keys follow HOCON semantics — objects merge,
+  otherwise last-wins (F0.7); and exactly one top-level value with a strict
+  EOF check (the F3.2 strictness rule). A `//` comment ends at LS/PS as well
+  as LF/CR — deliberately different from the jsonc dialect, whose owner ends
+  comments at LF/CR only.
+
 ### Fixed
 
 - **BREAKING (spec fix, S9.2): a triple-quoted string whose content starts

--- a/README.ja.md
+++ b/README.ja.md
@@ -349,6 +349,7 @@ const merged = cfg.withFallback(base).resolve()
 | `@o3co/ts.hocon/adapters/properties` | — | `java.util.Properties`。`include` と構文レイヤーを共有 |
 | `@o3co/ts.hocon/adapters/env` | — | プレフィックス付き名前空間の一括マウント。`.env` の読み込みも可能 |
 | `@o3co/ts.hocon/adapters/jsonc` | — | コメントと末尾カンマを許す JSON |
+| `@o3co/ts.hocon/adapters/json5` | — | JSON5 1.0.0。手書き scanner で依存ゼロ |
 | `@o3co/ts.hocon/adapters/toml` | `smol-toml` | オプショナルなピア依存 |
 | `@o3co/ts.hocon/adapters/yaml` | `yaml` 2.9.x | オプショナルなピア依存。スカラー解決はそのライブラリの答えで、`version: '1.2'` を明示してドリフトを防止 |
 

--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ Deferring resolution matters: the plain `parse` resolves as it goes, so a
 | `@o3co/ts.hocon/adapters/properties` | — | `java.util.Properties`, sharing the `include` syntax layer |
 | `@o3co/ts.hocon/adapters/env` | — | Bulk-mounts a prefixed namespace; also reads `.env` |
 | `@o3co/ts.hocon/adapters/jsonc` | — | JSON with comments and trailing commas |
+| `@o3co/ts.hocon/adapters/json5` | — | JSON5 1.0.0, hand-rolled scanner, zero dependencies |
 | `@o3co/ts.hocon/adapters/toml` | `smol-toml` | Optional peer dependency |
 | `@o3co/ts.hocon/adapters/yaml` | `yaml` 2.9.x | Optional peer dependency; scalar resolution is that library's answer, with `version: '1.2'` declared so it cannot drift |
 
@@ -458,11 +459,12 @@ cfg.getString('"foo.bar"')   // "dotted"  — one key whose name contains a dot
 cfg.getString('foo.bar')     // "nested"  — foo -> bar
 ```
 
-### Numbers from JSONC and YAML
+### Numbers from JSONC, JSON5 and YAML
 
 Integers are ingested losslessly: an integer literal too wide for a JS `number`
 keeps its digits instead of being rounded, and one outside the int64 range is
-refused rather than silently mangled. What you get back depends on the getter:
+refused rather than silently mangled (JSON5's hex integers included). What you
+get back depends on the getter:
 
 ```ts
 const cfg = parseJsonc('{"id": 9007199254740993}')

--- a/package.json
+++ b/package.json
@@ -62,6 +62,16 @@
         "default": "./dist/adapters/jsonc.cjs"
       }
     },
+    "./adapters/json5": {
+      "import": {
+        "types": "./dist/adapters/json5.d.ts",
+        "default": "./dist/adapters/json5.js"
+      },
+      "require": {
+        "types": "./dist/adapters/json5.d.cts",
+        "default": "./dist/adapters/json5.cjs"
+      }
+    },
     "./adapters/toml": {
       "import": {
         "types": "./dist/adapters/toml.d.ts",

--- a/src/adapters/json5.ts
+++ b/src/adapters/json5.ts
@@ -573,6 +573,10 @@ class Parser {
       if (mag > limit) {
         throw this.errf(`integer ${this.src.slice(start, this.pos)} does not fit in int64 (spec F0.5)`)
       }
+      // BigInt has no -0, so a negative zero hex literal (-0x0) would lose
+      // its sign here; route it through the number path, which preserves -0
+      // (the adapter's documented behaviour for decimal literals).
+      if (neg && mag === 0n) return -0
       return integerValue(neg ? -mag : mag)
     }
 

--- a/src/adapters/json5.ts
+++ b/src/adapters/json5.ts
@@ -1,0 +1,627 @@
+import { fromMap } from '../value-factory.js'
+import type { Config } from '../config.js'
+import { ConfigError } from '../errors.js'
+import { stripBom } from '../internal/strip-bom.js'
+import { depthError, guardStackDepth } from '../internal/depth.js'
+
+/**
+ * Read JSON5 (https://json5.org, spec 1.0.0) as HOCON config.
+ *
+ * Unlike the jsonc adapter — which strips comments and hands the rest to
+ * `JSON.parse` — JSON5 changes the token grammar itself (unquoted identifier
+ * keys, single-quoted strings with line continuations, hex integers, leading
+ * and trailing decimal points, an explicit plus sign), so this adapter is a
+ * hand-rolled scanner and recursive-descent parser. Zero dependencies, like
+ * every adapter in this package; it is a port of go.hocon's `adapters/json5`.
+ *
+ * The accepted grammar is JSON5 1.0.0 as defined by the reference
+ * implementation (the json5 npm package), the dialect owner this spec item
+ * tracks — the same ownership rule F3.2 applies to JSONC. That is why a `//`
+ * comment here ends at LS/PS as well as LF/CR, while the jsonc adapter's runs
+ * through them: each dialect's owner decides. Where the mapping spec is
+ * stricter than JSON5, the spec wins:
+ *
+ *   - `Infinity` and `NaN` (signed or bare) are errors, not values (spec F0.6).
+ *   - Integers — decimal or hex — must fit in int64 (spec F0.5); a number
+ *     written with `.`, `e` or `E` is a float, all other decimal forms and
+ *     every hex form are integers. An integer past 2^53 is carried as a
+ *     `bigint` so its digits survive verbatim (`getString` returns them
+ *     exactly); `getNumber` and `toObject` still apply the JS number model,
+ *     as they do for HOCON's own literals.
+ *   - An unpaired `\uXXXX` surrogate **escape** is an error, and a valid pair
+ *     combines into the astral codepoint (spec F3.5). This deliberately
+ *     differs from the jsonc adapter, which accepts one: there `JSON.parse` —
+ *     the host language's own decoder — owns the escape, and refusing would be
+ *     the spec overriding the platform (the S1.2.6 class). Here the scanner is
+ *     ours, so the four implementations can and do agree. A lone surrogate
+ *     *code unit* sitting raw in the source string is still accepted as data —
+ *     a JavaScript string is UTF-16 and holds it natively; go.hocon's
+ *     equivalent check rejects invalid UTF-8 bytes, a case that cannot arise
+ *     in a JS string.
+ *   - Duplicate keys follow HOCON semantics: objects merge, otherwise the
+ *     later value wins (spec F0.7).
+ *   - The document holds exactly one value; whitespace and comments may follow
+ *     it, anything else is an error (the F3.2 strictness rule).
+ *
+ * See the F3.x items in the format-ingestion mapping spec:
+ * https://github.com/o3co/xx.hocon/blob/main/docs/format-ingestion-mapping.md
+ */
+export function parseJson5(input: string, originDescription?: string): Config {
+  // F0.9: a leading BOM is not data. (JSON5 additionally treats U+FEFF as
+  // whitespace anywhere, which the scanner handles; stripping here keeps the
+  // origin column of the first token honest.)
+  const p = new Parser(stripBom(input), originDescription)
+  // The parser recurses once per nesting level, so the guard has to wrap it —
+  // fromMap below carries its own.
+  const doc = guardStackDepth(
+    () => p.parseDocument(),
+    msg => depthError(`json5: ${describe(originDescription)}: ${msg}`),
+  )
+  if (doc === null || typeof doc !== 'object' || Array.isArray(doc)) {
+    throw new ConfigError(
+      `json5: ${describe(originDescription)}: document root is ${rootKind(doc)}, but a config root must be an object (spec F0.3)`,
+      '',
+    )
+  }
+  return fromMap(doc, originDescription)
+}
+
+function describe(origin: string | undefined): string {
+  return origin === undefined || origin === '' ? 'document' : origin
+}
+
+function rootKind(doc: Json5Value): string {
+  if (doc === null) return 'null'
+  if (Array.isArray(doc)) return 'an array'
+  return typeof doc
+}
+
+// ─── Scanner / parser ─────────────────────────────────────────────────────────
+
+type Json5Value = null | boolean | string | number | bigint | Json5Value[] | Json5Object
+type Json5Object = { [key: string]: Json5Value }
+
+/** HOCON integers are int64-wide (spec F0.5); past these bounds is an error. */
+const INT64_MAX = 9223372036854775807n
+const INT64_MIN = -9223372036854775808n
+
+/**
+ * The JSON5 LineTerminator set: LF, CR, LS, PS. This deliberately differs from
+ * the jsonc adapter (F3.2), whose dialect owner ends `//` comments at LF/CR
+ * only — the JSON5 spec includes LS and PS.
+ */
+function isLineTerminator(cp: number): boolean {
+  return cp === 0x0a || cp === 0x0d || cp === 0x2028 || cp === 0x2029
+}
+
+const ZS_RE = /^\p{Zs}$/u
+
+/** The JSON5 WhiteSpace set: TAB, VT, FF, SP, NBSP, BOM, and any Unicode Zs. */
+function isJson5Space(cp: number): boolean {
+  switch (cp) {
+    case 0x09:
+    case 0x0b:
+    case 0x0c:
+    case 0x20:
+    case 0xa0:
+    case 0xfeff:
+      return true
+    default:
+      return ZS_RE.test(String.fromCodePoint(cp))
+  }
+}
+
+// isIdentStart / isIdentPart implement ES5 IdentifierName characters, the key
+// grammar the JSON5 spec adopts: start = UnicodeLetter (Lu Ll Lt Lm Lo Nl) |
+// '$' | '_'; part adds Mn Mc Nd Pc and ZWNJ/ZWJ.
+const IDENT_START_RE = /^[\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}]$/u
+const IDENT_PART_EXTRA_RE = /^[\p{Mn}\p{Mc}\p{Nd}\p{Pc}]$/u
+
+function isIdentStart(cp: number): boolean {
+  return cp === 0x24 || cp === 0x5f || IDENT_START_RE.test(String.fromCodePoint(cp))
+}
+
+function isIdentPart(cp: number): boolean {
+  return (
+    isIdentStart(cp) || cp === 0x200c || cp === 0x200d ||
+    IDENT_PART_EXTRA_RE.test(String.fromCodePoint(cp))
+  )
+}
+
+/**
+ * Whether `s` continues with an identifier character at index `i` — used to
+ * reject tokens like `nullx`, and to keep `Infinityx` an unexpected token
+ * rather than the F0.6 case.
+ */
+function continuesIdentifier(s: string, i: number): boolean {
+  if (i >= s.length) return false
+  return isIdentPart(s.codePointAt(i) as number)
+}
+
+function isHexDigit(c: string): boolean {
+  return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F')
+}
+
+const hex4 = (cp: number): string => cp.toString(16).toUpperCase().padStart(4, '0')
+
+/** Whether this parsed value is an object (for F0.7 duplicate-key merging). */
+function isPlainObject(v: Json5Value): v is Json5Object {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+}
+
+/**
+ * Merge `src` over `dst` per HOCON duplicate-key semantics (F0.7), returning a
+ * new object. Carriers are null-prototype so a `__proto__` key stays an own
+ * property (the F2.9 principle: safety by construction, never by dropping keys).
+ */
+function mergeObjects(dst: Json5Object, src: Json5Object): Json5Object {
+  const out = Object.create(null) as Json5Object
+  for (const [k, v] of Object.entries(dst)) out[k] = v
+  for (const [k, v] of Object.entries(src)) {
+    const prev = k in out ? out[k] : undefined
+    if (prev !== undefined && isPlainObject(prev) && isPlainObject(v)) {
+      out[k] = mergeObjects(prev, v)
+    } else {
+      out[k] = v
+    }
+  }
+  return out
+}
+
+class Parser {
+  private pos = 0 // UTF-16 code unit offset
+  private line = 0 // 0-based; reported 1-based
+  private lineAt = 0 // code unit offset where the current line starts
+
+  constructor(
+    private readonly src: string,
+    private readonly origin: string | undefined,
+  ) {}
+
+  private errf(msg: string): ConfigError {
+    const col = [...this.src.slice(this.lineAt, this.pos)].length + 1
+    return new ConfigError(
+      `json5: ${describe(this.origin)}: line ${this.line + 1} col ${col}: ${msg}`,
+      '',
+    )
+  }
+
+  /** The code point at `pos` (caller guarantees `pos < src.length`). */
+  private rune(): { cp: number; size: number } {
+    const cp = this.src.codePointAt(this.pos) as number
+    return { cp, size: cp > 0xffff ? 2 : 1 }
+  }
+
+  private advance(cp: number, size: number): void {
+    this.pos += size
+    if (isLineTerminator(cp)) {
+      // Treat CRLF as one terminator for line counting.
+      if (cp === 0x0d && this.src[this.pos] === '\n') this.pos++
+      this.line++
+      this.lineAt = this.pos
+    }
+  }
+
+  /**
+   * Parse exactly one JSON5 value, allowing only whitespace and comments after
+   * it (the F3.2 strictness rule).
+   */
+  parseDocument(): Json5Value {
+    this.skipSpace()
+    const v = this.parseValue()
+    this.skipSpace()
+    if (this.pos < this.src.length) {
+      throw this.errf('unexpected content after top-level value')
+    }
+    return v
+  }
+
+  /** Consume whitespace, line terminators, and both comment forms. */
+  private skipSpace(): void {
+    while (this.pos < this.src.length) {
+      const { cp, size } = this.rune()
+      if (isJson5Space(cp) || isLineTerminator(cp)) {
+        this.advance(cp, size)
+        continue
+      }
+      if (cp === 0x2f && this.src[this.pos + 1] === '/') {
+        this.pos += 2
+        // A // comment ends at ANY JSON5 line terminator — LS/PS included,
+        // unlike the jsonc dialect. The terminator itself is left for the
+        // outer loop, which counts the line.
+        while (this.pos < this.src.length) {
+          const cp2 = this.src.codePointAt(this.pos) as number
+          if (isLineTerminator(cp2)) break
+          this.pos += cp2 > 0xffff ? 2 : 1
+        }
+        continue
+      }
+      if (cp === 0x2f && this.src[this.pos + 1] === '*') {
+        this.pos += 2
+        let closed = false
+        while (this.pos < this.src.length) {
+          const r2 = this.rune()
+          if (r2.cp === 0x2a && this.src[this.pos + 1] === '/') {
+            this.pos += 2
+            closed = true
+            break
+          }
+          this.advance(r2.cp, r2.size)
+        }
+        if (!closed) throw this.errf('unterminated /* comment')
+        continue
+      }
+      return
+    }
+  }
+
+  private parseValue(): Json5Value {
+    if (this.pos >= this.src.length) {
+      throw this.errf('unexpected end of input, expected a value')
+    }
+    const c = this.src[this.pos] as string
+    if (c === '{') return this.parseObject()
+    if (c === '[') return this.parseArray()
+    if (c === '"' || c === "'") return this.parseString(c)
+    if (c === '+' || c === '-' || c === '.' || (c >= '0' && c <= '9')) return this.parseNumber()
+    return this.parseKeyword()
+  }
+
+  /**
+   * Handle true/false/null, and reject Infinity/NaN by name so the error
+   * explains itself (spec F0.6).
+   */
+  private parseKeyword(): Json5Value {
+    const rest = this.src.slice(this.pos)
+    for (const [kw, v] of [
+      ['true', true],
+      ['false', false],
+      ['null', null],
+    ] as const) {
+      if (rest.startsWith(kw) && !continuesIdentifier(rest, kw.length)) {
+        this.pos += kw.length
+        return v
+      }
+    }
+    for (const kw of ['Infinity', 'NaN']) {
+      if (rest.startsWith(kw) && !continuesIdentifier(rest, kw.length)) {
+        throw this.errf(`${kw} is not representable in the HOCON number model (spec F0.6)`)
+      }
+    }
+    const first = String.fromCodePoint(rest.codePointAt(0) as number)
+    throw this.errf(`unexpected character ${JSON.stringify(first)}`)
+  }
+
+  // ── Objects and arrays ──────────────────────────────────────────────────────
+
+  private parseObject(): Json5Object {
+    this.pos++ // '{'
+    // Null-prototype carrier: `__proto__` must land as an own property, never
+    // through the inherited setter (the F2.9 principle).
+    const obj = Object.create(null) as Json5Object
+    for (;;) {
+      this.skipSpace()
+      if (this.pos >= this.src.length) throw this.errf("unterminated object, expected '}'")
+      if (this.src[this.pos] === '}') {
+        this.pos++
+        return obj
+      }
+      const key = this.parseMemberName()
+      this.skipSpace()
+      if (this.pos >= this.src.length || this.src[this.pos] !== ':') {
+        throw this.errf(`expected ':' after object key ${JSON.stringify(key)}`)
+      }
+      this.pos++
+      this.skipSpace()
+      let val = this.parseValue()
+      // F0.7: duplicate keys follow HOCON semantics — two objects merge, any
+      // other combination is last-wins.
+      if (key in obj) {
+        const prev = obj[key] as Json5Value
+        if (isPlainObject(prev) && isPlainObject(val)) val = mergeObjects(prev, val)
+      }
+      obj[key] = val
+      this.skipSpace()
+      if (this.pos >= this.src.length) throw this.errf("unterminated object, expected ',' or '}'")
+      const c = this.src[this.pos]
+      if (c === ',') {
+        this.pos++ // trailing comma before '}' is legal; loop handles it
+      } else if (c === '}') {
+        this.pos++
+        return obj
+      } else {
+        throw this.errf("expected ',' or '}' in object")
+      }
+    }
+  }
+
+  private parseArray(): Json5Value[] {
+    this.pos++ // '['
+    const arr: Json5Value[] = []
+    for (;;) {
+      this.skipSpace()
+      if (this.pos >= this.src.length) throw this.errf("unterminated array, expected ']'")
+      if (this.src[this.pos] === ']') {
+        this.pos++
+        return arr
+      }
+      arr.push(this.parseValue())
+      this.skipSpace()
+      if (this.pos >= this.src.length) throw this.errf("unterminated array, expected ',' or ']'")
+      const c = this.src[this.pos]
+      if (c === ',') {
+        this.pos++ // trailing comma before ']' is legal; loop handles it
+      } else if (c === ']') {
+        this.pos++
+        return arr
+      } else {
+        throw this.errf("expected ',' or ']' in array")
+      }
+    }
+  }
+
+  // ── Member names (quoted or ES5 IdentifierName) ─────────────────────────────
+
+  private parseMemberName(): string {
+    const c = this.src[this.pos]
+    if (c === '"' || c === "'") return this.parseString(c)
+    return this.parseIdentifier()
+  }
+
+  /**
+   * Scan an ES5 IdentifierName, honouring `\uXXXX` escapes in the name (the
+   * escaped codepoint must itself be a legal identifier character for its
+   * position, per ES5 — `1` cannot start a key).
+   */
+  private parseIdentifier(): string {
+    let name = ''
+    let first = true
+    while (this.pos < this.src.length) {
+      const r = this.rune()
+      let cp = r.cp
+      let escaped = false
+      if (cp === 0x5c /* backslash */) {
+        if (this.src[this.pos + 1] !== 'u') {
+          throw this.errf('only \\uXXXX escapes are allowed in identifiers')
+        }
+        this.pos += 2
+        cp = this.readHex4()
+        escaped = true
+      }
+      const legal = first ? isIdentStart(cp) : isIdentPart(cp)
+      if (!legal) {
+        if (escaped) {
+          throw this.errf(`escape \\u${hex4(cp)} is not a valid identifier character here`)
+        }
+        if (first) {
+          throw this.errf(`expected an object key, got ${JSON.stringify(String.fromCodePoint(cp))}`)
+        }
+        break
+      }
+      name += String.fromCodePoint(cp)
+      if (!escaped) this.pos += r.size
+      first = false
+    }
+    if (name.length === 0) throw this.errf('expected an object key')
+    return name
+  }
+
+  /** Read exactly four hex digits at `pos` and return the code point. */
+  private readHex4(): number {
+    if (this.pos + 4 > this.src.length) throw this.errf('truncated \\u escape')
+    const quad = this.src.slice(this.pos, this.pos + 4)
+    if (!/^[0-9a-fA-F]{4}$/.test(quad)) {
+      throw this.errf(`invalid \\u escape ${JSON.stringify('\\u' + quad)}`)
+    }
+    this.pos += 4
+    return parseInt(quad, 16)
+  }
+
+  // ── Strings ─────────────────────────────────────────────────────────────────
+
+  /**
+   * Scan a single- or double-quoted JSON5 string. `quote` is the opening quote
+   * character. JSON5 differences from JSON: either quote character, `\xHH`
+   * escapes, `\v`, `\0`, line continuations (backslash before a line
+   * terminator, including CRLF as one), any other non-digit character escaping
+   * to itself, and unescaped LS/PS allowed inside the string.
+   */
+  private parseString(quote: string): string {
+    this.pos++ // opening quote
+    let out = ''
+    for (;;) {
+      if (this.pos >= this.src.length) throw this.errf('unterminated string')
+      const { cp, size } = this.rune()
+      if (this.src[this.pos] === quote) {
+        this.pos++
+        return out
+      }
+      if (cp === 0x0a || cp === 0x0d) {
+        throw this.errf('unescaped line terminator in string')
+      }
+      if (cp === 0x5c /* backslash */) {
+        this.pos++
+        out += this.readEscape()
+        continue
+      }
+      // LS/PS are legal unescaped inside JSON5 strings; advance() still counts
+      // them as line breaks for positions. A lone surrogate code unit is host
+      // string data and passes through untouched (see the module doc).
+      out += this.src.slice(this.pos, this.pos + size)
+      this.advance(cp, size)
+    }
+  }
+
+  /**
+   * Consume one escape sequence (the backslash is already consumed) and return
+   * its value.
+   */
+  private readEscape(): string {
+    if (this.pos >= this.src.length) throw this.errf('unterminated escape sequence')
+    const { cp, size } = this.rune()
+    // Line continuation: backslash before a line terminator joins the lines,
+    // contributing nothing. CRLF counts as one terminator.
+    if (isLineTerminator(cp)) {
+      this.advance(cp, size)
+      return ''
+    }
+    const ch = String.fromCodePoint(cp)
+    switch (ch) {
+      case 'n':
+        this.pos++
+        return '\n'
+      case 't':
+        this.pos++
+        return '\t'
+      case 'r':
+        this.pos++
+        return '\r'
+      case 'b':
+        this.pos++
+        return '\b'
+      case 'f':
+        this.pos++
+        return '\f'
+      case 'v':
+        this.pos++
+        return '\v'
+      case '0': {
+        // \0 is NUL unless followed by a decimal digit (octal escapes are not
+        // part of JSON5).
+        const next = this.src[this.pos + 1]
+        if (next !== undefined && next >= '0' && next <= '9') {
+          throw this.errf('octal escape sequences are not allowed')
+        }
+        this.pos++
+        return '\0'
+      }
+      case '1':
+      case '2':
+      case '3':
+      case '4':
+      case '5':
+      case '6':
+      case '7':
+      case '8':
+      case '9':
+        throw this.errf(`escape \\${ch} is not allowed (digits cannot be escaped)`)
+      case 'x': {
+        this.pos++
+        if (this.pos + 2 > this.src.length) throw this.errf('truncated \\x escape')
+        const hh = this.src.slice(this.pos, this.pos + 2)
+        if (!/^[0-9a-fA-F]{2}$/.test(hh)) throw this.errf('invalid \\x escape')
+        this.pos += 2
+        return String.fromCharCode(parseInt(hh, 16))
+      }
+      case 'u': {
+        this.pos++
+        const hi = this.readHex4()
+        // F3.5: a lone surrogate escape is an error; a valid pair combines.
+        if (hi >= 0xd800 && hi <= 0xdfff) {
+          if (
+            this.pos + 6 <= this.src.length &&
+            this.src[this.pos] === '\\' &&
+            this.src[this.pos + 1] === 'u'
+          ) {
+            this.pos += 2
+            const lo = this.readHex4()
+            if (hi <= 0xdbff && lo >= 0xdc00 && lo <= 0xdfff) {
+              return String.fromCodePoint(0x10000 + ((hi - 0xd800) << 10) + (lo - 0xdc00))
+            }
+            throw this.errf(`unpaired \\u${hex4(hi)} surrogate (spec F3.5)`)
+          }
+          throw this.errf(`unpaired \\u${hex4(hi)} surrogate (spec F3.5)`)
+        }
+        return String.fromCharCode(hi)
+      }
+      default:
+        // Any other character escapes to itself (JSON5 SingleEscapeCharacter
+        // and NonEscapeCharacter collapse to this rule).
+        this.advance(cp, size)
+        return ch
+    }
+  }
+
+  // ── Numbers ─────────────────────────────────────────────────────────────────
+
+  /**
+   * Scan a JSON5 numeric literal: optional sign, then a hex integer or a
+   * decimal with optional leading/trailing point and exponent. Signed
+   * Infinity/NaN are routed to the F0.6 error here.
+   */
+  private parseNumber(): number | bigint {
+    const start = this.pos
+    let neg = false
+    const sign = this.src[this.pos]
+    if (sign === '+' || sign === '-') {
+      neg = sign === '-'
+      this.pos++
+    }
+    const rest = this.src.slice(this.pos)
+    for (const kw of ['Infinity', 'NaN']) {
+      if (rest.startsWith(kw) && !continuesIdentifier(rest, kw.length)) {
+        throw this.errf(`${kw} is not representable in the HOCON number model (spec F0.6)`)
+      }
+    }
+    if (rest.startsWith('0x') || rest.startsWith('0X')) {
+      this.pos += 2
+      const ds = this.pos
+      while (this.pos < this.src.length && isHexDigit(this.src[this.pos] as string)) this.pos++
+      if (this.pos === ds) throw this.errf('hex literal needs at least one digit')
+      const mag = BigInt('0x' + this.src.slice(ds, this.pos))
+      const limit = neg ? 1n << 63n : (1n << 63n) - 1n
+      if (mag > limit) {
+        throw this.errf(`integer ${this.src.slice(start, this.pos)} does not fit in int64 (spec F0.5)`)
+      }
+      return integerValue(neg ? -mag : mag)
+    }
+
+    let sawDigit = false
+    let sawDot = false
+    let sawExp = false
+    while (this.pos < this.src.length) {
+      const c = this.src[this.pos] as string
+      if (c >= '0' && c <= '9') {
+        sawDigit = true
+      } else if (c === '.' && !sawDot && !sawExp) {
+        sawDot = true
+      } else if ((c === 'e' || c === 'E') && sawDigit && !sawExp) {
+        sawExp = true
+        const n = this.src[this.pos + 1]
+        if (n === '+' || n === '-') this.pos++
+      } else {
+        break
+      }
+      this.pos++
+    }
+    const text = this.src.slice(start, this.pos)
+    if (!sawDigit) throw this.errf(`malformed number ${JSON.stringify(text)}`)
+    // F0.5: '.', 'e', 'E' make a float; everything else is an integer or an
+    // error. Number() accepts a leading '+' in both paths.
+    if (sawDot || sawExp) {
+      const f = Number(text)
+      // An exponent past float range is what Go's strconv reports as an error
+      // rather than a silent ±Inf; mirrored here so F0.6 stays unreachable.
+      if (Number.isNaN(f) || !Number.isFinite(f)) {
+        throw this.errf(`malformed number ${JSON.stringify(text)}`)
+      }
+      return f
+    }
+    const digits = text.startsWith('+') ? text.slice(1) : text
+    const i = BigInt(digits)
+    if (i > INT64_MAX || i < INT64_MIN) {
+      throw this.errf(`integer ${text} does not fit in int64 (spec F0.5)`)
+    }
+    // Within the safe range the value travels as a JS number — Number("-0")
+    // keeps the sign, which fromMap preserves like the core parser does; past
+    // it, a bigint carries the digits verbatim (spec F0.5).
+    if (i >= -9007199254740991n && i <= 9007199254740991n) return Number(digits)
+    return i
+  }
+}
+
+/** An int64-checked integer as a JS number when safe, else a lossless bigint. */
+function integerValue(v: bigint): number | bigint {
+  if (v >= -9007199254740991n && v <= 9007199254740991n) return Number(v)
+  return v
+}

--- a/tests/adapters/json5.test.ts
+++ b/tests/adapters/json5.test.ts
@@ -1,0 +1,309 @@
+// tests/adapters/json5.test.ts
+//
+// Port of go.hocon's adapters/json5 test battery (json5_test.go), with the
+// same inputs and expected values. Divergences forced by the host language are
+// pinned explicitly below: integers past 2^53 are read back via getString (the
+// repo's F0.5 convention, as in the jsonc tests), -0 keeps its sign (as the
+// core parser and fromMap do), and go's invalid-UTF-8 rejection has no ts
+// equivalent — a lone surrogate CODE UNIT in source is host string data and
+// passes through, while a lone surrogate \uXXXX ESCAPE is refused (F3.5).
+
+import { describe, it, expect } from 'vitest'
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { parseJson5 } from '../../src/adapters/json5.js'
+import { parseStringWithOptions } from '../../src/index.js'
+import { ConfigError } from '../../src/errors.js'
+
+const parse5 = (src: string) => parseJson5(src, 'test.json5')
+const parseErr = (src: string, wantSubstr: string): void => {
+  expect(() => parseJson5(src, 'test.json5'), src).toThrow(wantSubstr)
+}
+
+// ─── The json5.org front-page example, minus Infinity/NaN (spec F0.6 rejects
+//     those — pinned separately below) ─────────────────────────────────────────
+
+describe('json5 front-page example', () => {
+  const cfg = parse5(`{
+  // comments
+  unquoted: 'and you can quote me on that',
+  singleQuotes: 'I can use "double quotes" here',
+  lineBreaks: "Look, Mom! \\
+No \\\\n's!",
+  hexadecimal: 0xdecaf,
+  leadingDecimalPoint: .8675309, andTrailing: 8675309.,
+  positiveSign: +1,
+  trailingComma: 'in objects', andIn: ['arrays',],
+  "backwardsCompatible": "with JSON",
+}`)
+
+  it('reads every string member', () => {
+    expect(cfg.getString('unquoted')).toBe('and you can quote me on that')
+    expect(cfg.getString('singleQuotes')).toBe('I can use "double quotes" here')
+    expect(cfg.getString('lineBreaks')).toBe("Look, Mom! No \\n's!")
+    expect(cfg.getString('trailingComma')).toBe('in objects')
+    expect(cfg.getString('backwardsCompatible')).toBe('with JSON')
+  })
+
+  it('reads the number members', () => {
+    expect(cfg.getNumber('hexadecimal')).toBe(0xdecaf)
+    expect(cfg.getNumber('leadingDecimalPoint')).toBe(0.8675309)
+    expect(cfg.getNumber('andTrailing')).toBe(8675309.0)
+    expect(cfg.getNumber('positiveSign')).toBe(1)
+  })
+
+  it('reads the trailing-comma array', () => {
+    expect(cfg.getList('andIn')).toEqual(['arrays'])
+  })
+})
+
+// ─── Identifier keys (ES5 IdentifierName) ─────────────────────────────────────
+
+describe('json5 identifier keys', () => {
+  it('accepts $, _, digits after the first character, and Unicode letters', () => {
+    const cfg = parse5('{a: 1, $b: 2, _c: 3, é: 4, a1: 5}')
+    for (const [path, want] of [['a', 1], ['$b', 2], ['_c', 3], ['é', 4], ['a1', 5]] as const) {
+      expect(cfg.getNumber(path), path).toBe(want)
+    }
+  })
+
+  it('honours \\uXXXX escapes inside a key', () => {
+    // \u0061 = 'a'; ES5 allows \u escapes inside IdentifierName.
+    expect(parse5('{\\u0061\\u0062: 7}').getNumber('ab')).toBe(7)
+  })
+
+  it('rejects illegal identifier starts and non-\\u escapes', () => {
+    parseErr('{1a: 1}', 'expected an object key')
+    // \u0031 = '1' — a legal escape, but not a legal identifier START.
+    parseErr('{\\u0031x: 1}', 'not a valid identifier character')
+    parseErr('{\\x61: 1}', 'only \\uXXXX escapes')
+  })
+})
+
+// ─── Strings ──────────────────────────────────────────────────────────────────
+
+describe('json5 strings', () => {
+  it('decodes the JSON5 escape set', () => {
+    const cfg = parse5(`{
+  hex: "\\x41\\x42",
+  vtab: "a\\vb",
+  nul: "a\\0b",
+  self: "\\q\\'\\"",
+  astral: "\\uD83D\\uDE00",
+}`)
+    expect(cfg.getString('hex')).toBe('AB')
+    expect(cfg.getString('vtab')).toBe('a\vb')
+    expect(cfg.getString('nul')).toBe('a\x00b')
+    expect(cfg.getString('self')).toBe('q\'"')
+    expect(cfg.getString('astral')).toBe('😀')
+  })
+
+  it('treats LF, CRLF, and LS line continuations as nothing', () => {
+    const cfg = parse5("{a: 'x\\\ny', b: 'x\\\r\ny', c: 'x\\\u2028y'}")
+    for (const path of ['a', 'b', 'c']) {
+      expect(cfg.getString(path), path).toBe('xy')
+    }
+  })
+
+  it('allows unescaped LS/PS inside a string (the ES5 quirk)', () => {
+    expect(parse5("{a: 'x\u2028y'}").getString('a')).toBe('x\u2028y')
+  })
+
+  it('rejects malformed strings and escapes', () => {
+    parseErr("{a: 'x\ny'}", 'unescaped line terminator')
+    parseErr("{a: 'oops}", 'unterminated string')
+    parseErr("{a: '\\01'}", 'octal escape')
+    parseErr("{a: '\\7'}", 'digits cannot be escaped')
+    // F3.5: a lone surrogate escape is an error, high or low, paired-wrong or
+    // alone.
+    parseErr('{a: "\\uD800"}', 'spec F3.5')
+    parseErr('{a: "\\uD800\\u0041"}', 'spec F3.5')
+    parseErr('{a: "\\uDE00"}', 'spec F3.5')
+  })
+
+  // go.hocon's counterpart check rejects invalid UTF-8 bytes, which a
+  // JavaScript string cannot contain. Its nearest analogue — a lone surrogate
+  // CODE UNIT raw in the source — is host string data here, kept exactly as
+  // the jsonc adapter keeps it (the S1.2.6 class, documented under F3.5). Only
+  // the \uXXXX escape spelling is refused, above.
+  it('keeps a raw lone surrogate code unit in source as data', () => {
+    expect(parse5("{a: '\ud800'}").getString('a')).toBe('\ud800')
+  })
+})
+
+// ─── Numbers ──────────────────────────────────────────────────────────────────
+
+describe('json5 numbers', () => {
+  it('reads hex, signs, leading/trailing points, exponents', () => {
+    const cfg = parse5(`{
+  hex: 0xFF, hexneg: -0x10, hexplus: +0xA,
+  min: -0x8000000000000000, max: 0x7FFFFFFFFFFFFFFF,
+  lead: .5, trail: 5., plus: +5, exp: 1e3, negzero: -0,
+}`)
+    expect(cfg.getNumber('hex')).toBe(255)
+    expect(cfg.getNumber('hexneg')).toBe(-16)
+    expect(cfg.getNumber('hexplus')).toBe(10)
+    // int64 min/max are past 2^53, so the digits travel as a bigint and come
+    // back exact through getString (the repo's F0.5 convention — same as the
+    // jsonc adapter; go's GetInt64 asserts the same values).
+    expect(cfg.getString('min')).toBe('-9223372036854775808')
+    expect(cfg.getString('max')).toBe('9223372036854775807')
+    expect(cfg.getNumber('lead')).toBe(0.5)
+    expect(cfg.getNumber('trail')).toBe(5.0)
+    expect(cfg.getNumber('plus')).toBe(5)
+    expect(cfg.getNumber('exp')).toBe(1000.0)
+    // go's int64 model reads -0 as 0; the JS number model has a signed zero
+    // and this repo's convention (core parser, fromMap, jsonc) preserves it.
+    expect(cfg.getString('negzero')).toBe('-0')
+    expect(cfg.getNumber('negzero') === 0).toBe(true)
+  })
+
+  it('ingests an integer past the safe range losslessly (F0.5)', () => {
+    expect(parse5('{big: 9007199254740993}').getString('big')).toBe('9007199254740993')
+    expect(parse5('{big: -9007199254740993}').getString('big')).toBe('-9007199254740993')
+    // getNumber still rounds — the JS number model does, and the core parser
+    // rounds the same literal identically. The ingest is what must be lossless.
+    expect(parse5('{big: 9007199254740993}').getNumber('big')).toBe(9007199254740992)
+  })
+
+  it('rejects integers past int64, empty hex, and out-of-range floats', () => {
+    // F0.5: integers that do not fit in int64 are errors, not silent floats.
+    parseErr('{a: 0x10000000000000000}', 'spec F0.5')
+    parseErr('{a: -0x8000000000000001}', 'spec F0.5')
+    parseErr('{a: 9223372036854775808}', 'spec F0.5')
+    parseErr('{a: 0x}', 'hex literal needs at least one digit')
+  })
+
+  it('rejects Infinity and NaN in every spelling (F0.6)', () => {
+    for (const lit of ['Infinity', '-Infinity', '+Infinity', 'NaN', '-NaN', '+NaN']) {
+      parseErr(`{a: ${lit}}`, 'spec F0.6')
+    }
+  })
+
+  it('treats identifiers merely starting with Infinity/NaN as ordinary junk', () => {
+    // A longer identifier that merely STARTS with those spellings is not the
+    // F0.6 case — it errors as an unexpected token / malformed number.
+    parseErr('{a: Infinityx}', 'unexpected character')
+    parseErr('{a: NaNx}', 'unexpected character')
+    parseErr('{a: -Infinityx}', 'malformed number')
+  })
+})
+
+// ─── Comments, whitespace, structure ──────────────────────────────────────────
+
+describe('json5 comments, whitespace, structure', () => {
+  it('accepts both comment forms and JSON5 whitespace (NBSP, EM SPACE, LS)', () => {
+    // The LS after "line comment" TERMINATES the // comment — deliberately
+    // different from the jsonc dialect, whose owner ends comments at LF/CR
+    // only — so `a: 1,` is live content, not comment body.
+    const cfg = parse5('{\n  // line comment\u2028 a: 1,\n  /* block\n comment */ b: 2,\u00a0c:\u20033\n}')
+    expect(cfg.getNumber('a')).toBe(1)
+    expect(cfg.getNumber('b')).toBe(2)
+    expect(cfg.getNumber('c')).toBe(3)
+  })
+
+  it('PS terminates a // comment too', () => {
+    expect(parse5('{// c\u2029a: 1\n}').getNumber('a')).toBe(1)
+  })
+
+  it('rejects structural errors with named expectations', () => {
+    parseErr('{a: 1} /* open', 'unterminated /* comment')
+    parseErr('{a: 1} }', 'unexpected content after top-level value')
+    parseErr('{a: 1', 'unterminated object')
+    parseErr('[1, 2', 'unterminated array')
+    parseErr('[,1]', 'unexpected character')
+    parseErr('[1,,2]', 'unexpected character')
+    parseErr('{a 1}', "expected ':'")
+    parseErr('{a: nullx}', 'unexpected character')
+    parseErr('', 'unexpected end of input')
+    // F0.3: the root must be an object.
+    parseErr('[1, 2]', 'spec F0.3')
+    parseErr('"just a string"', 'spec F0.3')
+  })
+
+  // Trailing whitespace and comments after the value are fine (only content is
+  // an error).
+  it('accepts trailing trivia after the top-level value', () => {
+    expect(parse5('{a: 1} // done\n/* and a block */\n\n').getNumber('a')).toBe(1)
+  })
+})
+
+// ─── Duplicate keys (spec F0.7) ───────────────────────────────────────────────
+
+describe('json5 duplicate keys follow HOCON semantics (F0.7)', () => {
+  it('deep-merges two objects', () => {
+    const cfg = parse5('{a: {x: 1, shared: {p: 1}}, a: {y: 2, shared: {q: 2}}}')
+    expect(cfg.getNumber('a.x')).toBe(1)
+    expect(cfg.getNumber('a.y')).toBe(2)
+    expect(cfg.getNumber('a.shared.p')).toBe(1)
+    expect(cfg.getNumber('a.shared.q')).toBe(2)
+  })
+
+  it('is last-wins for anything else', () => {
+    expect(parse5('{a: 1, a: 2}').getNumber('a')).toBe(2)
+    expect(parse5('{a: {x: 1}, a: 2}').getNumber('a')).toBe(2)
+  })
+})
+
+// ─── BOM (spec F0.9) ──────────────────────────────────────────────────────────
+
+describe('json5 BOM handling', () => {
+  it('strips a leading BOM and treats an interior U+FEFF as whitespace', () => {
+    expect(parseJson5('\ufeff{a: \ufeff1}', 'test.json5').getNumber('a')).toBe(1)
+  })
+})
+
+// ─── ts-specific hardening (repo conventions, not in the go battery) ─────────
+
+describe('json5 ts-specific hardening', () => {
+  // F2.9 principle: safety by construction, never by dropping keys. The
+  // object carrier is null-prototype, so `__proto__` lands as an own property.
+  it('preserves a __proto__ key without polluting prototypes', () => {
+    const cfg = parse5('{__proto__: {x: 1}, safe: 2}')
+    expect(cfg.keys().sort()).toEqual(['__proto__', 'safe'])
+    expect(cfg.getNumber('__proto__.x')).toBe(1)
+    expect(({} as { x?: unknown }).x).toBeUndefined()
+  })
+
+  // The hand-rolled parser recurses once per level, so the depth guard has to
+  // wrap it — same contract as the other adapters (#177).
+  it('reports a too-deep document as a ConfigError', () => {
+    expect(parse5(`${'{a:'.repeat(100)}1${'}'.repeat(100)}`).has('a')).toBe(true)
+    expect(() => parse5(`${'{a:'.repeat(50000)}1${'}'.repeat(50000)}`)).toThrow(ConfigError)
+  })
+})
+
+// ─── Merge with a HOCON document (the adapter's purpose) ─────────────────────
+
+describe('json5 as a substitution source under HOCON', () => {
+  it('resolves ${...} through withFallback into the json5 layer', () => {
+    const base = parseJson5("{db: {host: 'localhost', port: 5432}}", 'base.json5')
+    const cfg = parseStringWithOptions('db { host = db.example.com }\nurl = ${db.host}', {
+      resolveSubstitutions: false,
+    })
+    const merged = cfg.withFallback(base).resolve()
+    expect(merged.getString('db.host')).toBe('db.example.com')
+    expect(merged.getNumber('db.port')).toBe(5432)
+    expect(merged.getString('url')).toBe('db.example.com')
+  })
+})
+
+// ─── Origin naming ────────────────────────────────────────────────────────────
+
+describe('json5 origin naming', () => {
+  // The adapters read text rather than paths (the repo convention — see the
+  // properties adapter's doc), so go's ParseFile test becomes: read the file,
+  // pass its path as the origin, and the error must name it.
+  it('names the source file in errors when the path is the origin', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'ts-hocon-json5-'))
+    const path = join(dir, 'conf.json5')
+    writeFileSync(path, '{a: [}')
+    expect(() => parseJson5(readFileSync(path, 'utf-8'), path)).toThrow('conf.json5')
+  })
+
+  it('falls back to "document" with no origin', () => {
+    expect(() => parseJson5('{a: [}')).toThrow('json5: document:')
+  })
+})

--- a/tests/adapters/json5.test.ts
+++ b/tests/adapters/json5.test.ts
@@ -312,3 +312,41 @@ it('S: -0x0 preserves the sign like decimal -0 (Copilot review pin)', () => {
   const cfg = parseJson5('{a: -0x0}')
   expect(Object.is((cfg.toObject() as Record<string, unknown>).a, -0)).toBe(true)
 })
+
+// ── codecov patch-coverage pins (branches the ported battery missed) ─────────
+
+it('S: whitespace forms TAB/VT/FF separate tokens', () => {
+  expect(parseJson5('{a:\t1,\u000bb:\u000c2}').toObject()).toEqual({ a: 1, b: 2 })
+})
+
+it('S: bare true/false/null values', () => {
+  expect(parseJson5('{t: true, f: false, n: null}').toObject()).toEqual({ t: true, f: false, n: null })
+})
+
+it('S: missing separator errors in objects and arrays', () => {
+  expect(() => parseJson5('{a: 1 b: 2}')).toThrow(/expected ',' or '}'/)
+  expect(() => parseJson5('[1 2]')).toThrow(/expected ',' or ']'/)
+})
+
+it('S: invalid \\u quad is rejected', () => {
+  expect(() => parseJson5('{a: "\\uZZZZ"}')).toThrow(/invalid \\u escape/)
+})
+
+it('S: the single-character escape set decodes', () => {
+  const cfg = parseJson5(`{a: "\\n\\t\\r\\b\\f"}`)
+  expect((cfg.toObject() as Record<string, unknown>).a).toBe('\n\t\r\b\f')
+})
+
+it('S: digit escapes \\1–\\9 are rejected', () => {
+  for (const d of ['1', '5', '9']) {
+    expect(() => parseJson5(`{a: "\\${d}"}`)).toThrow(/digits cannot be escaped/)
+  }
+})
+
+it('S: a plain BMP \\u escape decodes', () => {
+  expect((parseJson5('{a: "\\u0041"}').toObject() as Record<string, unknown>).a).toBe('A')
+})
+
+it('S: float overflow is malformed, not Infinity', () => {
+  expect(() => parseJson5('{a: 1e999}')).toThrow(/malformed number/)
+})

--- a/tests/adapters/json5.test.ts
+++ b/tests/adapters/json5.test.ts
@@ -307,3 +307,8 @@ describe('json5 origin naming', () => {
     expect(() => parseJson5('{a: [}')).toThrow('json5: document:')
   })
 })
+
+it('S: -0x0 preserves the sign like decimal -0 (Copilot review pin)', () => {
+  const cfg = parseJson5('{a: -0x0}')
+  expect(Object.is((cfg.toObject() as Record<string, unknown>).a, -0)).toBe(true)
+})

--- a/tests/conformance/format-ingestion.test.ts
+++ b/tests/conformance/format-ingestion.test.ts
@@ -14,6 +14,7 @@ import { fileURLToPath } from 'node:url'
 
 import type { Config } from '../../src/config.js'
 import { loadEnv, parseDotEnv } from '../../src/adapters/env.js'
+import { parseJson5 } from '../../src/adapters/json5.js'
 import { parseJsonc } from '../../src/adapters/jsonc.js'
 import { parsePropertiesConfig } from '../../src/adapters/properties.js'
 import { parseTomlConfig } from '../../src/adapters/toml.js'
@@ -50,6 +51,8 @@ describe('format-ingestion fixtures (xx.hocon)', () => {
     switch (c.format) {
       case 'jsonc':
         return parseJsonc(text, c.id)
+      case 'json5':
+        return parseJson5(text, c.id)
       case 'properties':
         return parsePropertiesConfig(text, c.id)
       case 'toml':

--- a/tools/smoke-entrypoints.mjs
+++ b/tools/smoke-entrypoints.mjs
@@ -95,6 +95,10 @@ const checks = {
   './adapters/jsonc': async (m) => {
     eq(m.parseJsonc('{"a": 1 /* c */, "b": [1,2,],}').getNumber('a'), 1, 'jsonc adapter')
   },
+  './adapters/json5': async (m) => {
+    eq(m.parseJson5("{db: {host: 'local'}, port: 0x1F90, /* c */}").getString('db.host'), 'local', 'json5 adapter')
+    eq(m.parseJson5('{port: 0x1F90}').getNumber('port'), 8080, 'json5 hex integer')
+  },
   './adapters/toml': async (m) => {
     eq(m.parseTomlConfig('[db]\nhost = "local"\n').getString('db.host'), 'local', 'toml adapter')
   },

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     'adapters/properties': 'src/adapters/properties.ts',
     'adapters/env': 'src/adapters/env.ts',
     'adapters/jsonc': 'src/adapters/jsonc.ts',
+    'adapters/json5': 'src/adapters/json5.ts',
     'adapters/toml': 'src/adapters/toml.ts',
     'adapters/yaml': 'src/adapters/yaml.ts',
   },


### PR DESCRIPTION
## Summary

Horizontal rollout of [go.hocon#193](https://github.com/o3co/go.hocon/pull/193) (JSON5 adapter, merged). Ports the hand-rolled scanner + recursive descent with the go implementation as the semantic source (zero dependencies). The grammar follows the dialect owner (the json5 npm reference implementation), and the spec-first divergences of mapping spec F3.3 ([xx#92](https://github.com/o3co/xx.hocon/pull/92)) — F0.5 int64 / F0.6 Infinity and NaN / F3.5 surrogates / F0.7 duplicate keys / strict EOF — are preserved.

go's test battery is ported case-for-case, with host-language differences (int representation, invalid-UTF-8 boundaries, the recursion guard) resolved to match each repo's existing conventions (details in the commit bodies / in-code comments). json5 dispatch is registered in the fixture runner — **with parity across the 4 implementations now in place, the json5 fixture set goes into xx after this same-window merge, turning F3.3 ✅**.

Same window: 3 PRs for ts / py / rs (go already merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
