### PR TITLE
feat(config): renderHocon — ts port of the E18 emitter (round-trip contract)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ tests/lightbend/testdata/expected/
 
 # Deferred-resolution fixtures fetched from xx.hocon via `make testdata`
 tests/lightbend/testdata/hocon/deferred-resolution/
+
+# E18 emitter round-trip corpus fetched from xx.hocon via `make testdata`
+tests/testdata/emitter-roundtrip/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   EOF check (the F3.2 strictness rule). A `//` comment ends at LS/PS as well
   as LF/CR — deliberately different from the jsonc dialect, whose owner ends
   comments at LF/CR only.
+- **`Config.renderHocon()` — HOCON emitter (E18)**: renders a resolved,
+  data-only Config back to HOCON text. The correctness contract is the round
+  trip — `parseString(cfg.renderHocon())` yields the same value tree — not
+  byte-for-byte formatting: a string is quoted whenever leaving it bare would
+  re-parse as another type (`"8080"`, keyword look-alikes such as `no`/`on`,
+  `${…}` look-alikes), numbers / booleans / null emit raw, and a multi-line
+  string is triple-quoted only when that is lossless (no CR, no embedded
+  `"""`, no trailing `"`). An unresolved Config throws `ConfigError` — a
+  substitution has no textual round trip through a value tree. Lockstep with
+  go.hocon v1.11.0 `RenderHOCON` and the py.hocon / rs.hocon ports; verified
+  against the shared xx.hocon `emitter-roundtrip` corpus (rt01–rt10, synced
+  by `make testdata`).
 
 ### Fixed
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ EMITTER_ROUNDTRIP_DIR       := tests/testdata/emitter-roundtrip
 .PHONY: testdata test
 
 testdata:
