### PR TITLE
chore(release): 1.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.13.0] - 2026-08-19
+
 ### Added
 
 - **`adapters/json5` — JSON5 1.0.0 ingestion (spec F3.3).** A new


### PR DESCRIPTION
## Summary

Release prep for the v1.13.0 lockstep cut: move `[Unreleased]` into `[1.13.0] - 2026-08-19`. No version-file bumps — published versions come from the tag (the design established for 1.12.0). The release workflow's CHANGELOG-extraction awk was run locally and yields a non-empty section (the empty-section abort guard will not trigger).

Contents (lockstep across the four implementations): the BREAKING spec-fix batch — S13a.12, S9.2 (leading-newline strip; plus go's CRLF normalization), S13.12 — the Lightbend units alignment (kB case sensitivity and the extended byte table, BREAKING), the JSON5 adapter (F3.3), and the HOCON emitter (E18).

Same-window PRs: go / ts / rs / py. After all four merge, `v1.13.0` is tagged on each default branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)