### PR TITLE
fix(parser)!: reject overflowing float literals (E19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **BREAKING (extra-spec E19, xx.hocon#97): a numeric literal whose magnitude
+  overflows the double range (`1e999`) is now a parse error** instead of
+  silently becoming `Infinity` — a value HOCON cannot render or re-parse as a
+  number (Lightbend's own render → re-parse turns it into the string
+  `"Infinity"`). This aligns ts with go, which has always errored here; a
+  deliberate, documented divergence from Lightbend. Underflow (`1e-400`) still
+  reads as `0`. Workaround for configs that carried such a literal as data:
+  quote it (`a = "1e999"` stays a string).
+
 ## [1.13.0] - 2026-08-19
 
 ### Added

--- a/src/internal/parser/parser.ts
+++ b/src/internal/parser/parser.ts
@@ -584,7 +584,7 @@ class Parser {
         node = { kind: 'scalar', raw: t.value, valueType: 'string', pos: { line: t.line, col: t.col } }
       } else if (t.kind === 'unquoted') {
         this.advance()
-        node = { kind: 'scalar', raw: t.value, valueType: this.scalarValueType(t.value), pos: { line: t.line, col: t.col } }
+        node = { kind: 'scalar', raw: t.value, valueType: this.scalarValueType(t.value, t.line, t.col), pos: { line: t.line, col: t.col } }
       } else if ((t.kind === 'colon' || t.kind === 'equals') && parts.length > 0) {
         // In value concat context, colon/equals after at least one part are plain string chars
         // e.g.  url = ${host}:/path  or  x = ${a}=b
@@ -632,13 +632,24 @@ class Parser {
     return { kind: 'array', items, pos: p }
   }
 
-  private scalarValueType(raw: string): ScalarValueType {
+  private scalarValueType(raw: string, line: number, col: number): ScalarValueType {
     if (raw === 'true' || raw === 'false') return 'boolean'
     if (raw === 'null') return 'null'
     // Number detection: first char must be 0-9 or - (Lightbend-aligned)
     // Use strict decimal regex matching coerceNumber to ensure consistency
     if (raw.length > 0 && (raw.charCodeAt(0) >= 0x30 && raw.charCodeAt(0) <= 0x39 || raw.charCodeAt(0) === 0x2d)) {
-      if (DECIMAL_NUMBER_RE.test(raw)) return 'number'
+      if (DECIMAL_NUMBER_RE.test(raw)) {
+        // E19: a numeric literal whose magnitude overflows the double range
+        // (`1e999`) is a parse error. Lightbend admits Infinity but cannot
+        // render or re-parse it as a number; erroring at the parse (as go
+        // always has via strconv.ParseFloat) is the documented divergence.
+        // Underflow (`1e-400`) stays accepted as 0 — the regex-passing raw
+        // can never yield NaN, so only the infinite case is checked.
+        if (!Number.isFinite(Number(raw))) {
+          throw new ParseError(`invalid float "${raw}"`, line, col)
+        }
+        return 'number'
+      }
     }
     return 'string'
   }

--- a/tests/e19-float-overflow.test.ts
+++ b/tests/e19-float-overflow.test.ts
@@ -1,0 +1,64 @@
+// tests/e19-float-overflow.test.ts
+//
+// E19 — a numeric literal whose magnitude overflows the double range is a
+// parse error in all four sibling implementations (xx.hocon#97, posture B).
+// This is a documented divergence from Lightbend: the reference admits the
+// literal as Infinity, but HOCON has no Infinity literal, so the value cannot
+// be rendered or re-parsed as a number (Lightbend's own render → re-parse
+// silently turns it into the STRING "Infinity"). go.hocon has always errored
+// here via strconv.ParseFloat; ts/py/rs align with it.
+//
+// Underflow is NOT an error: `1e-400` reads as 0 in every implementation and
+// in Lightbend, so only the infinite case is rejected.
+
+import { describe, expect, it } from 'vitest'
+import { ParseError, parse } from '../src/index.js'
+
+describe('E19 — overflowing float literal is a parse error', () => {
+  it('rejects a = 1e999', () => {
+    expect(() => parse('a = 1e999')).toThrow(ParseError)
+    expect(() => parse('a = 1e999')).toThrow(/invalid float "1e999"/)
+  })
+
+  it('rejects a = -1e999', () => {
+    expect(() => parse('a = -1e999')).toThrow(ParseError)
+    expect(() => parse('a = -1e999')).toThrow(/invalid float "-1e999"/)
+  })
+
+  it('rejects an overflowing fraction/exponent combination', () => {
+    expect(() => parse('a = 2.5e999')).toThrow(ParseError)
+  })
+
+  it('rejects an overflow inside an array element', () => {
+    expect(() => parse('a = [1, 1e999]')).toThrow(ParseError)
+  })
+
+  it('accepts underflow as 0 (1e-400)', () => {
+    const cfg = parse('a = 1e-400')
+    expect(cfg.getNumber('a')).toBe(0)
+  })
+
+  it('accepts the finite extremes', () => {
+    expect(parse('a = 1e308').getNumber('a')).toBe(1e308)
+    expect(parse('a = 5e-324').getNumber('a')).toBe(5e-324)
+  })
+
+  it('keeps a quoted "1e999" as a string', () => {
+    expect(parse('a = "1e999"').getString('a')).toBe('1e999')
+  })
+
+  it('keeps unquoted Infinity as a string (no Infinity literal in HOCON)', () => {
+    expect(parse('a = Infinity').getString('a')).toBe('Infinity')
+  })
+
+  it('reports the position of the offending literal', () => {
+    try {
+      parse('a = 1e999')
+      expect.unreachable('expected ParseError')
+    } catch (e) {
+      expect(e).toBeInstanceOf(ParseError)
+      expect((e as ParseError).line).toBe(1)
+      expect((e as ParseError).col).toBe(5)
+    }
+  })
+})

--- a/tests/e19-float-overflow.test.ts
+++ b/tests/e19-float-overflow.test.ts
@@ -33,6 +33,12 @@ describe('E19 — overflowing float literal is a parse error', () => {
     expect(() => parse('a = [1, 1e999]')).toThrow(ParseError)
   })
 
+  it('rejects an integer-form literal beyond the double range', () => {
+    // E19 is keyed on the lexeme's value, not its spelling: 400 nines
+    // overflow Number the same way an exponent form does.
+    expect(() => parse(`a = ${'9'.repeat(400)}`)).toThrow(ParseError)
+  })
+
   it('accepts underflow as 0 (1e-400)', () => {
     const cfg = parse('a = 1e-400')
     expect(cfg.getNumber('a')).toBe(0)


### PR DESCRIPTION
Part of the four-impl posture-B alignment for [xx.hocon#97](https://github.com/o3co/xx.hocon/issues/97): an overflowing float literal is a parse error in all four cores.

## What changes

- `scalarValueType` now checks the value of a regex-classified number token: if `Number(raw)` is not finite, the parser throws `ParseError: invalid float "1e999"` (same message shape as go) at the literal's position.
- Underflow (`1e-400`) is unchanged — it reads as `0`, matching every sibling and Lightbend.
- Quoted `"1e999"` and unquoted `Infinity` remain strings (no Infinity literal exists in HOCON).

## Why error instead of following Lightbend

Lightbend admits the literal as `Infinity`, but the value cannot survive any downstream path: HOCON has no Infinity literal, so no emitter can round-trip it (Lightbend's own `render()` → re-parse silently turns it into the STRING `"Infinity"`), and canonical JSON cannot carry it. go has always errored here via `strconv.ParseFloat`'s range error and measured no fallout. This is a deliberate, documented divergence (extra-spec **E19**, to be added to `xx.hocon/docs/extra-spec-conventions.md` in the same window; sibling PRs align py and rs, and rs additionally hardens its serde path against non-finite values).

**BREAKING**: a config that previously parsed with `a = 1e999` (yielding `Infinity`) now errors. Workaround: quote the literal to keep it as data. CHANGELOG entry included with the BREAKING label; ships in the next lockstep minor.

## Tests

`tests/e19-float-overflow.test.ts` pins: overflow (plain / negative / fractional / array-element) → `ParseError` with position; underflow → 0; finite extremes (`1e308`, `5e-324`) accepted; quoted and `Infinity` string behavior unchanged. Full suite: 1546 passed.

Note: `make testdata` surfaced that the fi60–fi67 json5 fixtures were never vendored into this repo's tracked `format-ingestion/` tree — deliberately **not** bundled here (fixture sync ships as an independent chore PR per repo convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)