-	@if [ -f .xx-hocon-version ] && [ -d "$(EXPECTED_DIR)" ] && [ -d "$(UNITS_DIR)" ] && [ -d "$(UNQUOTED_STARTS_DIR)" ] && [ -d "$(UNQUOTED_PARENS_DIR)" ] && [ -d "$(DEFERRED_RESOLUTION_DIR)" ] && [ -d "$(KEY_HYPHEN_DIR)" ] && [ -d "$(PATH_EXPR_WS_DIR)" ] && [ -d "$(ARRAY_ROOT_DIR)" ] && [ -d "$(PATH_EMPTY_SEGMENT_DIR)" ] && [ -d "$(UNQUOTED_FORBIDDEN_DIR)" ]; then \
+	@if [ -f .xx-hocon-version ] && [ -d "$(EXPECTED_DIR)" ] && [ -d "$(UNITS_DIR)" ] && [ -d "$(UNQUOTED_STARTS_DIR)" ] && [ -d "$(UNQUOTED_PARENS_DIR)" ] && [ -d "$(DEFERRED_RESOLUTION_DIR)" ] && [ -d "$(KEY_HYPHEN_DIR)" ] && [ -d "$(PATH_EXPR_WS_DIR)" ] && [ -d "$(ARRAY_ROOT_DIR)" ] && [ -d "$(PATH_EMPTY_SEGMENT_DIR)" ] && [ -d "$(UNQUOTED_FORBIDDEN_DIR)" ] && [ -d "$(EMITTER_ROUNDTRIP_DIR)" ]; then \
 	  remote_sha=$$(curl -sf "https://api.github.com/repos/$(TESTDATA_REPO)/commits/$(TESTDATA_REF)" | grep '"sha"' | head -1 | cut -d'"' -f4) && \
 	  local_sha=$$(cat .xx-hocon-version) && \
 	  if [ "$$remote_sha" = "$$local_sha" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ PATH_EXPR_WS_DIR            := tests/lightbend/testdata/hocon/path-expr-whitespa
 ARRAY_ROOT_DIR              := tests/lightbend/testdata/hocon/array-root
 PATH_EMPTY_SEGMENT_DIR      := tests/lightbend/testdata/hocon/path-empty-segment
 UNQUOTED_FORBIDDEN_DIR      := tests/lightbend/testdata/hocon/unquoted-forbidden
+EMITTER_ROUNDTRIP_DIR       := tests/testdata/emitter-roundtrip
 
 .PHONY: testdata test
 
@@ -48,6 +49,7 @@ testdata:
 	{ [ ! -d "$$tmpdir/testdata/hocon/array-root" ] || cp -R "$$tmpdir/testdata/hocon/array-root/." "$(ARRAY_ROOT_DIR)/"; } && \
 	cp -R "$$tmpdir/testdata/hocon/path-empty-segment/." "$(PATH_EMPTY_SEGMENT_DIR)/" && \
 	cp -R "$$tmpdir/testdata/hocon/unquoted-forbidden/." "$(UNQUOTED_FORBIDDEN_DIR)/" && \
+	{ [ ! -d "$$tmpdir/testdata/emitter-roundtrip" ] || { rm -rf "$(EMITTER_ROUNDTRIP_DIR)" && mkdir -p "$(EMITTER_ROUNDTRIP_DIR)" && cp -R "$$tmpdir/testdata/emitter-roundtrip/." "$(EMITTER_ROUNDTRIP_DIR)/"; }; } && \
 	curl -sf "https://api.github.com/repos/$(TESTDATA_REPO)/commits/$(TESTDATA_REF)" | grep '"sha"' | head -1 | cut -d'"' -f4 > .xx-hocon-version && \
 	echo "Done. Fetched $$(cat .xx-hocon-version)"
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -80,6 +80,7 @@ HOCON は単なるシリアライズ形式ではなく、**プログラムに注
 - `+=` 追加演算子
 - `include "file.conf"` および `include file("file.conf")` ディレクティブ
 - トリプルクォート文字列（`"""..."""`）
+- HOCON エミッタ（`renderHocon()`）— 解決済み `Config` を HOCON テキストとして出力。再パースすると同一の値ツリーになる（E18 ラウンドトリップ契約）
 - 同期・非同期 API（`parse` / `parseAsync` / `parseFile` / `parseFileAsync`）
 - ESM + CJS デュアルパッケージ（全エントリポイントを CI で両形式ロード検証）
 - [Zod](https://zod.dev/) スキーマバリデーション統合（オプション）
@@ -121,6 +122,7 @@ parseFileAsync(path: string, opts?: ParseOptions): Promise<Config>
 | `keys()` | `string[]` | — |
 | `withFallback(fallback)` | `Config` | — |
 | `toObject()` | `unknown` | — |
+| `renderHocon()` | `string` | 未解決の場合 |
 
 ### Zod 統合
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ On top of that, HOCON combines the readability of YAML with the structure of JSO
 - `include "file.conf"` and `include file("file.conf")` directives
 - Triple-quoted strings (`"""..."""`)
 - Duration and byte size parsing (`getDuration()`, `getBytes()`)
+- HOCON emitter (`renderHocon()`) — renders a resolved `Config` back to HOCON text; re-parsing yields the same value tree (E18 round-trip contract)
 - Sync and async API (`parse` / `parseAsync` / `parseFile` / `parseFileAsync`)
 - ESM + CJS dual package (every entrypoint smoke-tested in both formats on each CI run)
 - Optional [Zod](https://zod.dev/) integration for schema validation
@@ -134,6 +135,7 @@ parseFileAsync(path: string, opts?: ParseOptions): Promise<Config>
 | `resolveWith(source, opts?)` | `Config` | source unresolved, or unresolvable substitution |
 | `isResolved()` | `boolean` | — |
 | `toObject()` | `unknown` | — |
+| `renderHocon()` | `string` | unresolved |
 
 ### Deferred resolution API (E12)
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,7 @@ import {
 } from './internal/resolver/resolver.js'
 import { isConcat, isResObj, isSubst, mergeUnresolved } from './internal/resolver/types.js'
 import type { ResObj, ResolveOptions as InternalResolveOptions } from './internal/resolver/types.js'
+import { renderHoconFromRoot } from './render-hocon.js'
 import { numericObjectToArray } from './value/numeric-array.js'
 import type { HoconValue, ReadonlyHoconValue, ScalarValueType } from './value.js'
 
@@ -410,6 +411,40 @@ export class Config {
    */
   toObject(opts?: { nullPrototype?: boolean }): unknown {
     return hoconToJs(this.root, opts?.nullPrototype === true)
+  }
+
+  /**
+   * Renders this resolved Config as HOCON text (E18; lockstep with go.hocon's
+   * `Config.RenderHOCON`, v1.11.0).
+   *
+   * The output round-trips: parsing it back yields the same value tree. That
+   * is the correctness contract, not byte-for-byte formatting — a scalar is
+   * quoted whenever leaving it bare would re-parse as a different type (a
+   * string `"8080"` becomes `"8080"`, not `8080`), and left bare only when it
+   * provably cannot.
+   *
+   * The Config must be resolved and hold only data (objects, arrays, string /
+   * number / boolean / null scalars) — exactly what {@link fromMap} and the
+   * format adapters produce. An unresolved placeholder throws
+   * {@link ConfigError}; substitutions have no textual round trip through a
+   * value tree.
+   *
+   * The root object's fields are emitted without enclosing braces, nested
+   * objects as `key { … }`, arrays as newline-separated `[ … ]`, indented two
+   * spaces. Source comments are not represented — a value tree does not carry
+   * them.
+   */
+  renderHocon(): string {
+    if (!this._resolved) {
+      // Placeholder fields are omitted from the partial root, so the walk
+      // below could not see them — gate on the resolved flag instead (same
+      // whole-config granularity as isResolved, E12 decision 11).
+      throw new ConfigError(
+        'renderHocon: unrenderable unresolved substitution (config must be resolved data)',
+        '',
+      )
+    }
+    return renderHoconFromRoot(this.root)
   }
 
   /**

--- a/src/render-hocon.ts
+++ b/src/render-hocon.ts
@@ -1,0 +1,168 @@
+// src/render-hocon.ts
+// Copyright 2026 1o1 Co. Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+
+// E18 HOCON emitter — port of go.hocon's render_hocon.go (v1.11.0).
+// See `Config.renderHocon` in config.ts for the public contract.
+
+import { ConfigError } from './errors.js'
+import type { HoconValue } from './value.js'
+
+/**
+ * Renders a resolved, data-only HoconValue object tree as HOCON text.
+ *
+ * The output round-trips: parsing it back yields the same value tree. That is
+ * the correctness contract, not byte-for-byte formatting — a scalar is quoted
+ * whenever leaving it bare would re-parse as a different type (a string
+ * `"8080"` becomes `"8080"`, not `8080`), and left bare only when it provably
+ * cannot.
+ *
+ * The root object's fields are emitted without enclosing braces, nested
+ * objects as `key { … }`, arrays as newline-separated `[ … ]`, indented two
+ * spaces. Source comments are not represented — a value tree does not carry
+ * them.
+ */
+export function renderHoconFromRoot(root: HoconValue & { kind: 'object' }): string {
+  const out: string[] = []
+  renderObjectBody(out, root, 0)
+  return out.join('')
+}
+
+function renderObjectBody(out: string[], o: HoconValue & { kind: 'object' }, depth: number): void {
+  const indent = '  '.repeat(depth)
+  for (const [k, v] of o.fields) {
+    out.push(indent, renderKey(k))
+    if (v.kind === 'object') {
+      out.push(' {')
+      if (v.fields.size === 0) {
+        out.push('}\n')
+        continue
+      }
+      out.push('\n')
+      renderObjectBody(out, v, depth + 1)
+      out.push(indent, '}\n')
+    } else {
+      out.push(' = ')
+      renderValue(out, v, depth)
+      out.push('\n')
+    }
+  }
+}
+
+function renderValue(out: string[], v: HoconValue, depth: number): void {
+  switch (v.kind) {
+    case 'object': {
+      if (v.fields.size === 0) {
+        out.push('{}')
+        return
+      }
+      out.push('{\n')
+      renderObjectBody(out, v, depth + 1)
+      out.push('  '.repeat(depth), '}')
+      return
+    }
+    case 'array':
+      renderArray(out, v, depth)
+      return
+    case 'scalar':
+      out.push(renderScalar(v))
+      return
+    default:
+      // Unreachable for a well-formed HoconValue; a placeholder masquerading
+      // as one (allowUnresolved leftovers) has no `kind` and lands here.
+      throw new ConfigError(
+        'renderHocon: unrenderable value (config must be resolved data)',
+        '',
+      )
+  }
+}
+
+function renderArray(out: string[], a: HoconValue & { kind: 'array' }, depth: number): void {
+  if (a.items.length === 0) {
+    out.push('[]')
+    return
+  }
+  const inner = '  '.repeat(depth + 1)
+  out.push('[\n')
+  for (const e of a.items) {
+    out.push(inner)
+    renderValue(out, e, depth + 1)
+    out.push('\n')
+  }
+  out.push('  '.repeat(depth), ']')
+}
+
+function renderScalar(s: HoconValue & { kind: 'scalar' }): string {
+  switch (s.valueType) {
+    case 'null':
+      return 'null'
+    case 'boolean':
+    case 'number':
+      // raw already holds the canonical textual form; both re-parse to their
+      // own type, so they are emitted bare.
+      return s.raw
+    case 'string':
+      return renderString(s.raw)
+  }
+}
+
+/**
+ * Matches a key that is unambiguous unquoted: no dot (which would nest), no
+ * whitespace, no forbidden character.
+ */
+const SAFE_UNQUOTED_KEY = /^[A-Za-z0-9_-]+$/
+
+function renderKey(k: string): string {
+  return SAFE_UNQUOTED_KEY.test(k) ? k : quoteString(k)
+}
+
+/**
+ * Matches a string value that cannot be misread as another type: an
+ * identifier that is not a boolean/null keyword and not numeric. Any other
+ * string is quoted, which always round-trips.
+ */
+const SAFE_BARE_STRING = /^[A-Za-z][A-Za-z0-9_-]*$/
+
+const STRING_KEYWORDS = new Set(['true', 'false', 'null', 'yes', 'no', 'on', 'off'])
+
+function renderString(s: string): string {
+  return SAFE_BARE_STRING.test(s) && !STRING_KEYWORDS.has(s.toLowerCase()) ? s : quoteString(s)
+}
+
+function quoteString(s: string): string {
+  // A string containing newlines is triple-quoted when that is unambiguous
+  // and lossless: no embedded `"""`, no trailing `"`, and no carriage return
+  // (the parser normalizes CRLF inside triple quotes, which would drop the
+  // `\r`, so those fall through to escaped double quotes below).
+  if (s.includes('\n') && !s.includes('\r') && !s.includes('"""') && !s.endsWith('"')) {
+    return `"""${s}"""`
+  }
+  let b = '"'
+  for (const ch of s) {
+    switch (ch) {
+      case '"':
+        b += '\\"'
+        break
+      case '\\':
+        b += '\\\\'
+        break
+      case '\n':
+        b += '\\n'
+        break
+      case '\r':
+        b += '\\r'
+        break
+      case '\t':
+        b += '\\t'
+        break
+      default:
+        b += ch
+    }
+  }
+  return b + '"'
+}

--- a/src/render-hocon.ts
+++ b/src/render-hocon.ts
@@ -118,6 +118,10 @@ function renderScalar(s: HoconValue & { kind: 'scalar' }): string {
 const SAFE_UNQUOTED_KEY = /^[A-Za-z0-9_-]+$/
 
 function renderKey(k: string): string {
+  // `include` is reserved unquoted at the start of a key (S12.5/S14a) — the
+  // parser (and Lightbend: "include keyword is not followed by a quoted
+  // string") rejects `include = 1`, so the key must be quoted to round-trip.
+  if (k === 'include') return quoteString(k)
   return SAFE_UNQUOTED_KEY.test(k) ? k : quoteString(k)
 }
 
@@ -137,8 +141,9 @@ function renderString(s: string): string {
 function quoteString(s: string): string {
   // A string containing newlines is triple-quoted when that is unambiguous
   // and lossless: no embedded `"""`, no trailing `"`, and no carriage return
-  // (the parser normalizes CRLF inside triple quotes, which would drop the
-  // `\r`, so those fall through to escaped double quotes below).
+  // (an invisible raw CR inside triple quotes is ambiguous to readers and
+  // editors even though this lexer preserves it — Lightbend probe 2026-08-19
+  // — so CR strings take the escaped double-quoted form below).
   if (s.includes('\n') && !s.includes('\r') && !s.includes('"""') && !s.endsWith('"')) {
     return `"""${s}"""`
   }

--- a/tests/e18-emitter-roundtrip.test.ts
+++ b/tests/e18-emitter-roundtrip.test.ts
@@ -7,10 +7,12 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
+import { fileURLToPath } from 'node:url'
+
 import { parseString } from '../src/parse.js'
 import { fromMap } from '../src/value-factory.js'
 
-const corpusDir = new URL('./testdata/emitter-roundtrip', import.meta.url).pathname
+const corpusDir = fileURLToPath(new URL('./testdata/emitter-roundtrip', import.meta.url))
 
 describe('E18 emitter round-trip corpus', () => {
   if (!existsSync(corpusDir)) {

--- a/tests/e18-emitter-roundtrip.test.ts
+++ b/tests/e18-emitter-roundtrip.test.ts
@@ -1,0 +1,50 @@
+// tests/e18-emitter-roundtrip.test.ts
+//
+// E18 — the shared emitter round-trip corpus (xx.hocon
+// testdata/emitter-roundtrip/, synced by `make testdata`). Each fixture is a
+// JSON value tree; the contract is parse(render(tree)) == tree, compared as
+// trees, never as text. See xx.hocon docs/extra-spec-conventions.md §E18.
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { parseString } from '../src/parse.js'
+import { fromMap } from '../src/value-factory.js'
+
+const corpusDir = new URL('./testdata/emitter-roundtrip', import.meta.url).pathname
+
+describe('E18 emitter round-trip corpus', () => {
+  if (!existsSync(corpusDir)) {
+    it.skip('emitter-roundtrip corpus not synced — run `make testdata`', () => {})
+    return
+  }
+
+  const fixtures = readdirSync(corpusDir)
+    .filter(f => f.endsWith('.json'))
+    .sort()
+
+  it('corpus directory holds fixtures', () => {
+    expect(fixtures.length).toBeGreaterThan(0)
+  })
+
+  for (const name of fixtures) {
+    it(name.replace(/\.json$/, ''), () => {
+      // Corpus numbers stay within 2^53 by convention (E18), so JSON.parse
+      // reads every fixture number exactly; go's json.Number int64/float64
+      // split is not needed under the JS number model.
+      const tree = JSON.parse(readFileSync(join(corpusDir, name), 'utf-8')) as Record<string, unknown>
+      const cfg = fromMap(tree, name)
+      const before = cfg._renderJSONForTest()
+      const text = cfg.renderHocon()
+      let reparsed
+      try {
+        reparsed = parseString(text)
+      } catch (e) {
+        throw new Error(`re-parse of emitted HOCON failed: ${String(e)}\n--- emitted ---\n${text}`)
+      }
+      expect(
+        reparsed._renderJSONForTest(),
+        `round trip changed the tree\n--- emitted ---\n${text}`,
+      ).toBe(before)
+    })
+  }
+})

--- a/tests/render-hocon.test.ts
+++ b/tests/render-hocon.test.ts
@@ -1,0 +1,180 @@
+// tests/render-hocon.test.ts
+//
+// Config.renderHocon() — E18 HOCON emitter, ported from go.hocon's
+// render_hocon_test.go (v1.11.0). The correctness contract is the round trip:
+// parse(render(tree)) yields the same value tree, compared as canonical JSON
+// (sorted keys), never as text.
+import { describe, expect, it } from 'vitest'
+import { ConfigError } from '../src/errors.js'
+import { parseString, parseStringWithOptions } from '../src/parse.js'
+import { fromMap } from '../src/value-factory.js'
+
+/**
+ * Renders a config to HOCON, parses it back, and returns the re-parsed
+ * config's canonical JSON alongside the original's. Equal JSON means the
+ * emit → parse round trip preserved the value tree, which is the emitter's
+ * correctness contract.
+ */
+function roundTrip(values: Record<string, unknown>): { before: string; after: string; text: string } {
+  const cfg = fromMap(values, 'test')
+  const before = cfg._renderJSONForTest()
+  const text = cfg.renderHocon()
+  let reparsed
+  try {
+    reparsed = parseString(text)
+  } catch (e) {
+    throw new Error(`parseString of emitted HOCON failed: ${String(e)}\n--- emitted ---\n${text}`)
+  }
+  const after = reparsed._renderJSONForTest()
+  return { before, after, text }
+}
+
+function assertRoundTrip(values: Record<string, unknown>): void {
+  const { before, after, text } = roundTrip(values)
+  expect(after, `round trip changed the tree\n--- emitted ---\n${text}`).toBe(before)
+}
+
+describe('renderHocon round trip', () => {
+  it('scalars', () => {
+    assertRoundTrip({ s: 'hello', n: 8080, f: 1.5, b: true, z: false, nul: null })
+  })
+
+  it('nested-objects', () => {
+    assertRoundTrip({
+      db: { host: 'localhost', port: 5432, opts: { ssl: true } },
+    })
+  })
+
+  it('arrays', () => {
+    assertRoundTrip({
+      tags: ['a', 'b', 'c'],
+      nums: [1, 2, 3],
+      objs: [{ id: 1 }, { id: 2 }],
+      nested: [[1, 2], [3, 4]],
+      'empty-a': [],
+    })
+  })
+
+  // Strings that would re-parse as another type MUST stay strings.
+  it('ambiguous-strings', () => {
+    assertRoundTrip({
+      'looks-num': '8080',
+      'looks-float': '1.5',
+      'looks-bool': 'true',
+      'looks-null': 'null',
+      norway: 'no',
+      neg: '-5',
+    })
+  })
+
+  // Strings needing quoting for their content.
+  it('special-strings', () => {
+    assertRoundTrip({
+      spaces: 'hello world',
+      empty: '',
+      reserved: 'a:b=c,d',
+      leading: '  padded  ',
+      url: 'https://example.com/a?b=1',
+      substish: '${foo.bar}',
+    })
+  })
+
+  it('multiline', () => {
+    assertRoundTrip({
+      block: 'line1\nline2\nline3',
+      crlf: 'a\r\nb',
+      tab: 'a\tb',
+    })
+  })
+
+  // Keys that cannot be bare.
+  it('awkward-keys', () => {
+    assertRoundTrip({
+      'a.b': 'dotted key',
+      'has space': 1,
+      '': 'empty key',
+      'a=b': true,
+      '123': 'numeric key ok',
+    })
+  })
+
+  it('empty-object', () => {
+    assertRoundTrip({ outer: { inner: {} } })
+  })
+
+  it('unicode', () => {
+    assertRoundTrip({ jp: 'こんにちは', emoji: '😀', mixed: 'a😀b' })
+  })
+
+  // Strings that defeat triple-quoting (embedded """, a trailing ") must fall
+  // through to escaped double quotes and still round-trip.
+  it('quote-heavy', () => {
+    assertRoundTrip({
+      'embedded-triple': 'a"""b\nc',
+      'trailing-quote': 'ends"',
+      'lone-quote': 'a"b',
+      'multiline-quote': 'x\ny"',
+      backslash: 'a\\b\\\\c',
+    })
+  })
+
+  // Empty object as an array element and as a direct value exercise the
+  // value-position empty-object branch (distinct from a nested key).
+  it('empty-object-positions', () => {
+    assertRoundTrip({
+      'in-array': [{}, { a: 1 }],
+      direct: {},
+    })
+  })
+})
+
+// An unresolved config has no textual round trip through a value tree, so
+// renderHocon must refuse it rather than emit a broken document. The
+// placeholders sit at three depths so the whole-config gate covers the nested
+// object and array shapes, not only the top level.
+describe('renderHocon rejects unresolved', () => {
+  const cases: Record<string, string> = {
+    'top-level': 'a = 1\nb = ${a}\n',
+    nested: 'a = 1\nb { c = ${a} }\n',
+    'in-array': 'a = 1\nb = [1, ${a}, 3]\n',
+    'obj-in-arr': 'a = 1\nb = [{ c = ${a} }]\n',
+  }
+  for (const [name, src] of Object.entries(cases)) {
+    it(name, () => {
+      const cfg = parseStringWithOptions(src, { resolveSubstitutions: false })
+      expect(() => cfg.renderHocon()).toThrow(ConfigError)
+      expect(() => cfg.renderHocon()).toThrow(/config must be resolved data/)
+    })
+  }
+})
+
+// The emitted text should be idiomatic where it is safe: a plain identifier
+// value and key stay bare, a number is not quoted.
+describe('renderHocon idiomatic output', () => {
+  it('keeps safe scalars bare', () => {
+    const cfg = fromMap({ name: 'svc', port: 8080, enabled: true })
+    const got = cfg.renderHocon()
+    for (const want of ['name = svc\n', 'port = 8080\n', 'enabled = true\n']) {
+      expect(got, `emitted HOCON missing ${JSON.stringify(want)}`).toContain(want)
+    }
+  })
+})
+
+// A parsed HOCON document (not from fromMap) also round-trips once resolved.
+describe('renderHocon from parsed document', () => {
+  it('round-trips a resolved parse', () => {
+    const src = 'a = 1\nb { c = "x", d = [1, 2, "three"] }\ne = ${a}\n'
+    const cfg = parseString(src)
+    const text = cfg.renderHocon()
+    let reparsed
+    try {
+      reparsed = parseString(text)
+    } catch (e) {
+      throw new Error(`re-parse failed: ${String(e)}\n--- emitted ---\n${text}`)
+    }
+    expect(
+      reparsed._renderJSONForTest(),
+      `parsed-doc round trip diverged\n--- emitted ---\n${text}`,
+    ).toBe(cfg._renderJSONForTest())
+  })
+})

--- a/tests/render-hocon.test.ts
+++ b/tests/render-hocon.test.ts
@@ -95,6 +95,7 @@ describe('renderHocon round trip', () => {
       '': 'empty key',
       'a=b': true,
       '123': 'numeric key ok',
+      include: 'reserved word must be quoted to round-trip',
     })
   })
 


### PR DESCRIPTION
## Summary

Horizontal rollout of the E18 emitter ([xx#93](https://github.com/o3co/xx.hocon/pull/93), merged). With go.hocon v1.11.0 `RenderHOCON()` as the semantic source, ports E18's round-trip contract (`parse(render(tree)) == tree`, byte format not fixed), its quoting rules, and the resolved-data-only input domain.

- Ported go's test battery (round-trip / rejects-unresolved / idiomatic / parsed-document)
- **Wired the runner for the shared corpus rt01–rt10 and confirmed all 10 fixtures PASS locally** (skipped when not synced; a sync block was added to `make testdata`)
- Host-language differences (granularity of unresolved detection, fidelity of raw numbers) are resolved to match each repo's existing conventions (see the commit bodies)

Same window: 3 PRs for ts / py / rs (for go, the corpus runner is [go#195](https://github.com/o3co/go.hocon/pull/195)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
